### PR TITLE
fix: Kruize ClusterRole RBAC + default ingress image

### DIFF
--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -23,10 +23,29 @@ rules:
 - apiGroups:
   - ""
   resources:
+  - endpoints
+  - nodes
+  - pods
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
   - events
   verbs:
   - create
   - patch
+- apiGroups:
+  - apps
+  resources:
+  - daemonsets
+  - replicasets
+  verbs:
+  - get
+  - list
+  - watch
 - apiGroups:
   - apps
   resources:
@@ -71,6 +90,21 @@ rules:
   - patch
   - update
   - watch
+- apiGroups:
+  - custom.metrics.k8s.io
+  resources:
+  - '*'
+  verbs:
+  - get
+  - list
+- apiGroups:
+  - metrics.k8s.io
+  resources:
+  - nodes
+  - pods
+  verbs:
+  - get
+  - list
 - apiGroups:
   - monitoring.coreos.com
   resources:

--- a/config/samples/service.costmanagement_v1alpha1_costmanagementserviceconfig.yaml
+++ b/config/samples/service.costmanagement_v1alpha1_costmanagementserviceconfig.yaml
@@ -35,13 +35,15 @@ spec:
   costManagement:
     api:
       image:
-        repository: quay.io/martin_povolny/koku
-        tag: "latest"
+        # arm64 CRC: quay.io/martin_povolny/koku:latest
+        # amd64 clusterbot/CI: use cost-mgmt-dev-tenant (multi-arch) below
+        repository: quay.io/redhat-services-prod/cost-mgmt-dev-tenant/koku
+        tag: "d8055ac"
       replicas: 1
     masu:
       image:
-        repository: quay.io/martin_povolny/koku
-        tag: "latest"
+        repository: quay.io/redhat-services-prod/cost-mgmt-dev-tenant/koku
+        tag: "d8055ac"
       replicas: 1
     listener:
       replicas: 2
@@ -80,6 +82,11 @@ spec:
       repository: quay.io/redhat-services-prod/kruize-autotune-tenant/autotune
       tag: "d1f0140"
 
+  ingress:
+    image:
+      repository: quay.io/iop/ingress
+      tag: "master"
+
   # Envoy JWT gateway requires a reachable Keycloak/RHBK JWKS endpoint.
   # Without it, gateway pods can become Ready while API calls return 401.
   auth:
@@ -107,7 +114,9 @@ spec:
     #   name: cost-management-ui-oauth-client
     oauthProxy:
       image:
-        repository: registry.access.redhat.com/rhceph/oauth2-proxy-rhel9
+        # Use registry.redhat.io (not registry.access.redhat.com) — access.redhat.com
+        # rejects pulls that require terms acceptance on OpenShift CI/clusterbot.
+        repository: registry.redhat.io/rhceph/oauth2-proxy-rhel9
         tag: "v7.6.0"
     app:
       image:

--- a/config/samples/service.costmanagement_v1alpha1_costmanagementserviceconfig_byoi.yaml
+++ b/config/samples/service.costmanagement_v1alpha1_costmanagementserviceconfig_byoi.yaml
@@ -143,6 +143,11 @@ spec:
       repository: quay.io/redhat-services-prod/kruize-autotune-tenant/autotune
       tag: "d1f0140"
 
+  ingress:
+    image:
+      repository: quay.io/iop/ingress
+      tag: "master"
+
   ui:
     replicaCount: 1
     # User-provided OAuth client Secret (keys: client-id, client-secret).

