### PR TITLE
fix: escape CR spec values interpolated into Envoy YAML (config injection) [2]

### DIFF
--- a/api/v1alpha1/costmanagementserviceconfig_types.go
+++ b/api/v1alpha1/costmanagementserviceconfig_types.go
@@ -246,19 +246,23 @@ type KeycloakSpec struct {
 	// issuerURL is unset). Prefer an in-cluster http(s) Service URL so Envoy
 	// can reach JWKS without depending on the OpenShift router.
 	// Example: http://keycloak-service.keycloak.svc.cluster.local:8080
+	// +kubebuilder:validation:Pattern=`^[^\x00-\x1f\x7f]*$`
 	URL string `json:"url,omitempty"`
 	// IssuerURL is the JWT iss value Envoy validates (must match tokens).
 	// RHBK with a configured hostname issues tokens with the public Route URL
 	// as iss even when clients obtain them via the in-cluster Service — set
 	// this to that frontend base URL (or the full .../realms/<realm> issuer).
 	// When empty, issuer is derived from url + realm.
+	// +kubebuilder:validation:Pattern=`^[^\x00-\x1f\x7f]*$`
 	IssuerURL string `json:"issuerURL,omitempty"`
 	// Keycloak namespace. Defaults to "keycloak".
 	Namespace string `json:"namespace,omitempty"`
 	// +kubebuilder:default:=kubernetes
+	// +kubebuilder:validation:Pattern=`^[^\x00-\x1f\x7f]*$`
 	Realm string `json:"realm,omitempty"`
 	// JWT audiences accepted by the gateway.
 	// +kubebuilder:default:={"cost-management-operator","cost-management-ui"}
+	// +kubebuilder:validation:items:Pattern=`^[^\x00-\x1f\x7f]*$`
 	Audiences []string        `json:"audiences,omitempty"`
 	TLS       KeycloakTLSSpec `json:"tls,omitempty"`
 }

--- a/api/v1alpha1/costmanagementserviceconfig_types.go
+++ b/api/v1alpha1/costmanagementserviceconfig_types.go
@@ -274,16 +274,11 @@ type KeycloakTLSSpec struct {
 	CACertSecretName string `json:"caCertSecretName,omitempty"`
 }
 
-// RealmUser defines an initial Keycloak user created by the operator.
-// NOTE: do not put production credentials here — the Password field is stored
-// in etcd. Use a Secret reference instead once secret-backed user provisioning
-// is implemented (COST-7694).
+// RealmUser identifies a user whose RBAC admin identity (Tenant + Principal)
+// is bootstrapped into the RBAC database by AdminBootstrapJob.
+// Keycloak user provisioning is handled externally (deploy-rhbk.sh), not here.
 type RealmUser struct {
 	Username      string `json:"username"`
-	Password      string `json:"password"`
-	Email         string `json:"email,omitempty"`
-	FirstName     string `json:"firstName,omitempty"`
-	LastName      string `json:"lastName,omitempty"`
 	OrgID         string `json:"orgId,omitempty"`
 	AccountNumber string `json:"accountNumber,omitempty"`
 	OrgAdmin      bool   `json:"orgAdmin,omitempty"`

--- a/config/crd/bases/service.costmanagement.openshift.io_costmanagementserviceconfigs.yaml
+++ b/config/crd/bases/service.costmanagement.openshift.io_costmanagementserviceconfigs.yaml
@@ -140,6 +140,7 @@ spec:
                         - cost-management-ui
                         description: JWT audiences accepted by the gateway.
                         items:
+                          pattern: ^[^\x00-\x1f\x7f]*$
                           type: string
                         type: array
                       issuerURL:
@@ -149,12 +150,14 @@ spec:
                           as iss even when clients obtain them via the in-cluster Service — set
                           this to that frontend base URL (or the full .../realms/<realm> issuer).
                           When empty, issuer is derived from url + realm.
+                        pattern: ^[^\x00-\x1f\x7f]*$
                         type: string
                       namespace:
                         description: Keycloak namespace. Defaults to "keycloak".
                         type: string
                       realm:
                         default: kubernetes
+                        pattern: ^[^\x00-\x1f\x7f]*$
                         type: string
                       tls:
                         properties:
@@ -177,6 +180,7 @@ spec:
                           issuerURL is unset). Prefer an in-cluster http(s) Service URL so Envoy
                           can reach JWKS without depending on the OpenShift router.
                           Example: http://keycloak-service.keycloak.svc.cluster.local:8080
+                        pattern: ^[^\x00-\x1f\x7f]*$
                         type: string
                     type: object
                   realmUsers:

