### PR TITLE
Update leader election ID to openshift.io

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -184,7 +184,7 @@ func main() {
 		WebhookServer:          webhookServer,
 		HealthProbeBindAddress: probeAddr,
 		LeaderElection:         enableLeaderElection,
-		LeaderElectionID:       "1898b328.redhat.com",
+		LeaderElectionID:       "koku-service-operator.costmanagement-service-cfg.openshift.io",
 		// LeaderElectionReleaseOnCancel defines if the leader should step down voluntarily
 		// when the Manager ends. This requires the binary to immediately end when the
 		// Manager is stopped, otherwise, this setting is unsafe. Setting this significantly


### PR DESCRIPTION
## Summary
- Rename `LeaderElectionID` from the scaffold value `1898b328.redhat.com` to `koku-service-operator.costmanagement-service-cfg.openshift.io`
- Align the leader-election lock name with the operator name and `openshift.io` API domain

## Test plan
- [ ] Confirm `cmd/main.go` uses the new `LeaderElectionID`
- [ ] With `--leader-elect`, verify the Lease is created under the new name


Made with [Cursor](https://cursor.com)

## Summary by Sourcery

Enhancements:
- Align the LeaderElectionID with the operator name and the openshift.io API domain for leader election leases.