--- a/docs/development/clusterbot-smoke-2026-08-10.md
+++ b/docs/development/clusterbot-smoke-2026-08-10.md
@@ -1,0 +1,115 @@
+# Clusterbot smoke — 2026-08-10 (resume notes)
+
+Smoke of **upstream `main` @ `7908c48`** on OpenShift clusterbot, then fixes on
+branch `fix/clusterbot-kruize-rbac-ingress`. Cluster was expected to shut down
+within hours — use this to continue on a fresh clusterbot tomorrow.
+
+## What was deployed
+
+| Piece | Namespace | Notes |
+|-------|-----------|--------|
+| Operator image | `koku-service-operator-system` | `quay.io/martin_povolny/koku-server-operator:fix-7908c48` (also `:dev`) |
+| CMSC `cost-management` | `cost-onprem` | Bundled DB/cache; MinIO + AMQ Streams BYOI |
+| MinIO | `cost-byoi-infra` | Storage secret `cost-management-storage-credentials` |
+| Kafka | `kafka` | `./config/samples/byoi/deploy-kafka.sh` (`STORAGE_CLASS=gp3-csi`) |
+| RHBK | `keycloak` | Chart `scripts/deploy-rhbk.sh` — **completed** before handoff |
+| UI OAuth secret | `cost-onprem` | Stub first; real mirror from Keycloak **not confirmed** after interrupt |
+
+Last known CMSC state (before Keycloak wiring finished):
+
+- `phase=Ready`, `Available=True`, `UIReady=True` (secret present)
+- All app Deployments **1/1** except UI (`oauth-proxy` CrashLoop — no Keycloak DNS at that time)
+- Routes: API + UI present
+
+Public Keycloak URL from RHBK script:
+
+`https://keycloak-keycloak.apps.chat-bot-wqsg6-65d66e.crt-mce-aws.devcluster.openshift.com`
+
+UI URL:
+
+`https://cost-management-ui-cost-onprem.apps.chat-bot-wqsg6-65d66e.crt-mce-aws.devcluster.openshift.com`
+
+## Fixes in this PR (code)
+
+1. **Kruize ClusterRole escalate** — manager SA could not create `{cr}-kruize`
+   ClusterRole (missing held permissions for pods/nodes/endpoints/metrics/…).
+   Added kubebuilder RBAC markers → `config/rbac/role.yaml`.
+2. **Empty ingress image** — omitted `spec.ingress.image` produced `:` /
+   `InvalidImageName`. Default to `quay.io/iop/ingress:master` (chart parity);
+   samples updated; unit tests added.
+
+## Findings / gaps (not all fixed in code)
+
+| Severity | Finding | Status |
+|----------|---------|--------|
+| **Blocker** | Manager cannot create Kruize ClusterRole (RBAC escalate) | **Fixed in PR** |
+| **Blocker** | Empty ingress image → InvalidImageName | **Fixed in PR** |
+| **High** | Sample `ui.oauthProxy.image` uses `registry.access.redhat.com/...` — clusterbot requires `registry.redhat.io/...` (terms) | **Should fix in PR samples** |
+| **High** | Bundled sample `quay.io/martin_povolny/koku:latest` is **arm64-only** — migrate ImagePullBackOff on amd64 clusterbot | Doc / sample: use `cost-mgmt-dev-tenant/koku:d8055ac` on amd64 |
+| **Expected BYOI** | RHBK not created by operator — need `deploy-rhbk.sh` | Deployed on this cluster; redo on next |
+| **Expected BYOI** | UI OAuth Secret must be mirrored (`mirror-ui-oauth-secret.sh --force`) | Script exists; re-run after RHBK |
+| **Config** | Set `spec.auth.keycloak.issuerURL` to public RHBK Route when `iss` ≠ in-cluster URL | Not applied after RHBK (interrupted) |
+| **Ops** | `make deploy` OpenAPI validate can timeout on clusterbot — use `--validate=false` | Workaround only |
+| **Ops** | Grant `anyuid` (+ often `privileged`) to `{cr}-koku` SA for migrate Jobs | Manual each cluster |
+| **Cleanup** | Stale UI ReplicaSet pods can linger after image patches | Delete old pods / RS |
+
+## Resume checklist (new clusterbot tomorrow)
+
+```bash
+# 0. Context
+kubectl config use-context <new-clusterbot>
+
+# 1. Operator (from this branch or rebuilt image)
+cd .worktrees/fix-clusterbot-kruize-ingress   # or checkout the PR branch
+export IMG=quay.io/martin_povolny/koku-server-operator:dev   # rebuild/push if needed
+KUSTOMIZE=../../bin/kustomize   # or make kustomize
+(cd config/manager && $KUSTOMIZE edit set image controller=$IMG)
+$KUSTOMIZE build config/default | kubectl apply --validate=false --server-side --force-conflicts -f -
+
+# 2. Infra BYOI
+STORAGE_CLASS=gp3-csi LOG_LEVEL=INFO ./config/samples/byoi/deploy-kafka.sh
+# MinIO: kubectl apply -f config/samples/byoi/infra/{namespace,serviceaccount,credentials,minio}.yaml
+# + storage secret in cost-onprem (access-key/secret-key)
+
+# 3. RHBK
+cd ../cost-onprem-chart   # sibling checkout
+STORAGE_CLASS=gp3-csi LOG_LEVEL=INFO \
+  COST_MGMT_NAMESPACE=cost-onprem \
+  COST_MGMT_RELEASE_NAME=cost-management \
+  COST_MGMT_UI_BASE_URL="https://cost-management-ui-cost-onprem.apps.<DOMAIN>" \
+  ./scripts/deploy-rhbk.sh
+
+# 4. Mirror UI OAuth + wire CR
+NAMESPACE=cost-onprem CR_NAME=cost-management \
+  ./config/samples/byoi/mirror-ui-oauth-secret.sh --force
+
+# Patch CMSC (example fields):
+# - global.clusterDomain / storageClass=gp3-csi
+# - objectStorage → MinIO
+# - costManagement.api/masu image → amd64 koku tag
+# - ui.oauthProxy.image → registry.redhat.io/rhceph/oauth2-proxy-rhel9:v7.6.0
+# - auth.keycloak.url → http://keycloak-service.keycloak.svc.cluster.local:8080 (confirm svc name)
+# - auth.keycloak.issuerURL → https://keycloak-keycloak.apps.<DOMAIN>
+# - auth.keycloak.tls.insecureSkipVerify: true (lab) or caCertSecretName
+
+oc adm policy add-scc-to-user anyuid -z cost-management-koku -n cost-onprem
+
+# 5. Verify
+kubectl -n cost-onprem get cmsc cost-management -o yaml | less
+kubectl -n cost-onprem get deploy,pods
+kubectl -n cost-onprem logs deploy/cost-management-ui -c oauth-proxy --tail=50
+```
+
+## Success criteria for “everything working”
+
+- [ ] CMSC `phase=Ready`, `Available=True`, `UIReady=True`, no `Degraded`
+- [ ] UI pod **2/2** Ready (oauth-proxy + app)
+- [ ] Browser login via UI Route against RHBK
+- [ ] API Route `/api` accepts JWT from Keycloak (not only gateway Ready)
+- [ ] No ImagePullBackOff / InvalidImageName
+
+## Related
+
+- Code branch: `fix/clusterbot-kruize-rbac-ingress`
+- Chart RHBK: `cost-onprem-chart/scripts/deploy-rhbk.sh`
+- UI OAuth notes: wiki `docs/cmsc/koku-ui-oauth2-proxy.md` (personal wiki)