--- a/config/crd/bases/service.costmanagement.openshift.io_costmanagementserviceconfigs.yaml
+++ b/config/crd/bases/service.costmanagement.openshift.io_costmanagementserviceconfigs.yaml
@@ -182,29 +182,19 @@ spec:
                   realmUsers:
                     items:
                       description: |-
-                        RealmUser defines an initial Keycloak user created by the operator.
-                        NOTE: do not put production credentials here — the Password field is stored
-                        in etcd. Use a Secret reference instead once secret-backed user provisioning
-                        is implemented (COST-7694).
+                        RealmUser identifies a user whose RBAC admin identity (Tenant + Principal)
+                        is bootstrapped into the RBAC database by AdminBootstrapJob.
+                        Keycloak user provisioning is handled externally (deploy-rhbk.sh), not here.
                       properties:
                         accountNumber:
-                          type: string
-                        email:
-                          type: string
-                        firstName:
-                          type: string
-                        lastName:
                           type: string
                         orgAdmin:
                           type: boolean
                         orgId:
                           type: string
-                        password:
-                          type: string
                         username:
                           type: string
                       required:
-                      - password
                       - username
                       type: object
                     type: array

--- a/docs/design/design-vs-jira.md
+++ b/docs/design/design-vs-jira.md
@@ -119,12 +119,23 @@ implemented (still pending).
 These items are implementation gaps — not intentional design decisions. They
 will be addressed in upcoming tickets.
 
-### 4a. `RealmUser.Password` in CR spec
+### 4a. `RealmUser.Password` is dead code in the operator
 
-`RealmUser.Password` stores Keycloak user passwords directly in the CR spec.
-CR specs are stored in etcd, appear in `kubectl get -o yaml`, and are captured
-in audit logs. **Fix:** Remove `Password` from `RealmUser`; read credentials
-from a Secret reference instead.
+`RealmUser` is used by `ResolveBootstrapAdmin()` to seed the RBAC admin
+identity (`Username`, `OrgID`, `AccountNumber`) into the RBAC Job. The
+`Password` field is present in the type but **the operator never reads or uses
+it** — Keycloak user provisioning is done by the external `deploy-rhbk.sh`
+install script, not the operator.
+
+The `Password` field should be **removed from the CRD** entirely:
+- It appears in `kubectl get cmsc -o yaml` and etcd (a security exposure for
+  no benefit since the operator ignores it)
+- It creates a false expectation that the operator provisions Keycloak users
+- The Helm chart equivalent (`jwtAuth.realmUsers[].password`) is consumed by
+  `deploy-rhbk.sh` — this is out of scope for the operator
+
+The remaining `RealmUsers` fields (`Username`, `OrgID`, `AccountNumber`,
+`OrgAdmin`) are used and should stay.
 
 ### 4b. `Env map[string]string` raw override
 
@@ -142,12 +153,10 @@ init containers, volumes, or security context are silently ignored on
 subsequent reconciliations. **Fix:** Apply only mutable spec fields via SSA;
 detect VCT changes separately and surface as a condition.
 
-### 4d. `MergeEnv` appends without deduplication
+### 4d. `MergeEnv` deduplication ✅ Fixed
 
-`MergeEnv` in `env.go` appends override keys without checking for duplicates,
-producing duplicate env var entries in pod specs. Kubernetes honours the last
-occurrence but wastes memory. **Fix:** Replace the earlier entry when the key
-already exists.
+`MergeEnv` was sorting and deduplicating overrides. This is now done — keys
+are sorted for stable SSA apply and duplicates replaced rather than appended.
 
 ---
 
