### PR TITLE
feat: apply global.imagePullSecrets to operator workloads

### DIFF
--- a/api/v1alpha1/costmanagementserviceconfig_types.go
+++ b/api/v1alpha1/costmanagementserviceconfig_types.go
@@ -85,7 +85,9 @@ func BoolVal(b *bool, defaultVal bool) bool {
 
 type GlobalConfig struct {
 	// +kubebuilder:default:=IfNotPresent
-	PullPolicy       corev1.PullPolicy             `json:"pullPolicy,omitempty"`
+	PullPolicy corev1.PullPolicy `json:"pullPolicy,omitempty"`
+	// ImagePullSecrets are applied to every Pod the operator creates (Deployments,
+	// StatefulSets, Jobs, CronJobs) so workloads can pull from private registries.
 	ImagePullSecrets []corev1.LocalObjectReference `json:"imagePullSecrets,omitempty"`
 	// Cluster base domain used for Route hostname generation.
 	// Auto-detected by the Discovery phase when empty.

--- a/config/crd/bases/service.costmanagement.openshift.io_costmanagementserviceconfigs.yaml
+++ b/config/crd/bases/service.costmanagement.openshift.io_costmanagementserviceconfigs.yaml
@@ -1504,6 +1504,9 @@ spec:
                       Auto-detected by the Discovery phase when empty.
                     type: string
                   imagePullSecrets:
+                    description: |-
+                      ImagePullSecrets are applied to every Pod the operator creates (Deployments,
+                      StatefulSets, Jobs, CronJobs) so workloads can pull from private registries.
                     items:
                       description: |-
                         LocalObjectReference contains enough information to let you locate the

--- a/internal/controller/costmanagementserviceconfig_controller.go
+++ b/internal/controller/costmanagementserviceconfig_controller.go
@@ -702,9 +702,10 @@ func (r *CostManagementServiceConfigReconciler) applyStatefulSet(ctx context.Con
 	if err != nil {
 		return err
 	}
-	// Only update mutable fields (replicas, container image, resources).
+	// Only update mutable fields (replicas, container image, resources, pull secrets).
 	patch := existing.DeepCopy()
 	patch.Spec.Replicas = desired.Spec.Replicas
+	patch.Spec.Template.Spec.ImagePullSecrets = desired.Spec.Template.Spec.ImagePullSecrets
 	if len(patch.Spec.Template.Spec.Containers) > 0 && len(desired.Spec.Template.Spec.Containers) > 0 {
 		patch.Spec.Template.Spec.Containers[0].Image = desired.Spec.Template.Spec.Containers[0].Image
 		patch.Spec.Template.Spec.Containers[0].Resources = desired.Spec.Template.Spec.Containers[0].Resources

--- a/internal/resources/cache.go
+++ b/internal/resources/cache.go
@@ -43,7 +43,8 @@ func CacheDeployment(cfg *costv1alpha1.CostManagementServiceConfig) *appsv1.Depl
 			Template: corev1.PodTemplateSpec{
 				ObjectMeta: metav1.ObjectMeta{Labels: allLabels},
 				Spec: corev1.PodSpec{
-					SecurityContext: cachePodSC(),
+					SecurityContext:  cachePodSC(),
+					ImagePullSecrets: imagePullSecrets(cfg),
 					Containers: []corev1.Container{
 						{
 							Name:            "valkey",

--- a/internal/resources/database.go
+++ b/internal/resources/database.go
@@ -56,7 +56,8 @@ func DatabaseStatefulSet(cfg *costv1alpha1.CostManagementServiceConfig) *appsv1.
 			Template: corev1.PodTemplateSpec{
 				ObjectMeta: metav1.ObjectMeta{Labels: allLabels},
 				Spec: corev1.PodSpec{
-					SecurityContext: dbPodSC(),
+					SecurityContext:  dbPodSC(),
+					ImagePullSecrets: imagePullSecrets(cfg),
 					Containers: []corev1.Container{
 						{
 							Name:            "postgres",
@@ -204,4 +205,11 @@ func pullPolicy(cfg *costv1alpha1.CostManagementServiceConfig) corev1.PullPolicy
 		return cfg.Spec.Global.PullPolicy
 	}
 	return corev1.PullIfNotPresent
+}
+
+// imagePullSecrets returns global.imagePullSecrets for Pod specs so private
+// registry credentials (e.g. registry.redhat.io pull secrets) are applied to
+// every workload the operator creates.
+func imagePullSecrets(cfg *costv1alpha1.CostManagementServiceConfig) []corev1.LocalObjectReference {
+	return cfg.Spec.Global.ImagePullSecrets
 }

--- a/internal/resources/database.go
+++ b/internal/resources/database.go
@@ -187,29 +187,3 @@ func dbContainerSC() *corev1.SecurityContext {
 		Capabilities:             &corev1.Capabilities{Drop: []corev1.Capability{"ALL"}},
 	}
 }
-
-// helpers used across multiple builders
-
-func nonRootPodSC() *corev1.PodSecurityContext {
-	nonRoot := true
-	return &corev1.PodSecurityContext{
-		RunAsNonRoot: &nonRoot,
-		SeccompProfile: &corev1.SeccompProfile{
-			Type: corev1.SeccompProfileTypeRuntimeDefault,
-		},
-	}
-}
-
-func pullPolicy(cfg *costv1alpha1.CostManagementServiceConfig) corev1.PullPolicy {
-	if cfg.Spec.Global.PullPolicy != "" {
-		return cfg.Spec.Global.PullPolicy
-	}
-	return corev1.PullIfNotPresent
-}
-
-// imagePullSecrets returns global.imagePullSecrets for Pod specs so private
-// registry credentials (e.g. registry.redhat.io pull secrets) are applied to
-// every workload the operator creates.
-func imagePullSecrets(cfg *costv1alpha1.CostManagementServiceConfig) []corev1.LocalObjectReference {
-	return cfg.Spec.Global.ImagePullSecrets
-}

--- a/internal/resources/envoy.go
+++ b/internal/resources/envoy.go
@@ -188,6 +188,7 @@ func EnvoyDeployment(cfg *costv1alpha1.CostManagementServiceConfig) *appsv1.Depl
 				Spec: corev1.PodSpec{
 					AutomountServiceAccountToken: &falseVal,
 					SecurityContext:              nonRootPodSC(),
+					ImagePullSecrets:             imagePullSecrets(cfg),
 					InitContainers: []corev1.Container{
 						CACombineInitContainer(cfg),
 					},

--- a/internal/resources/image_pull_secrets_test.go
+++ b/internal/resources/image_pull_secrets_test.go
@@ -1,0 +1,57 @@
+package resources
+
+import (
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	costv1alpha1 "github.com/project-koku/koku-service-operator/api/v1alpha1"
+)
+
+func TestImagePullSecretsAppliedToWorkloads(t *testing.T) {
+	cfg := &costv1alpha1.CostManagementServiceConfig{
+		ObjectMeta: metav1.ObjectMeta{Name: "cost-management", Namespace: "cost-onprem"},
+		Spec: costv1alpha1.CostManagementServiceConfigSpec{
+			Global: costv1alpha1.GlobalConfig{
+				ImagePullSecrets: []corev1.LocalObjectReference{{Name: "rh-pull-secret"}},
+			},
+			Auth: costv1alpha1.AuthConfig{
+				Keycloak: costv1alpha1.KeycloakSpec{
+					URL: "http://keycloak.keycloak.svc:8080",
+				},
+			},
+		},
+	}
+	cfg.Spec.CostManagement.API.Image.Repository = "quay.io/koku/koku"
+	cfg.Spec.CostManagement.API.Image.Tag = "test"
+	cfg.Spec.Auth.Envoy.Image.Repository = "registry.redhat.io/openshift-service-mesh/proxyv2-rhel9"
+	cfg.Spec.Auth.Envoy.Image.Tag = "2.6"
+
+	want := []corev1.LocalObjectReference{{Name: "rh-pull-secret"}}
+
+	checks := []struct {
+		name string
+		got  []corev1.LocalObjectReference
+	}{
+		{"koku-api", KokuAPIDeployment(cfg).Spec.Template.Spec.ImagePullSecrets},
+		{"envoy", EnvoyDeployment(cfg).Spec.Template.Spec.ImagePullSecrets},
+		{"database", DatabaseStatefulSet(cfg).Spec.Template.Spec.ImagePullSecrets},
+		{"cache", CacheDeployment(cfg).Spec.Template.Spec.ImagePullSecrets},
+		{"migration", MigrationJob(cfg, "test").Spec.Template.Spec.ImagePullSecrets},
+	}
+	for _, tc := range checks {
+		if len(tc.got) != 1 || tc.got[0].Name != want[0].Name {
+			t.Errorf("%s ImagePullSecrets = %#v, want %#v", tc.name, tc.got, want)
+		}
+	}
+}
+
+func TestImagePullSecretsEmptyByDefault(t *testing.T) {
+	cfg := &costv1alpha1.CostManagementServiceConfig{
+		ObjectMeta: metav1.ObjectMeta{Name: "cost-management", Namespace: "cost-onprem"},
+	}
+	if got := imagePullSecrets(cfg); len(got) != 0 {
+		t.Fatalf("expected empty imagePullSecrets, got %#v", got)
+	}
+}

--- a/internal/resources/ingress.go
+++ b/internal/resources/ingress.go
@@ -141,6 +141,7 @@ func IngressDeployment(cfg *costv1alpha1.CostManagementServiceConfig) *appsv1.De
 				Spec: corev1.PodSpec{
 					AutomountServiceAccountToken: &falseVal,
 					SecurityContext:              nonRootPodSC(),
+					ImagePullSecrets:             imagePullSecrets(cfg),
 					InitContainers:               []corev1.Container{CACombineInitContainer(cfg)},
 					Containers: []corev1.Container{{
 						Name:            "ingress",

--- a/internal/resources/koku.go
+++ b/internal/resources/koku.go
@@ -231,6 +231,7 @@ func deploymentWithContainerName(
 					ServiceAccountName:           NameKokuServiceAccount(cfg),
 					AutomountServiceAccountToken: &falseVal,
 					SecurityContext:              nonRootPodSC(),
+					ImagePullSecrets:             imagePullSecrets(cfg),
 					InitContainers: []corev1.Container{
 						CACombineInitContainer(cfg),
 						WaitForValkeyInitContainer(cfg),
@@ -283,6 +284,7 @@ func deployment(
 					ServiceAccountName:           NameKokuServiceAccount(cfg),
 					AutomountServiceAccountToken: &falseVal,
 					SecurityContext:              nonRootPodSC(),
+					ImagePullSecrets:             imagePullSecrets(cfg),
 					InitContainers: []corev1.Container{
 						CACombineInitContainer(cfg),
 						WaitForValkeyInitContainer(cfg),

--- a/internal/resources/kruize.go
+++ b/internal/resources/kruize.go
@@ -256,6 +256,7 @@ func KruizeDeployment(cfg *costv1alpha1.CostManagementServiceConfig) *appsv1.Dep
 				Spec: corev1.PodSpec{
 					ServiceAccountName: NameKruizeServiceAccount(cfg),
 					SecurityContext:    nonRootPodSC(),
+					ImagePullSecrets:   imagePullSecrets(cfg),
 					InitContainers:     initContainers,
 					Containers: []corev1.Container{{
 						Name:            "kruize",
@@ -335,8 +336,9 @@ func KruizeDeletePartitionsCronJob(cfg *costv1alpha1.CostManagementServiceConfig
 					Template: corev1.PodTemplateSpec{
 						ObjectMeta: metav1.ObjectMeta{Labels: Labels(cfg, "ros-optimization-maintenance")},
 						Spec: corev1.PodSpec{
-							RestartPolicy:   onFailure,
-							SecurityContext: nonRootPodSC(),
+							RestartPolicy:    onFailure,
+							SecurityContext:  nonRootPodSC(),
+							ImagePullSecrets: imagePullSecrets(cfg),
 							Containers: []corev1.Container{{
 								Name:            "delete-kruize-partitions",
 								Image:           image,

--- a/internal/resources/migration.go
+++ b/internal/resources/migration.go
@@ -506,6 +506,7 @@ func migrationJob(
 					AutomountServiceAccountToken: boolPtr(false),
 					RestartPolicy:                corev1.RestartPolicyOnFailure,
 					SecurityContext:              nonRootPodSC(),
+					ImagePullSecrets:             imagePullSecrets(cfg),
 					InitContainers:               initContainers,
 					Containers: []corev1.Container{{
 						Name:            "migrate",

--- a/internal/resources/pod.go
+++ b/internal/resources/pod.go
@@ -1,0 +1,33 @@
+package resources
+
+import (
+	corev1 "k8s.io/api/core/v1"
+
+	costv1alpha1 "github.com/project-koku/koku-service-operator/api/v1alpha1"
+)
+
+// Shared PodSpec helpers used by workload builders across this package.
+
+func nonRootPodSC() *corev1.PodSecurityContext {
+	nonRoot := true
+	return &corev1.PodSecurityContext{
+		RunAsNonRoot: &nonRoot,
+		SeccompProfile: &corev1.SeccompProfile{
+			Type: corev1.SeccompProfileTypeRuntimeDefault,
+		},
+	}
+}
+
+func pullPolicy(cfg *costv1alpha1.CostManagementServiceConfig) corev1.PullPolicy {
+	if cfg.Spec.Global.PullPolicy != "" {
+		return cfg.Spec.Global.PullPolicy
+	}
+	return corev1.PullIfNotPresent
+}
+
+// imagePullSecrets returns global.imagePullSecrets for Pod specs so private
+// registry credentials (e.g. registry.redhat.io pull secrets) are applied to
+// every workload the operator creates.
+func imagePullSecrets(cfg *costv1alpha1.CostManagementServiceConfig) []corev1.LocalObjectReference {
+	return cfg.Spec.Global.ImagePullSecrets
+}

--- a/internal/resources/rbac.go
+++ b/internal/resources/rbac.go
@@ -156,6 +156,7 @@ func RBACAPIDeployment(cfg *costv1alpha1.CostManagementServiceConfig) *appsv1.De
 				Spec: corev1.PodSpec{
 					AutomountServiceAccountToken: &falseVal,
 					SecurityContext:              nonRootPodSC(),
+					ImagePullSecrets:             imagePullSecrets(cfg),
 					InitContainers: []corev1.Container{
 						waitForRBACDB(cfg),
 						WaitForValkeyInitContainer(cfg),
@@ -245,6 +246,7 @@ func RBACWorkerDeployment(cfg *costv1alpha1.CostManagementServiceConfig) *appsv1
 				Spec: corev1.PodSpec{
 					AutomountServiceAccountToken: &falseVal,
 					SecurityContext:              nonRootPodSC(),
+					ImagePullSecrets:             imagePullSecrets(cfg),
 					InitContainers: []corev1.Container{
 						waitForRBACDB(cfg),
 						WaitForValkeyInitContainer(cfg),

--- a/internal/resources/ros.go
+++ b/internal/resources/ros.go
@@ -275,6 +275,7 @@ func ROSAPIDeployment(cfg *costv1alpha1.CostManagementServiceConfig) *appsv1.Dep
 					ServiceAccountName:           NameROSServiceAccount(cfg),
 					AutomountServiceAccountToken: &falseVal,
 					SecurityContext:              nonRootPodSC(),
+					ImagePullSecrets:             imagePullSecrets(cfg),
 					InitContainers: []corev1.Container{
 						waitForROSDB(cfg),
 						waitForKafka(cfg),
@@ -412,6 +413,7 @@ func ROSProcessorDeployment(cfg *costv1alpha1.CostManagementServiceConfig) *apps
 				Spec: corev1.PodSpec{
 					AutomountServiceAccountToken: &falseVal,
 					SecurityContext:              nonRootPodSC(),
+					ImagePullSecrets:             imagePullSecrets(cfg),
 					InitContainers: []corev1.Container{
 						waitForROSDB(cfg),
 						waitForKafka(cfg),
@@ -490,6 +492,7 @@ func ROSPollerDeployment(cfg *costv1alpha1.CostManagementServiceConfig) *appsv1.
 				Spec: corev1.PodSpec{
 					AutomountServiceAccountToken: &falseVal,
 					SecurityContext:              nonRootPodSC(),
+					ImagePullSecrets:             imagePullSecrets(cfg),
 					InitContainers: []corev1.Container{
 						waitForROSDB(cfg),
 						waitForKafka(cfg),
@@ -564,6 +567,7 @@ func ROSHousekeeperDeployment(cfg *costv1alpha1.CostManagementServiceConfig) *ap
 				Spec: corev1.PodSpec{
 					AutomountServiceAccountToken: &falseVal,
 					SecurityContext:              nonRootPodSC(),
+					ImagePullSecrets:             imagePullSecrets(cfg),
 					InitContainers: []corev1.Container{
 						waitForROSDB(cfg),
 						waitForKafka(cfg),
@@ -625,6 +629,7 @@ func ROSPartitionCleanerCronJob(cfg *costv1alpha1.CostManagementServiceConfig) *
 							ServiceAccountName: NameROSServiceAccount(cfg),
 							RestartPolicy:      onFailure,
 							SecurityContext:    nonRootPodSC(),
+							ImagePullSecrets:   imagePullSecrets(cfg),
 							Containers: []corev1.Container{{
 								Name:            "ros-partition-cleaner",
 								Image:           image,

--- a/internal/resources/ui.go
+++ b/internal/resources/ui.go
@@ -246,7 +246,8 @@ func UIDeployment(cfg *costv1alpha1.CostManagementServiceConfig) *appsv1.Deploym
 			Template: corev1.PodTemplateSpec{
 				ObjectMeta: metav1.ObjectMeta{Labels: allLabels},
 				Spec: corev1.PodSpec{
-					SecurityContext: nonRootPodSC(),
+					SecurityContext:  nonRootPodSC(),
+					ImagePullSecrets: imagePullSecrets(cfg),
 					Containers: []corev1.Container{
 						{
 							Name:            "oauth-proxy",


### PR DESCRIPTION
## Summary
- Apply `spec.global.imagePullSecrets` to all operator-managed PodSpecs (Deployments, StatefulSets, Jobs, CronJobs)
- Propagate pull secrets on StatefulSet updates
- Document the field in the CRD and cover it with unit tests

This fixes a dead CRD field: the schema exposed `imagePullSecrets` but no Pod used it, so private-registry pulls had no working configuration path.

## Test plan
- [ ] Unit tests for image pull secrets pass
- [ ] With `global.imagePullSecrets: [{name: <pull-secret>}]`, a Deployment (e.g. Koku API) shows the secret under `spec.template.spec.imagePullSecrets`
- [ ] Without the field set, PodSpecs remain unchanged (empty pull secrets)

## Summary by Sourcery

Apply the global imagePullSecrets configuration to all operator-managed workloads and ensure it is properly documented and tested.

New Features:
- Support configuring image pull secrets globally so operator-created Pods can pull images from private registries.

Enhancements:
- Propagate global imagePullSecrets to all relevant PodSpecs across Deployments, StatefulSets, Jobs, and CronJobs.
- Ensure StatefulSet reconciliation updates image pull secrets when the desired spec changes.
- Document the global imagePullSecrets field in the CRD schema for CostManagementServiceConfig.

Tests:
- Add unit tests verifying imagePullSecrets are applied to key workloads and are empty by default when not configured.