--- a/docs/development/clusterbot-smoke-2026-08-10.md
+++ b/docs/development/clusterbot-smoke-2026-08-10.md
@@ -1,112 +1,122 @@
-# Clusterbot smoke — 2026-08-10 (resume notes)
+# Clusterbot smoke — 2026-08-10 / 2026-08-11
 
-Smoke of **upstream `main` @ `7908c48`** on OpenShift clusterbot, then fixes on
-branch `fix/clusterbot-kruize-rbac-ingress`. Cluster was expected to shut down
-within hours — use this to continue on a fresh clusterbot tomorrow.
+Smoke of branch `fix/clusterbot-kruize-rbac-ingress` (from upstream `main` @
+`7908c48`) on OpenShift clusterbot. Draft PR:
+https://github.com/project-koku/koku-service-operator/pull/17
 
-## What was deployed
+## 2026-08-11 status (current cluster) — SUCCESS
+
+Context: `clusterbot` →
+`api.chat-bot-krm93-3ftzcr.crt-mce-aws.devcluster.openshift.com`
 
 | Piece | Namespace | Notes |
 |-------|-----------|--------|
-| Operator image | `koku-service-operator-system` | `quay.io/martin_povolny/koku-server-operator:fix-7908c48` (also `:dev`) |
+| Operator | `koku-service-operator-system` | `quay.io/martin_povolny/koku-server-operator:fix-clusterbot-20260811` |
 | CMSC `cost-management` | `cost-onprem` | Bundled DB/cache; MinIO + AMQ Streams BYOI |