@@ -165,12 +174,12 @@ already exists.
 | Django key charset | `a-z0-9!@#$%^&*(-_=+)` | Correct charset | ✅ Done (PR #16) |
 | `*bool` for defaulted fields | — | Used throughout | ✅ Done |
 | Conditions over ComponentStatus | `metav1.Condition` | `metav1.Condition` used | ✅ Done |
-| Passwords in CR spec | — | `RealmUser.Password` remains | ❌ Gap (§4a) |
+| `RealmUser.Password` | — | Present in spec but unused by operator; operator never provisions Keycloak users | ❌ Should be removed (§4a) |
 | `Env map[string]string` | — | Still in spec | ❌ Gap (§4b) |
 | OwnerReference Controller+BlockOwnerDeletion | required | Set correctly | ✅ Done |
-| Finalizer for cluster-scoped resources | required (COST-7681) | `cost.redhat.com/cleanup` implemented | ✅ Done |
+| Finalizer for cluster-scoped resources | required (COST-7681) | `costmanagementserviceconfigs.service.costmanagement.openshift.io/cleanup` | ✅ Done |
 | StatefulSet via SSA | SSA preferred | `r.Update` partial patch | ❌ Gap (§4c) |
 | Periodic requeue / drift correction | 5 min (COST-7681) | `requeueDrift = 5 * time.Minute` | ✅ Done |
-| `MergeEnv` deduplication | — | Still appends without dedup | ❌ Gap (§4d) |
+| `MergeEnv` deduplication | — | Fixed — sorted keys, dedup on write | ✅ Done (§4d) |
 
 [k8s-conventions]: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#typical-status-properties

--- a/internal/resources/envoy.go
+++ b/internal/resources/envoy.go
@@ -295,9 +295,11 @@ func envoyVolumes(cfg *costv1alpha1.CostManagementServiceConfig) []corev1.Volume
 // Two classes of characters break plain YAML scalars:
 //   - Line-break characters (\n, \r, \x00): break out of the current line and
 //     allow the remainder to be parsed as new YAML structure (injection).
-//   - Colon+space (": " or ":\t"): YAML treats this as a mapping-value indicator
-//     even inside a scalar — silently changes the type of a list entry, or causes
-//     a parse error in a scalar position.
+//   - Colon+space/tab/end-of-value (": ", ":\t", or trailing ":"): YAML treats
+//     this as a mapping-value indicator even inside a scalar — silently changes
+//     the type of a list entry to a mapping, or causes a parse error in a scalar
+//     position. A trailing colon triggers this because the template always places
+//     a newline immediately after each interpolated value.
 //
 // Affected strings are double-quoted using strconv.Quote, which escapes all
 // control characters as \n, \r, \x00, etc. Everything else is returned as-is.
@@ -306,7 +308,7 @@ func yamlScalar(s string) string {
 		switch {
 		case c == '\n' || c == '\r' || c == '\x00':
 			return strconv.Quote(s)
-		case c == ':' && i+1 < len(s) && (s[i+1] == ' ' || s[i+1] == '\t'):
+		case c == ':' && (i+1 == len(s) || s[i+1] == ' ' || s[i+1] == '\t'):
 			return strconv.Quote(s)
 		}
 	}

--- a/internal/resources/envoy.go
+++ b/internal/resources/envoy.go
@@ -294,8 +294,9 @@ func envoyVolumes(cfg *costv1alpha1.CostManagementServiceConfig) []corev1.Volume
 // yamlScalar returns a YAML-safe representation of s for inline embedding.
 // The injection risk is embedded newlines — they break out of the current
 // scalar and allow the remainder to be parsed as new YAML structure.
-// Any string containing a newline or carriage return is double-quoted using
-// strconv.Quote, which escapes control characters as \n, \r, etc.
+// Any string containing a newline, carriage return, or NUL byte is
+// double-quoted using strconv.Quote, which escapes control characters
+// as \n, \r, \x00, etc.
 // Plain scalars (URLs, identifiers) that contain no control characters are
 // returned as-is; they are valid YAML without quoting.
 func yamlScalar(s string) string {

--- a/internal/resources/envoy.go
+++ b/internal/resources/envoy.go
@@ -291,17 +291,33 @@ func envoyVolumes(cfg *costv1alpha1.CostManagementServiceConfig) []corev1.Volume
 	return vols
 }
 
+// yamlScalar returns a YAML-safe representation of s for inline embedding.
+// The injection risk is embedded newlines — they break out of the current
+// scalar and allow the remainder to be parsed as new YAML structure.
+// Any string containing a newline or carriage return is double-quoted using
+// strconv.Quote, which escapes control characters as \n, \r, etc.
+// Plain scalars (URLs, identifiers) that contain no control characters are
+// returned as-is; they are valid YAML without quoting.
+func yamlScalar(s string) string {
+	for _, c := range s {
+		if c == '\n' || c == '\r' || c == '\x00' {
+			return strconv.Quote(s)
+		}
+	}
+	return s
+}
+
 // EnvoyYAML renders the Envoy static config from the CR (ported from the Helm chart).
 // Uses token replacement (not fmt.Sprintf) so Lua source with %s is left intact.
 func EnvoyYAML(cfg *costv1alpha1.CostManagementServiceConfig) string {
-	issuer := KeycloakIssuerURL(cfg)
+	issuer := yamlScalar(KeycloakIssuerURL(cfg))
 	jwks := KeycloakJWKSURL(cfg)
 	kcHost, kcPort, useTLS := keycloakHostPort(cfg)
 
 	var audYAML strings.Builder
 	for _, a := range KeycloakAudiences(cfg) {
 		audYAML.WriteString("                        - ")
-		audYAML.WriteString(a)
+		audYAML.WriteString(yamlScalar(a))
 		audYAML.WriteByte('\n')
 	}
 

--- a/internal/resources/envoy.go
+++ b/internal/resources/envoy.go
@@ -311,8 +311,9 @@ func yamlScalar(s string) string {
 // Uses token replacement (not fmt.Sprintf) so Lua source with %s is left intact.
 func EnvoyYAML(cfg *costv1alpha1.CostManagementServiceConfig) string {
 	issuer := yamlScalar(KeycloakIssuerURL(cfg))
-	jwks := KeycloakJWKSURL(cfg)
+	jwks := yamlScalar(KeycloakJWKSURL(cfg))
 	kcHost, kcPort, useTLS := keycloakHostPort(cfg)
+	kcHost = yamlScalar(kcHost)
 
 	var audYAML strings.Builder
 	for _, a := range KeycloakAudiences(cfg) {

--- a/internal/resources/envoy.go
+++ b/internal/resources/envoy.go
@@ -292,16 +292,21 @@ func envoyVolumes(cfg *costv1alpha1.CostManagementServiceConfig) []corev1.Volume
 }
 
 // yamlScalar returns a YAML-safe representation of s for inline embedding.
-// The injection risk is embedded newlines — they break out of the current
-// scalar and allow the remainder to be parsed as new YAML structure.
-// Any string containing a newline, carriage return, or NUL byte is
-// double-quoted using strconv.Quote, which escapes control characters
-// as \n, \r, \x00, etc.
-// Plain scalars (URLs, identifiers) that contain no control characters are
-// returned as-is; they are valid YAML without quoting.
+// Two classes of characters break plain YAML scalars:
+//   - Line-break characters (\n, \r, \x00): break out of the current line and
+//     allow the remainder to be parsed as new YAML structure (injection).
+//   - Colon+space (": " or ":\t"): YAML treats this as a mapping-value indicator
+//     even inside a scalar — silently changes the type of a list entry, or causes
+//     a parse error in a scalar position.
+//
+// Affected strings are double-quoted using strconv.Quote, which escapes all
+// control characters as \n, \r, \x00, etc. Everything else is returned as-is.
 func yamlScalar(s string) string {
-	for _, c := range s {
-		if c == '\n' || c == '\r' || c == '\x00' {
+	for i, c := range s {
+		switch {
+		case c == '\n' || c == '\r' || c == '\x00':
+			return strconv.Quote(s)
+		case c == ':' && i+1 < len(s) && (s[i+1] == ' ' || s[i+1] == '\t'):
 			return strconv.Quote(s)
 		}
 	}

--- a/internal/resources/envoy_test.go
+++ b/internal/resources/envoy_test.go
@@ -10,6 +10,89 @@ import (
 	costv1alpha1 "github.com/project-koku/koku-service-operator/api/v1alpha1"
 )
 
+// assertValidYAMLWithStringAudiences unmarshals the full EnvoyYAML output,
+// walks the YAML to find the audiences list, and asserts every entry is a
+// plain string — not a map (which would indicate YAML injection turned a
+// list entry like "evil:" into {evil: nil}).
+func assertValidYAMLWithStringAudiences(t *testing.T, yamlStr string) {
+	t.Helper()
+
+	var doc map[string]any
+	if err := yaml.Unmarshal([]byte(yamlStr), &doc); err != nil {
+		t.Fatalf("EnvoyYAML output is not valid YAML: %v", err)
+	}
+
+	// Walk: static_resources → listeners[0] → filter_chains[0] → filters[0]
+	//       → typed_config → http_filters → (jwt_authn) → typed_config
+	//       → providers → keycloak → audiences
+	audiences := yamlWalk(doc,
+		"static_resources", "listeners", 0, "filter_chains", 0,
+		"filters", 0, "typed_config", "http_filters",
+	)
+	if audiences == nil {
+		t.Fatal("could not walk YAML to http_filters")
+	}
+
+	filters, ok := audiences.([]any)
+	if !ok {
+		t.Fatalf("http_filters is %T, want []any", audiences)
+	}
+
+	for _, f := range filters {
+		fm, ok := f.(map[string]any)
+		if !ok {
+			continue
+		}
+		tc, ok := fm["typed_config"].(map[string]any)
+		if !ok {
+			continue
+		}
+		providers, ok := tc["providers"].(map[string]any)
+		if !ok {
+			continue
+		}
+		kc, ok := providers["keycloak"].(map[string]any)
+		if !ok {
+			continue
+		}
+		audList, ok := kc["audiences"].([]any)
+		if !ok {
+			t.Fatalf("audiences is %T, want []any", kc["audiences"])
+		}
+		for i, a := range audList {
+			if _, ok := a.(string); !ok {
+				t.Errorf("audiences[%d] is %T (%v), want string — YAML injection turned a list entry into a map", i, a, a)
+			}
+		}
+		return
+	}
+	t.Fatal("could not find keycloak provider with audiences in YAML")
+}
+
+// yamlWalk navigates a nested map/slice structure by keys (string) and
+// indices (int). Returns nil if any step fails.
+func yamlWalk(v any, path ...any) any {
+	for _, step := range path {
+		switch s := step.(type) {
+		case string:
+			m, ok := v.(map[string]any)
+			if !ok {
+				return nil
+			}
+			v = m[s]
+		case int:
+			sl, ok := v.([]any)
+			if !ok || s >= len(sl) {
+				return nil
+			}
+			v = sl[s]
+		default:
+			return nil
+		}
+	}
+	return v
+}
+
 func testCfg() *costv1alpha1.CostManagementServiceConfig {
 	return &costv1alpha1.CostManagementServiceConfig{
 		ObjectMeta: metav1.ObjectMeta{Name: "cost-management", Namespace: "cost-onprem"},
@@ -183,11 +266,8 @@ func TestEnvoyYAMLParsesForROSEnabledAndDisabled(t *testing.T) {
 		cfg := testCfg()
 		e := enabled
 		cfg.Spec.ROS.Enabled = &e
-		raw := EnvoyYAML(cfg)
-		var doc any
-		if err := yaml.Unmarshal([]byte(raw), &doc); err != nil {
-			t.Errorf("ros.enabled=%v: invalid YAML: %v", enabled, err)
-		}
+		out := EnvoyYAML(cfg)
+		assertValidYAMLWithStringAudiences(t, out)
 	}
 }
 
@@ -313,6 +393,7 @@ func TestEnvoyYAMLRejectsInjectedAudience(t *testing.T) {
 			if strings.Contains(out, tc.banned) {
 				t.Errorf("audience injection succeeded via %s: bare 'remote_jwks:' key in Envoy YAML", tc.name)
 			}
+			assertValidYAMLWithStringAudiences(t, out)
 		})
 	}
 }
@@ -328,6 +409,7 @@ func TestEnvoyYAMLRejectsInjectedIssuer(t *testing.T) {
 	if strings.Contains(out, "\nremote_jwks:") {
 		t.Error("issuer injection succeeded: bare 'remote_jwks:' key injected into Envoy YAML")
 	}
+	assertValidYAMLWithStringAudiences(t, out)
 }
 
 // TestEnvoyYAMLRejectsInjectedJWKSURI verifies the JWKS URI is YAML-escaped.
@@ -342,6 +424,7 @@ func TestEnvoyYAMLRejectsInjectedJWKSURI(t *testing.T) {
 	if strings.Contains(out, "\ncluster: attacker-controlled") {
 		t.Error("JWKS URI injection succeeded: bare YAML key injected via keycloak.url")
 	}
+	assertValidYAMLWithStringAudiences(t, out)
 }
 
 // TestEnvoyYAMLRejectsInjectedKCHost verifies the Keycloak cluster host is YAML-escaped.
@@ -360,6 +443,7 @@ func TestEnvoyYAMLRejectsInjectedKCHost(t *testing.T) {
 	if strings.Contains(out, "\ntype: LOGICAL_DNS") {
 		t.Error("KC_HOST injection succeeded: bare YAML key injected via keycloak.url hostname")
 	}
+	assertValidYAMLWithStringAudiences(t, out)
 }
 
 // TestEnvoyYAMLEscapesColonSpace verifies that a colon+space or trailing colon
@@ -393,6 +477,7 @@ func TestEnvoyYAMLEscapesColonSpace(t *testing.T) {
 			if strings.Contains(out, tc.banned) {
 				t.Errorf("audience %q appeared as unquoted plain scalar in YAML", tc.audience)
 			}
+			assertValidYAMLWithStringAudiences(t, out)
 		})
 	}
 }

--- a/internal/resources/envoy_test.go
+++ b/internal/resources/envoy_test.go
@@ -314,3 +314,33 @@ func TestEnvoyYAMLRejectsInjectedIssuer(t *testing.T) {
 		t.Error("issuer injection succeeded: bare 'remote_jwks:' key injected into Envoy YAML")
 	}
 }
+
+// TestEnvoyYAMLRejectsInjectedJWKSURI verifies the JWKS URI is YAML-escaped.
+// The URI appears as a plain scalar in the remote_jwks http_uri block; a newline
+// in auth.keycloak.url could inject arbitrary YAML keys at that indentation level.
+func TestEnvoyYAMLRejectsInjectedJWKSURI(t *testing.T) {
+	cfg := testCfg()
+	cfg.Spec.Auth.Keycloak.URL = "https://keycloak.example.com\ncluster: attacker-controlled\naddress:"
+
+	out := EnvoyYAML(cfg)
+
+	if strings.Contains(out, "\ncluster: attacker-controlled") {
+		t.Error("JWKS URI injection succeeded: bare YAML key injected via keycloak.url")
+	}
+}
+
+// TestEnvoyYAMLRejectsInjectedKCHost verifies the Keycloak cluster host is YAML-escaped.
+// The extracted hostname is used in the socket_address.address field and in the
+// TLS block's sni/match fields; a newline would inject into the cluster definition.
+func TestEnvoyYAMLRejectsInjectedKCHost(t *testing.T) {
+	cfg := testCfg()
+	// url.Parse fallback path: if the URL host can't be parsed, TrimPrefix is used.
+	// Craft a URL where Hostname() returns something with a newline embedded.
+	cfg.Spec.Auth.Keycloak.URL = "https://keycloak.example.com%0Atype: LOGICAL_DNS%0A"
+
+	out := EnvoyYAML(cfg)
+
+	if strings.Contains(out, "\ntype: LOGICAL_DNS") {
+		t.Error("KC_HOST injection succeeded: bare YAML key injected via keycloak.url hostname")
+	}
+}

--- a/internal/resources/envoy_test.go
+++ b/internal/resources/envoy_test.go
@@ -362,20 +362,37 @@ func TestEnvoyYAMLRejectsInjectedKCHost(t *testing.T) {
 	}
 }
 
-// TestEnvoyYAMLEscapesColonSpace verifies that a colon+space in any CR-derived
-// scalar is quoted. Without quoting, ": " in a YAML plain scalar creates a mapping-
-// value indicator — turning a list entry into a one-key map (silent type change) or
-// causing a hard parse error in a scalar position.
+// TestEnvoyYAMLEscapesColonSpace verifies that a colon+space or trailing colon
+// in any CR-derived scalar is quoted. Without quoting, ": " or a bare ":" at
+// end-of-value creates a YAML mapping-value indicator — silently turning a list
+// entry into a one-key map, or causing a hard parse error in a scalar position.
+// A trailing colon is equally dangerous because the template places a newline
+// immediately after every interpolated value (yaml-cpp's EndScalar() trigger).
 func TestEnvoyYAMLEscapesColonSpace(t *testing.T) {
-	cfg := testCfg()
-	// Audience with colon+space: without quoting this becomes a YAML mapping entry.
-	cfg.Spec.Auth.Keycloak.Audiences = []string{"evil: value"}
-
-	out := EnvoyYAML(cfg)
-
-	// After quoting the audience is a double-quoted scalar; the bare "evil: value"
-	// plain-scalar form must not appear at the expected indentation.
-	if strings.Contains(out, "\n                        - evil: value\n") {
-		t.Error("colon+space audience appeared as unquoted plain scalar in YAML")
+	cases := []struct {
+		name     string
+		audience string
+		banned   string
+	}{
+		{
+			name:     "colon-space",
+			audience: "evil: value",
+			banned:   "\n                        - evil: value\n",
+		},
+		{
+			name:     "trailing-colon",
+			audience: "evil:",
+			banned:   "\n                        - evil:\n",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			cfg := testCfg()
+			cfg.Spec.Auth.Keycloak.Audiences = []string{tc.audience}
+			out := EnvoyYAML(cfg)
+			if strings.Contains(out, tc.banned) {
+				t.Errorf("audience %q appeared as unquoted plain scalar in YAML", tc.audience)
+			}
+		})
 	}
 }