-| MinIO | `cost-byoi-infra` | Storage secret `cost-management-storage-credentials` |
-| Kafka | `kafka` | `./config/samples/byoi/deploy-kafka.sh` (`STORAGE_CLASS=gp3-csi`) |
-| RHBK | `keycloak` | Chart `scripts/deploy-rhbk.sh` — **completed** before handoff |
-| UI OAuth secret | `cost-onprem` | Stub first; real mirror from Keycloak **not confirmed** after interrupt |
+| MinIO | `cost-byoi-infra` | Secret `cost-management-storage-credentials` |
+| Kafka | `kafka` | `STORAGE_CLASS=gp3-csi ./config/samples/byoi/deploy-kafka.sh` |
+| RHBK | `keycloak` | `cost-onprem-chart/scripts/deploy-rhbk.sh` — completed |
+| UI OAuth | `cost-onprem` | Mirrored via `mirror-ui-oauth-secret.sh --force` |
 
-Last known CMSC state (before Keycloak wiring finished):
+Verified:
 
-- `phase=Ready`, `Available=True`, `UIReady=True` (secret present)
-- All app Deployments **1/1** except UI (`oauth-proxy` CrashLoop — no Keycloak DNS at that time)
-- Routes: API + UI present
+- CMSC `phase=Ready`, `Available=True`, `UIReady=True`, `AuthenticationReady=True`, `SchemaUpToDate=True`
+- UI pod **2/2** Ready; UI Route **302 → Keycloak** login
+- API Route (gateway host) **401** without JWT (Envoy JWT gate working)
+- Kruize `ClusterRole/cost-management-kruize` created (RBAC fix validated)
+- Ingress image `quay.io/iop/ingress:master` (default / sample)
 
-Public Keycloak URL from RHBK script:
+URLs:
 
-`https://keycloak-keycloak.apps.chat-bot-wqsg6-65d66e.crt-mce-aws.devcluster.openshift.com`
+- UI: `https://cost-management-ui-cost-onprem.apps.chat-bot-krm93-3ftzcr.crt-mce-aws.devcluster.openshift.com`
+- API: `https://cost-management-gateway-cost-onprem.apps.chat-bot-krm93-3ftzcr.crt-mce-aws.devcluster.openshift.com/api`
+- Keycloak: `https://keycloak-keycloak.apps.chat-bot-krm93-3ftzcr.crt-mce-aws.devcluster.openshift.com`
 
-UI URL:
+Auth patch applied on CMSC:
 
-`https://cost-management-ui-cost-onprem.apps.chat-bot-wqsg6-65d66e.crt-mce-aws.devcluster.openshift.com`
+```yaml
+spec:
+  auth:
+    keycloak:
+      url: http://keycloak-service.keycloak.svc.cluster.local:8080
+      issuerURL: https://keycloak-keycloak.apps.chat-bot-krm93-3ftzcr.crt-mce-aws.devcluster.openshift.com
+      realm: kubernetes
+      tls:
+        insecureSkipVerify: true
+```
 
 ## Fixes in this PR (code)
 
 1. **Kruize ClusterRole escalate** — manager SA could not create `{cr}-kruize`
-   ClusterRole (missing held permissions for pods/nodes/endpoints/metrics/…).
-   Added kubebuilder RBAC markers → `config/rbac/role.yaml`.
-2. **Empty ingress image** — omitted `spec.ingress.image` produced `:` /
-   `InvalidImageName`. Default to `quay.io/iop/ingress:master` (chart parity);
-   samples updated; unit tests added.
+   ClusterRole. Kubebuilder RBAC markers → `config/rbac/role.yaml`.
+2. **Empty ingress image** — default to `quay.io/iop/ingress:master`; samples + unit tests.
+3. **Sample polish** — amd64 koku tag; oauth2-proxy on `registry.redhat.io`.
 
-## Findings / gaps (not all fixed in code)
+## Findings / gaps
 
 | Severity | Finding | Status |
 |----------|---------|--------|
 | **Blocker** | Manager cannot create Kruize ClusterRole (RBAC escalate) | **Fixed in PR** |
 | **Blocker** | Empty ingress image → InvalidImageName | **Fixed in PR** |