--- a/internal/resources/envoy_test.go
+++ b/internal/resources/envoy_test.go
@@ -276,29 +276,44 @@ func TestEnvoyDeploymentMountsKeycloakCACert(t *testing.T) {
 }
 
 // TestEnvoyYAMLRejectsInjectedAudience verifies that audience values containing
-// embedded newlines cannot inject YAML structure into Envoy's JWT filter config.
-// Without escaping, a newline breaks out of the audience list and the injected
-// content becomes new YAML keys — which could override the remote_jwks endpoint
-// and route token validation to an attacker-controlled server.
+// control characters cannot inject YAML structure into Envoy's JWT filter config.
+// Without escaping, a line-breaking control character breaks out of the audience
+// list and the injected content becomes new YAML keys — which could override the
+// remote_jwks endpoint and route token validation to an attacker-controlled server.
 //
 // Best practice is structural YAML generation (not string templates); this test
 // guards the current escape-at-interpolation approach as defense-in-depth.
 func TestEnvoyYAMLRejectsInjectedAudience(t *testing.T) {
-	cfg := testCfg()
-	// Payload: embedded newline followed by a "remote_jwks:" key that would
-	// override the JWKS endpoint if injected as a bare YAML line.
-	cfg.Spec.Auth.Keycloak.Audiences = []string{
-		"legit-audience",
-		"evil\nremote_jwks:\n  http_uri:\n    uri: http://attacker.example.com/jwks",
+	cases := []struct {
+		name    string
+		payload string
+		banned  string
+	}{
+		{
+			name:    "newline",
+			payload: "evil\nremote_jwks:\n  http_uri:\n    uri: http://attacker.example.com/jwks",
+			banned:  "\nremote_jwks:",
+		},
+		{
+			name:    "carriage-return",
+			payload: "evil\rremote_jwks:\r  http_uri:\r    uri: http://attacker.example.com/jwks",
+			banned:  "\rremote_jwks:",
+		},
+		{
+			name:    "nul-byte",
+			payload: "evil\x00remote_jwks:\x00  http_uri:\x00    uri: http://attacker.example.com/jwks",
+			banned:  "\x00remote_jwks:",
+		},
 	}
-
-	out := EnvoyYAML(cfg)
-
-	// After the fix the injected string is quoted as a YAML scalar — the
-	// newline is escaped as \n so "remote_jwks:" never appears as a bare key.
-	// The URL may appear inside a quoted scalar value, which is safe.
-	if strings.Contains(out, "\nremote_jwks:") {
-		t.Error("audience injection succeeded: bare 'remote_jwks:' key injected into Envoy YAML")
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			cfg := testCfg()
+			cfg.Spec.Auth.Keycloak.Audiences = []string{"legit-audience", tc.payload}
+			out := EnvoyYAML(cfg)
+			if strings.Contains(out, tc.banned) {
+				t.Errorf("audience injection succeeded via %s: bare 'remote_jwks:' key in Envoy YAML", tc.name)
+			}
+		})
 	}
 }
 

--- a/internal/resources/envoy_test.go
+++ b/internal/resources/envoy_test.go
@@ -345,17 +345,37 @@ func TestEnvoyYAMLRejectsInjectedJWKSURI(t *testing.T) {
 }
 
 // TestEnvoyYAMLRejectsInjectedKCHost verifies the Keycloak cluster host is YAML-escaped.
-// The extracted hostname is used in the socket_address.address field and in the
-// TLS block's sni/match fields; a newline would inject into the cluster definition.
+// The extracted hostname appears in socket_address.address and in the TLS block's
+// sni/match fields; a newline in auth.keycloak.url that fails url.Parse triggers the
+// TrimPrefix fallback, which preserves the raw bytes — including any embedded newline.
 func TestEnvoyYAMLRejectsInjectedKCHost(t *testing.T) {
 	cfg := testCfg()
-	// url.Parse fallback path: if the URL host can't be parsed, TrimPrefix is used.
-	// Craft a URL where Hostname() returns something with a newline embedded.
-	cfg.Spec.Auth.Keycloak.URL = "https://keycloak.example.com%0Atype: LOGICAL_DNS%0A"
+	// A literal \n causes url.Parse to return an error; keycloakHostPort() falls
+	// back to strings.TrimPrefix, which does not URL-decode and returns the raw
+	// string (including the newline) as kcHost.
+	cfg.Spec.Auth.Keycloak.URL = "https://keycloak.example.com\ntype: LOGICAL_DNS\n"
 
 	out := EnvoyYAML(cfg)
 
 	if strings.Contains(out, "\ntype: LOGICAL_DNS") {
 		t.Error("KC_HOST injection succeeded: bare YAML key injected via keycloak.url hostname")
+	}
+}
+
+// TestEnvoyYAMLEscapesColonSpace verifies that a colon+space in any CR-derived
+// scalar is quoted. Without quoting, ": " in a YAML plain scalar creates a mapping-
+// value indicator — turning a list entry into a one-key map (silent type change) or
+// causing a hard parse error in a scalar position.
+func TestEnvoyYAMLEscapesColonSpace(t *testing.T) {
+	cfg := testCfg()
+	// Audience with colon+space: without quoting this becomes a YAML mapping entry.
+	cfg.Spec.Auth.Keycloak.Audiences = []string{"evil: value"}
+
+	out := EnvoyYAML(cfg)
+
+	// After quoting the audience is a double-quoted scalar; the bare "evil: value"
+	// plain-scalar form must not appear at the expected indentation.
+	if strings.Contains(out, "\n                        - evil: value\n") {
+		t.Error("colon+space audience appeared as unquoted plain scalar in YAML")
 	}
 }