-| **High** | Sample `ui.oauthProxy.image` uses `registry.access.redhat.com/...` — clusterbot requires `registry.redhat.io/...` (terms) | **Should fix in PR samples** |
-| **High** | Bundled sample `quay.io/martin_povolny/koku:latest` is **arm64-only** — migrate ImagePullBackOff on amd64 clusterbot | Doc / sample: use `cost-mgmt-dev-tenant/koku:d8055ac` on amd64 |
-| **Expected BYOI** | RHBK not created by operator — need `deploy-rhbk.sh` | Deployed on this cluster; redo on next |
-| **Expected BYOI** | UI OAuth Secret must be mirrored (`mirror-ui-oauth-secret.sh --force`) | Script exists; re-run after RHBK |
-| **Config** | Set `spec.auth.keycloak.issuerURL` to public RHBK Route when `iss` ≠ in-cluster URL | Not applied after RHBK (interrupted) |
-| **Ops** | `make deploy` OpenAPI validate can timeout on clusterbot — use `--validate=false` | Workaround only |
+| **High** | Sample oauth2-proxy on `registry.access.redhat.com` fails ToS pulls | **Fixed in PR samples** |
+| **High** | `quay.io/martin_povolny/koku:latest` arm64-only on amd64 clusterbot | **Sample → cost-mgmt-dev-tenant/koku:d8055ac** |
+| **Ops** | Bundled PostgreSQL STS uses **default** SA + `fsGroup: 26` → needs `oc adm policy add-scc-to-user anyuid -z default -n cost-onprem` (koku SA alone is not enough) | Document / consider SA on DB STS |
 | **Ops** | Grant `anyuid` (+ often `privileged`) to `{cr}-koku` SA for migrate Jobs | Manual each cluster |
-| **Cleanup** | Stale UI ReplicaSet pods can linger after image patches | Delete old pods / RS |
+| **Expected BYOI** | RHBK + mirror UI OAuth Secret | Scripts; not operator-owned |
+| **Config** | Set `issuerURL` to public RHBK Route when `iss` ≠ in-cluster URL | Required for JWT |
+| **Ops** | `make deploy` OpenAPI validate can timeout — `--validate=false` | Workaround |
+| **Note** | API Route hostname is `{cr}-gateway-{ns}.apps...` (not `…-api-…`) | Use `oc get route` |
 
-## Resume checklist (new clusterbot tomorrow)
+## Resume checklist (new clusterbot)
 
 ```bash
-# 0. Context
-kubectl config use-context <new-clusterbot>
+kubectl config use-context clusterbot   # or new context
 
-# 1. Operator (from this branch or rebuilt image)
-cd .worktrees/fix-clusterbot-kruize-ingress   # or checkout the PR branch
-export IMG=quay.io/martin_povolny/koku-server-operator:dev   # rebuild/push if needed
-KUSTOMIZE=../../bin/kustomize   # or make kustomize
-(cd config/manager && $KUSTOMIZE edit set image controller=$IMG)
-$KUSTOMIZE build config/default | kubectl apply --validate=false --server-side --force-conflicts -f -
+cd .worktrees/fix-clusterbot-kruize-ingress
+export IMG=quay.io/martin_povolny/koku-server-operator:fix-clusterbot-20260811
+# rebuild/push if needed; then:
+(cd config/manager && ../../bin/kustomize edit set image controller=$IMG)
+./bin/kustomize build config/default | kubectl apply --validate=false --server-side --force-conflicts -f -
 
-# 2. Infra BYOI
 STORAGE_CLASS=gp3-csi LOG_LEVEL=INFO ./config/samples/byoi/deploy-kafka.sh
-# MinIO: kubectl apply -f config/samples/byoi/infra/{namespace,serviceaccount,credentials,minio}.yaml
-# + storage secret in cost-onprem (access-key/secret-key)
 
-# 3. RHBK
-cd ../cost-onprem-chart   # sibling checkout
+# MinIO (+ SA anyuid)
+kubectl apply -f config/samples/byoi/infra/{namespace,serviceaccount,credentials,minio}.yaml
+oc adm policy add-scc-to-user anyuid -z byoi-infra -n cost-byoi-infra
+kubectl create ns cost-onprem --dry-run=client -o yaml | kubectl apply -f -
+kubectl -n cost-onprem create secret generic cost-management-storage-credentials \
+  --from-literal=access-key=byoi-minio-access \
+  --from-literal=secret-key=byoi-minio-secret-key \
+  --dry-run=client -o yaml | kubectl apply -f -
+
+# Apply CMSC (patch clusterDomain, gp3-csi, MinIO objectStorage, amd64 UI image)
+# Then:
+oc adm policy add-scc-to-user anyuid -z default -n cost-onprem
+oc adm policy add-scc-to-user anyuid -z cost-management-koku -n cost-onprem
+
+DOMAIN=$(kubectl get ingresses.config.openshift.io cluster -o jsonpath='{.spec.domain}')
+cd ../cost-onprem-chart
 STORAGE_CLASS=gp3-csi LOG_LEVEL=INFO \
   COST_MGMT_NAMESPACE=cost-onprem \
   COST_MGMT_RELEASE_NAME=cost-management \
-  COST_MGMT_UI_BASE_URL="https://cost-management-ui-cost-onprem.apps.<DOMAIN>" \
+  COST_MGMT_UI_BASE_URL="https://cost-management-ui-cost-onprem.${DOMAIN}" \
   ./scripts/deploy-rhbk.sh
 
-# 4. Mirror UI OAuth + wire CR
+cd - >/dev/null
 NAMESPACE=cost-onprem CR_NAME=cost-management \
   ./config/samples/byoi/mirror-ui-oauth-secret.sh --force
+# Patch auth.keycloak.url + issuerURL as above
 
-# Patch CMSC (example fields):
-# - global.clusterDomain / storageClass=gp3-csi
-# - objectStorage → MinIO
-# - costManagement.api/masu image → amd64 koku tag
-# - ui.oauthProxy.image → registry.redhat.io/rhceph/oauth2-proxy-rhel9:v7.6.0
-# - auth.keycloak.url → http://keycloak-service.keycloak.svc.cluster.local:8080 (confirm svc name)
-# - auth.keycloak.issuerURL → https://keycloak-keycloak.apps.<DOMAIN>
-# - auth.keycloak.tls.insecureSkipVerify: true (lab) or caCertSecretName
-
-oc adm policy add-scc-to-user anyuid -z cost-management-koku -n cost-onprem
-
-# 5. Verify
-kubectl -n cost-onprem get cmsc cost-management -o yaml | less
-kubectl -n cost-onprem get deploy,pods
-kubectl -n cost-onprem logs deploy/cost-management-ui -c oauth-proxy --tail=50
+kubectl -n cost-onprem get cmsc,deploy,pods,route
 ```
 