--- a/internal/resources/envoy_test.go
+++ b/internal/resources/envoy_test.go
@@ -274,3 +274,43 @@ func TestEnvoyDeploymentMountsKeycloakCACert(t *testing.T) {
 			"Envoy will fail to verify Keycloak Route certificates", "my-router-ca")
 	}
 }
+
+// TestEnvoyYAMLRejectsInjectedAudience verifies that audience values containing
+// embedded newlines cannot inject YAML structure into Envoy's JWT filter config.
+// Without escaping, a newline breaks out of the audience list and the injected
+// content becomes new YAML keys — which could override the remote_jwks endpoint
+// and route token validation to an attacker-controlled server.
+//
+// Best practice is structural YAML generation (not string templates); this test
+// guards the current escape-at-interpolation approach as defense-in-depth.
+func TestEnvoyYAMLRejectsInjectedAudience(t *testing.T) {
+	cfg := testCfg()
+	// Payload: embedded newline followed by a "remote_jwks:" key that would
+	// override the JWKS endpoint if injected as a bare YAML line.
+	cfg.Spec.Auth.Keycloak.Audiences = []string{
+		"legit-audience",
+		"evil\nremote_jwks:\n  http_uri:\n    uri: http://attacker.example.com/jwks",
+	}
+
+	out := EnvoyYAML(cfg)
+
+	// After the fix the injected string is quoted as a YAML scalar — the
+	// newline is escaped as \n so "remote_jwks:" never appears as a bare key.
+	// The URL may appear inside a quoted scalar value, which is safe.
+	if strings.Contains(out, "\nremote_jwks:") {
+		t.Error("audience injection succeeded: bare 'remote_jwks:' key injected into Envoy YAML")
+	}
+}
+
+// TestEnvoyYAMLRejectsInjectedIssuer verifies the issuer URL is YAML-escaped.
+// A newline in issuerURL injects structure into the JWT provider config block.
+func TestEnvoyYAMLRejectsInjectedIssuer(t *testing.T) {
+	cfg := testCfg()
+	cfg.Spec.Auth.Keycloak.IssuerURL = "https://legit.example.com\nremote_jwks:\n  http_uri:\n    uri: http://attacker.example.com/jwks"
+
+	out := EnvoyYAML(cfg)
+
+	if strings.Contains(out, "\nremote_jwks:") {
+		t.Error("issuer injection succeeded: bare 'remote_jwks:' key injected into Envoy YAML")
+	}
+}


### PR DESCRIPTION
## Security fix

Fixes config injection into the Envoy JWT authentication gateway via unescaped CR spec values in `EnvoyYAML()`.

### Problem

`EnvoyYAML()` builds the JWT provider config via string template + `strings.NewReplacer`. Two CR spec fields were inserted without escaping:

- `auth.keycloak.audiences[]` — written line-by-line with no sanitisation
- `auth.keycloak.issuerURL` — only whitespace-trimmed

A value containing an embedded newline could inject arbitrary YAML structure into Envoy's listener/cluster/filter config — the component that enforces JWT authentication for the entire API. A successful injection could disable or bypass JWT validation.

### Fix

`yamlScalar()` helper: strings containing `\n`, `\r`, or `\x00` are wrapped with `strconv.Quote`, producing a YAML double-quoted scalar where control characters are escaped. Plain scalars (URLs, identifiers) pass through unchanged so existing behaviour is preserved.

### Tests

Two new tests confirm structural injection via newline is blocked:
- `TestEnvoyYAMLRejectsInjectedAudience`
- `TestEnvoyYAMLRejectsInjectedIssuer`

Both verify that a `remote_jwks:` key does not appear as a bare YAML line after injection attempt.

## Summary by Sourcery

Harden Envoy JWT configuration generation against YAML injection by escaping control characters in CR-derived values.

Bug Fixes:
- Prevent JWT audience and issuer values containing newlines from injecting arbitrary YAML into Envoy's configuration, which could bypass token validation.

Enhancements:
- Introduce a yamlScalar helper to safely embed CR strings in YAML templates without changing behavior for plain scalar values.

Tests:
- Add tests ensuring EnvoyYAML rejects newline-based injection attempts via Keycloak audiences and issuer URL, verifying remote_jwks cannot be introduced as a bare YAML key.

## Summary by Sourcery

Harden Envoy JWT configuration generation against YAML injection by escaping control characters in CR-derived values and extending tests to cover additional injection vectors.

Bug Fixes:
- Prevent Keycloak issuer, JWKS URL, audience, and host values containing control characters from injecting arbitrary YAML into Envoy's configuration, preserving correct JWT validation behavior.

Enhancements:
- Introduce a yamlScalar helper to safely embed CR-sourced strings into Envoy's YAML templates while preserving existing behavior for plain scalar values.

Tests:
- Add tests validating EnvoyYAML rejects newline-, carriage-return-, NUL-, and hostname-based injection attempts via Keycloak audiences, issuer URL, JWKS URI, and derived host value.