-## Success criteria for “everything working”
+## Success criteria
 
-- [ ] CMSC `phase=Ready`, `Available=True`, `UIReady=True`, no `Degraded`
-- [ ] UI pod **2/2** Ready (oauth-proxy + app)
-- [ ] Browser login via UI Route against RHBK
-- [ ] API Route `/api` accepts JWT from Keycloak (not only gateway Ready)
-- [ ] No ImagePullBackOff / InvalidImageName
+- [x] CMSC `phase=Ready`, `Available=True`, `UIReady=True`, no `Degraded`
+- [x] UI pod **2/2** Ready; browser login redirect to RHBK
+- [x] API Route returns **401** without JWT (gateway up)
+- [x] No ImagePullBackOff / InvalidImageName for ingress / koku
+- [ ] Full browser login + authenticated `/api` call (manual)
 
 ## Related
 

--- a/internal/controller/costmanagementserviceconfig_controller.go
+++ b/internal/controller/costmanagementserviceconfig_controller.go
@@ -54,6 +54,12 @@ type CostManagementServiceConfigReconciler struct {
 // +kubebuilder:rbac:groups=console.openshift.io,resources=consolelinks,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=networking.k8s.io,resources=networkpolicies,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=core,resources=events,verbs=create;patch
+// Permissions held so the operator can create the Kruize ClusterRole (RBAC
+// escalation rules require the creator to already hold any granted verbs).
+// +kubebuilder:rbac:groups=core,resources=pods;nodes;endpoints,verbs=get;list;watch
+// +kubebuilder:rbac:groups=apps,resources=daemonsets;replicasets,verbs=get;list;watch
+// +kubebuilder:rbac:groups=metrics.k8s.io,resources=nodes;pods,verbs=get;list
+// +kubebuilder:rbac:groups=custom.metrics.k8s.io,resources=*,verbs=get;list
 
 func (r *CostManagementServiceConfigReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
 	logger := log.FromContext(ctx)

--- a/internal/resources/ingress.go
+++ b/internal/resources/ingress.go
@@ -57,9 +57,27 @@ func ingressS3UseSSL(cfg *costv1alpha1.CostManagementServiceConfig) string {
 // IngressDeployment builds the insights-ingress-go Deployment.
 // Traffic arrives pre-authenticated from the Envoy JWT gateway, so the ingress
 // binary trusts the X-Rh-Identity header injected by Envoy.
+const (
+	defaultIngressImageRepo = "quay.io/iop/ingress"
+	defaultIngressImageTag  = "master"
+)
+
+// ingressImage returns repository:tag, defaulting to the chart's insights-ingress-go image.
+func ingressImage(spec costv1alpha1.IngressConfig) string {
+	repo := spec.Image.Repository
+	tag := spec.Image.Tag
+	if repo == "" {
+		repo = defaultIngressImageRepo
+	}
+	if tag == "" {
+		tag = defaultIngressImageTag
+	}
+	return repo + ":" + tag
+}
+
 func IngressDeployment(cfg *costv1alpha1.CostManagementServiceConfig) *appsv1.Deployment {
 	spec := cfg.Spec.Ingress
-	image := spec.Image.Repository + ":" + spec.Image.Tag
+	image := ingressImage(spec)
 	selLabels := SelectorLabels(cfg, "ingress")
 	allLabels := Labels(cfg, "ingress")
 	replicas := int32(1)

--- a/internal/resources/ingress_test.go
+++ b/internal/resources/ingress_test.go
@@ -1,0 +1,34 @@
+package resources
+
+import (
+	"testing"
+
+	costv1alpha1 "github.com/project-koku/koku-service-operator/api/v1alpha1"
+)
+
+func TestIngressImageDefaults(t *testing.T) {
+	if got := ingressImage(costv1alpha1.IngressConfig{}); got != "quay.io/iop/ingress:master" {
+		t.Fatalf("empty IngressConfig image = %q", got)
+	}
+	cfg := costv1alpha1.IngressConfig{}
+	cfg.Image.Repository = "quay.io/example/ingress"
+	if got := ingressImage(cfg); got != "quay.io/example/ingress:master" {
+		t.Fatalf("repo-only image = %q", got)
+	}
+	cfg.Image.Tag = "v1"
+	if got := ingressImage(cfg); got != "quay.io/example/ingress:v1" {
+		t.Fatalf("full image = %q", got)
+	}
+}
+
+func TestIngressDeploymentUsesDefaultImage(t *testing.T) {
+	cfg := testCfg()
+	dep := IngressDeployment(cfg)
+	if len(dep.Spec.Template.Spec.Containers) == 0 {
+		t.Fatal("no containers")
+	}
+	got := dep.Spec.Template.Spec.Containers[0].Image
+	if got != "quay.io/iop/ingress:master" {
+		t.Fatalf("IngressDeployment image = %q, want default", got)
+	}
+}


### PR DESCRIPTION
## Summary
- Allow the operator manager to create the Kruize ClusterRole by granting matching escalate/RBAC permissions (fixes Forbidden during worker stage after migrations).
- Default empty ingress image to `quay.io/iop/ingress:master` (chart parity) so Deployments no longer hit `InvalidImageName` with `:` .
- Update samples for amd64-friendly koku image + `registry.redhat.io` oauth2-proxy; add [clusterbot smoke resume notes](docs/development/clusterbot-smoke-2026-08-10.md) (BYOI/RHBK wiring state, tomorrow checklist).

## Test plan
- [ ] `go test ./internal/resources/ ./internal/controller/ -count=1`
- [ ] `make manifests` / confirm `config/rbac/role.yaml` includes Kruize ClusterRole rules
- [ ] On clusterbot (or CRC): apply CMSC with workers+ingress enabled; confirm no ClusterRole escalate Forbidden and ingress pods pull a real image
- [ ] Confirm oauth2-proxy pulls from `registry.redhat.io` without ImagePullBackOff from terms-of-service on access.redhat.com
- [ ] Follow resume section in `docs/development/clusterbot-smoke-2026-08-10.md` to finish RHBK → UI oauth secret mirror on a fresh cluster

## Summary by Sourcery

Align operator RBAC and ingress defaults for smoother cluster deployments.

Bug Fixes:
- Grant the operator manager the same permissions required by the Kruize ClusterRole so it can be created without RBAC escalation errors.
- Default the ingress Deployment image to the chart’s quay.io/iop/ingress:master image when none is specified to avoid InvalidImageName issues.
- Update sample CostManagementServiceConfig manifests to use amd64-compatible koku and oauth2-proxy images that work in clusterbot/CI environments.

Enhancements:
- Document a repeatable clusterbot smoke test flow and findings for future debugging and validation runs.

Tests:
- Add unit tests verifying ingress image defaulting logic and usage in the generated Deployment.