### PR TITLE
test: add unit coverage for untested resource builders

### DIFF
--- a/internal/resources/cache_test.go
+++ b/internal/resources/cache_test.go
@@ -1,6 +1,7 @@
 package resources
 
 import (
+	"slices"
 	"testing"
 
 	appsv1 "k8s.io/api/apps/v1"
@@ -46,7 +47,7 @@ func TestCacheDeployment_Defaults(t *testing.T) {
 	}
 	wantArgs := []string{"--bind", "0.0.0.0", "--port", "6379", "--dir", "/data", "--appendonly", "yes"}
 	for _, want := range wantArgs {
-		if !containsString(c.Args, want) {
+		if !slices.Contains(c.Args, want) {
 			t.Errorf("Args missing %q: %v", want, c.Args)
 		}
 	}
@@ -113,13 +114,4 @@ func TestCachePVC_CustomSize(t *testing.T) {
 	if got.Cmp(resource.MustParse("20Gi")) != 0 {
 		t.Errorf("storage request = %s", got.String())
 	}
-}
-
-func containsString(list []string, s string) bool {
-	for _, v := range list {
-		if v == s {
-			return true
-		}
-	}
-	return false
 }

--- a/internal/resources/cache_test.go
+++ b/internal/resources/cache_test.go
@@ -81,7 +81,7 @@ func TestCacheService_DefaultPort(t *testing.T) {
 	if len(svc.Spec.Ports) != 1 || svc.Spec.Ports[0].Port != 6379 {
 		t.Errorf("ports = %+v", svc.Spec.Ports)
 	}
-	if svc.Spec.Selector["app.kubernetes.io/component"] != "cache" {
+	if svc.Spec.Selector[labelComponent] != "cache" {
 		t.Errorf("selector = %v", svc.Spec.Selector)
 	}
 }

--- a/internal/resources/cache_test.go
+++ b/internal/resources/cache_test.go
@@ -1,0 +1,125 @@
+package resources
+
+import (
+	"testing"
+
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+
+	costv1alpha1 "github.com/project-koku/koku-service-operator/api/v1alpha1"
+)
+
+func cacheCfg() *costv1alpha1.CostManagementServiceConfig {
+	cfg := testCfg()
+	cfg.Spec.Global.StorageClass = "gp3-csi"
+	cfg.Spec.Cache.Image.Repository = "registry.redhat.io/rhel10/valkey-8"
+	cfg.Spec.Cache.Image.Tag = "10.1"
+	return cfg
+}
+
+func TestCacheDeployment_Defaults(t *testing.T) {
+	cfg := cacheCfg()
+	d := CacheDeployment(cfg)
+
+	if d.Name != "cost-management-valkey" {
+		t.Errorf("Name = %q", d.Name)
+	}
+	if d.Namespace != "cost-onprem" {
+		t.Errorf("Namespace = %q", d.Namespace)
+	}
+	if d.Spec.Strategy.Type != appsv1.RecreateDeploymentStrategyType {
+		t.Errorf("Strategy = %q, want Recreate", d.Spec.Strategy.Type)
+	}
+	c := d.Spec.Template.Spec.Containers[0]
+	if c.Name != "valkey" {
+		t.Errorf("container name = %q", c.Name)
+	}
+	if c.Image != "registry.redhat.io/rhel10/valkey-8:10.1" {
+		t.Errorf("image = %q", c.Image)
+	}
+	if c.Command[0] != "valkey-server" {
+		t.Errorf("command = %v", c.Command)
+	}
+	if len(c.Ports) != 1 || c.Ports[0].ContainerPort != 6379 {
+		t.Errorf("ports = %+v, want 6379", c.Ports)
+	}
+	wantArgs := []string{"--bind", "0.0.0.0", "--port", "6379", "--dir", "/data", "--appendonly", "yes"}
+	for _, want := range wantArgs {
+		if !containsString(c.Args, want) {
+			t.Errorf("Args missing %q: %v", want, c.Args)
+		}
+	}
+	if d.Spec.Template.Spec.SecurityContext == nil || d.Spec.Template.Spec.SecurityContext.FSGroup == nil {
+		t.Fatal("expected pod FSGroup for PVC ownership")
+	}
+	if *d.Spec.Template.Spec.SecurityContext.FSGroup != 1000 {
+		t.Errorf("FSGroup = %d, want 1000", *d.Spec.Template.Spec.SecurityContext.FSGroup)
+	}
+	if len(d.Spec.Template.Spec.Volumes) != 1 || d.Spec.Template.Spec.Volumes[0].PersistentVolumeClaim == nil {
+		t.Fatalf("expected PVC volume, got %+v", d.Spec.Template.Spec.Volumes)
+	}
+	if d.Spec.Template.Spec.Volumes[0].PersistentVolumeClaim.ClaimName != NameValkeyPVC(cfg) {
+		t.Errorf("ClaimName = %q", d.Spec.Template.Spec.Volumes[0].PersistentVolumeClaim.ClaimName)
+	}
+}
+
+func TestCacheDeployment_DefaultImageWhenUnset(t *testing.T) {
+	cfg := testCfg()
+	d := CacheDeployment(cfg)
+	if got := d.Spec.Template.Spec.Containers[0].Image; got != "registry.redhat.io/rhel10/valkey-8:10.1" {
+		t.Errorf("default image = %q", got)
+	}
+}
+
+func TestCacheService_DefaultPort(t *testing.T) {
+	cfg := cacheCfg()
+	svc := CacheService(cfg)
+	if svc.Name != NameValkey(cfg) {
+		t.Errorf("Name = %q", svc.Name)
+	}
+	if len(svc.Spec.Ports) != 1 || svc.Spec.Ports[0].Port != 6379 {
+		t.Errorf("ports = %+v", svc.Spec.Ports)
+	}
+	if svc.Spec.Selector["app.kubernetes.io/component"] != "cache" {
+		t.Errorf("selector = %v", svc.Spec.Selector)
+	}
+}
+
+func TestCachePVC_DefaultSizeAndStorageClass(t *testing.T) {
+	cfg := cacheCfg()
+	pvc := CachePVC(cfg)
+	if pvc.Name != NameValkeyPVC(cfg) {
+		t.Errorf("Name = %q", pvc.Name)
+	}
+	want := resource.MustParse("5Gi")
+	got := pvc.Spec.Resources.Requests[corev1.ResourceStorage]
+	if got.Cmp(want) != 0 {
+		t.Errorf("storage request = %s, want %s", got.String(), want.String())
+	}
+	if pvc.Spec.StorageClassName == nil || *pvc.Spec.StorageClassName != "gp3-csi" {
+		t.Errorf("StorageClassName = %v", pvc.Spec.StorageClassName)
+	}
+	if len(pvc.Spec.AccessModes) != 1 || pvc.Spec.AccessModes[0] != corev1.ReadWriteOnce {
+		t.Errorf("AccessModes = %v", pvc.Spec.AccessModes)
+	}
+}
+
+func TestCachePVC_CustomSize(t *testing.T) {
+	cfg := cacheCfg()
+	cfg.Spec.Cache.Persistence.Size = resource.MustParse("20Gi")
+	pvc := CachePVC(cfg)
+	got := pvc.Spec.Resources.Requests[corev1.ResourceStorage]
+	if got.Cmp(resource.MustParse("20Gi")) != 0 {
+		t.Errorf("storage request = %s", got.String())
+	}
+}
+
+func containsString(list []string, s string) bool {
+	for _, v := range list {
+		if v == s {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/resources/configmaps_test.go
+++ b/internal/resources/configmaps_test.go
@@ -1,0 +1,84 @@
+package resources
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestDBInitConfigMap(t *testing.T) {
+	cfg := testCfg()
+	cm := DBInitConfigMap(cfg)
+	if cm.Name != NameDBInitConfigMap(cfg) {
+		t.Errorf("Name = %q", cm.Name)
+	}
+	script, ok := cm.Data["init-databases.sh"]
+	if !ok || script == "" {
+		t.Fatal("missing init-databases.sh")
+	}
+	for _, want := range []string{
+		"costonprem_ros",
+		"costonprem_koku",
+		"costonprem_rbac",
+		"costonprem_kruize",
+		"$ROS_USER",
+		"$KOKU_USER",
+		"pg_stat_statements",
+	} {
+		if !strings.Contains(script, want) {
+			t.Errorf("init script missing %q", want)
+		}
+	}
+}
+
+func TestAWSConfigMap_Defaults(t *testing.T) {
+	cfg := testCfg()
+	cm := AWSConfigMap(cfg)
+	if cm.Name != NameAWSConfigMap(cfg) {
+		t.Errorf("Name = %q", cm.Name)
+	}
+	cfgData := cm.Data["config"]
+	if !strings.Contains(cfgData, "region = onprem") {
+		t.Errorf("default region missing: %q", cfgData)
+	}
+	if !strings.Contains(cfgData, "addressing_style = path") {
+		t.Errorf("default addressing_style missing: %q", cfgData)
+	}
+}
+
+func TestAWSConfigMap_Overrides(t *testing.T) {
+	cfg := testCfg()
+	cfg.Spec.ObjectStorage.S3.Region = "us-east-1"
+	cfg.Spec.ObjectStorage.S3.AddressingStyle = "virtual"
+	cm := AWSConfigMap(cfg)
+	cfgData := cm.Data["config"]
+	if !strings.Contains(cfgData, "region = us-east-1") {
+		t.Errorf("region override missing: %q", cfgData)
+	}
+	if !strings.Contains(cfgData, "addressing_style = virtual") {
+		t.Errorf("addressing_style override missing: %q", cfgData)
+	}
+}
+
+func TestCACombineConfigMap(t *testing.T) {
+	cfg := testCfg()
+	cm := CACombineConfigMap(cfg)
+	if cm.Name != NameCACombineConfigMap(cfg) {
+		t.Errorf("Name = %q", cm.Name)
+	}
+	script := cm.Data["combine-ca.sh"]
+	if !strings.Contains(script, "/ca-output/ca-bundle.crt") {
+		t.Errorf("combine script missing output path: %q", script)
+	}
+}
+
+func TestServiceCAConfigMap_InjectAnnotation(t *testing.T) {
+	cfg := testCfg()
+	cm := ServiceCAConfigMap(cfg)
+	if cm.Name != NameServiceCAConfigMap(cfg) {
+		t.Errorf("Name = %q", cm.Name)
+	}
+	want := "service.beta.openshift.io/inject-cabundle"
+	if cm.Annotations[want] != "true" {
+		t.Errorf("annotations = %v, want %s=true", cm.Annotations, want)
+	}
+}

--- a/internal/resources/ingress_test.go
+++ b/internal/resources/ingress_test.go
@@ -1,0 +1,115 @@
+package resources
+
+import (
+	"testing"
+
+	costv1alpha1 "github.com/project-koku/koku-service-operator/api/v1alpha1"
+)
+
+func ingressCfg() *costv1alpha1.CostManagementServiceConfig {
+	cfg := testCfg()
+	cfg.Spec.Ingress.Image.Repository = "quay.io/cloudservices/insights-ingress"
+	cfg.Spec.Ingress.Image.Tag = "latest"
+	cfg.Spec.ObjectStorage.Endpoint = "minio.cost-byoi-infra.svc"
+	cfg.Spec.ObjectStorage.Port = 9000
+	useSSL := false
+	cfg.Spec.ObjectStorage.UseSSL = &useSSL
+	cfg.Spec.Kafka.BootstrapServers = "my-cluster-kafka-bootstrap.kafka.svc:9092"
+	return cfg
+}
+
+func TestIngressS3EndpointFromSpec(t *testing.T) {
+	cfg := ingressCfg()
+	if got := ingressS3Endpoint(cfg); got != "minio.cost-byoi-infra.svc:9000" {
+		t.Errorf("ingressS3Endpoint = %q", got)
+	}
+}
+
+func TestIngressS3EndpointFromDiscovered(t *testing.T) {
+	cfg := ingressCfg()
+	cfg.Status.DiscoveredConfig = &costv1alpha1.DiscoveredConfig{
+		S3: &costv1alpha1.DiscoveredS3{Endpoint: "https://s3.openshift-storage.svc:443"},
+	}
+	if got := ingressS3Endpoint(cfg); got != "s3.openshift-storage.svc:443" {
+		t.Errorf("ingressS3Endpoint discovered = %q", got)
+	}
+}
+
+func TestIngressS3UseSSL(t *testing.T) {
+	cfg := ingressCfg()
+	if got := ingressS3UseSSL(cfg); got != "false" {
+		t.Errorf("UseSSL=false → %q", got)
+	}
+	cfg.Spec.ObjectStorage.UseSSL = nil // default true
+	if got := ingressS3UseSSL(cfg); got != "true" {
+		t.Errorf("UseSSL default → %q", got)
+	}
+}
+
+func TestIngressDeployment(t *testing.T) {
+	cfg := ingressCfg()
+	d := IngressDeployment(cfg)
+	if d.Name != NameIngress(cfg) {
+		t.Errorf("Name = %q", d.Name)
+	}
+	c := d.Spec.Template.Spec.Containers[0]
+	if c.Name != "ingress" {
+		t.Errorf("container = %q", c.Name)
+	}
+	if c.Image != "quay.io/cloudservices/insights-ingress:latest" {
+		t.Errorf("image = %q", c.Image)
+	}
+	if len(c.Ports) != 2 {
+		t.Fatalf("ports = %+v", c.Ports)
+	}
+	env := map[string]string{}
+	for _, e := range c.Env {
+		if e.Value != "" {
+			env[e.Name] = e.Value
+		}
+	}
+	checks := map[string]string{
+		"INGRESS_WEBPORT":              "8080",
+		"INGRESS_METRICSPORT":          "9000",
+		"INGRESS_MINIOENDPOINT":        "minio.cost-byoi-infra.svc:9000",
+		"INGRESS_USESSL":               "false",
+		"INGRESS_VALID_UPLOAD_TYPES":   "hccm",
+		"INGRESS_STAGERIMPLEMENTATION": "s3",
+		"INGRESS_AUTH":                 "true",
+		"INGRESS_KAFKABROKERS":         "my-cluster-kafka-bootstrap.kafka.svc:9092",
+	}
+	for k, want := range checks {
+		if env[k] != want {
+			t.Errorf("env %s = %q, want %q", k, env[k], want)
+		}
+	}
+	var sawAccess, sawSecret bool
+	for _, e := range c.Env {
+		if e.Name == "INGRESS_MINIOACCESSKEY" && e.ValueFrom != nil && e.ValueFrom.SecretKeyRef != nil {
+			sawAccess = e.ValueFrom.SecretKeyRef.Key == "access-key"
+		}
+		if e.Name == "INGRESS_MINIOSECRETKEY" && e.ValueFrom != nil && e.ValueFrom.SecretKeyRef != nil {
+			sawSecret = e.ValueFrom.SecretKeyRef.Key == "secret-key"
+		}
+	}
+	if !sawAccess || !sawSecret {
+		t.Error("expected MINIO access/secret keys from Secret")
+	}
+	if len(d.Spec.Template.Spec.InitContainers) == 0 {
+		t.Error("expected CA combine init container")
+	}
+}
+
+func TestIngressService(t *testing.T) {
+	cfg := ingressCfg()
+	svc := IngressService(cfg)
+	if svc.Name != NameIngress(cfg) {
+		t.Errorf("Name = %q", svc.Name)
+	}
+	if len(svc.Spec.Ports) != 2 {
+		t.Fatalf("ports = %+v", svc.Spec.Ports)
+	}
+	if svc.Spec.Ports[0].Port != 8080 || svc.Spec.Ports[1].Port != 9000 {
+		t.Errorf("ports = %+v", svc.Spec.Ports)
+	}
+}

--- a/internal/resources/ingress_test.go
+++ b/internal/resources/ingress_test.go
@@ -35,6 +35,17 @@ func TestIngressS3EndpointFromDiscovered(t *testing.T) {
 	}
 }
 
+func TestIngressS3EndpointDiscoveredTakesPrecedence(t *testing.T) {
+	cfg := ingressCfg()
+	// Spec still has minio…:9000 from ingressCfg(); discovered must win.
+	cfg.Status.DiscoveredConfig = &costv1alpha1.DiscoveredConfig{
+		S3: &costv1alpha1.DiscoveredS3{Endpoint: "http://obc-bucket.openshift-storage.svc:443"},
+	}
+	if got := ingressS3Endpoint(cfg); got != "obc-bucket.openshift-storage.svc:443" {
+		t.Errorf("discovered should win over spec; got %q", got)
+	}
+}
+
 func TestIngressS3UseSSL(t *testing.T) {
 	cfg := ingressCfg()
 	if got := ingressS3UseSSL(cfg); got != "false" {
@@ -62,12 +73,7 @@ func TestIngressDeployment(t *testing.T) {
 	if len(c.Ports) != 2 {
 		t.Fatalf("ports = %+v", c.Ports)
 	}
-	env := map[string]string{}
-	for _, e := range c.Env {
-		if e.Value != "" {
-			env[e.Name] = e.Value
-		}
-	}
+	env := envValues(c)
 	checks := map[string]string{
 		"INGRESS_WEBPORT":              "8080",
 		"INGRESS_METRICSPORT":          "9000",

--- a/internal/resources/networkpolicies_test.go
+++ b/internal/resources/networkpolicies_test.go
@@ -1,0 +1,146 @@
+package resources
+
+import (
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	networkingv1 "k8s.io/api/networking/v1"
+)
+
+func TestGatewayNetworkPolicy(t *testing.T) {
+	cfg := testCfg()
+	np := GatewayNetworkPolicy(cfg)
+	if np.Name != cfg.Name+"-gateway" {
+		t.Errorf("Name = %q", np.Name)
+	}
+	assertIngressOnly(t, np)
+	if got := np.Spec.PodSelector.MatchLabels["app.kubernetes.io/component"]; got != "gateway" {
+		t.Errorf("podSelector component = %q", got)
+	}
+	// Router + UI + monitoring rules.
+	if len(np.Spec.Ingress) < 3 {
+		t.Fatalf("expected ≥3 ingress rules, got %d", len(np.Spec.Ingress))
+	}
+	if !ruleAllowsPort(np.Spec.Ingress, envoyHTTPPort) {
+		t.Errorf("missing HTTP port %d", envoyHTTPPort)
+	}
+	if !ruleAllowsPort(np.Spec.Ingress, envoyAdminPort) {
+		t.Errorf("missing admin port %d", envoyAdminPort)
+	}
+}
+
+func TestIngressNetworkPolicy_GatewayOnly(t *testing.T) {
+	cfg := testCfg()
+	np := IngressNetworkPolicy(cfg)
+	if np.Name != cfg.Name+"-ingress" {
+		t.Errorf("Name = %q", np.Name)
+	}
+	assertIngressOnly(t, np)
+	if len(np.Spec.Ingress) != 1 {
+		t.Fatalf("expected single gateway rule, got %d", len(np.Spec.Ingress))
+	}
+	if !peerHasComponent(np.Spec.Ingress[0], "gateway") {
+		t.Error("ingress rule must allow from gateway")
+	}
+	if !ruleAllowsPort(np.Spec.Ingress, ingressHTTPPort) {
+		t.Errorf("missing ingress HTTP port %d", ingressHTTPPort)
+	}
+}
+
+func TestKruizeNetworkPolicy(t *testing.T) {
+	cfg := testCfg()
+	np := KruizeNetworkPolicy(cfg)
+	assertIngressOnly(t, np)
+	wantFrom := []string{"ros-processor", "ros-recommendation-poller", "ros-housekeeper"}
+	for _, comp := range wantFrom {
+		found := false
+		for _, rule := range np.Spec.Ingress {
+			if peerHasComponent(rule, comp) {
+				found = true
+				break
+			}
+		}
+		if !found {
+			t.Errorf("missing peer component %q", comp)
+		}
+	}
+}
+
+func TestRBACAPINetworkPolicy(t *testing.T) {
+	cfg := testCfg()
+	np := RBACAPINetworkPolicy(cfg)
+	assertIngressOnly(t, np)
+	wantFrom := []string{"gateway", "cost-management-api", "cost-processor", "ros-api"}
+	for _, comp := range wantFrom {
+		found := false
+		for _, rule := range np.Spec.Ingress {
+			if peerHasComponent(rule, comp) {
+				found = true
+				break
+			}
+		}
+		if !found {
+			t.Errorf("missing peer component %q", comp)
+		}
+	}
+}
+
+func TestKokuAPINetworkPolicy(t *testing.T) {
+	cfg := testCfg()
+	np := KokuAPINetworkPolicy(cfg)
+	assertIngressOnly(t, np)
+	if !ruleAllowsPort(np.Spec.Ingress, 8000) {
+		t.Error("missing koku API port 8000")
+	}
+	if !ruleAllowsPort(np.Spec.Ingress, 9000) {
+		t.Error("missing koku metrics port 9000")
+	}
+	if !peerHasComponent(np.Spec.Ingress[0], "gateway") {
+		t.Error("first rule should allow gateway")
+	}
+}
+
+func TestROSAPINetworkPolicy_GatewayOnly(t *testing.T) {
+	// Extends the smoke test in names_test.go with peer/port assertions.
+	cfg := testCfg()
+	np := ROSAPINetworkPolicy(cfg)
+	assertIngressOnly(t, np)
+	if len(np.Spec.Ingress) != 1 {
+		t.Fatalf("expected single gateway rule, got %d", len(np.Spec.Ingress))
+	}
+	if !peerHasComponent(np.Spec.Ingress[0], "gateway") {
+		t.Error("ROS API must only accept traffic from gateway")
+	}
+	if !ruleAllowsPort(np.Spec.Ingress, rosAPIPort) {
+		t.Errorf("missing ros API port %d", rosAPIPort)
+	}
+}
+
+func assertIngressOnly(t *testing.T, np *networkingv1.NetworkPolicy) {
+	t.Helper()
+	if len(np.Spec.PolicyTypes) != 1 || np.Spec.PolicyTypes[0] != networkingv1.PolicyTypeIngress {
+		t.Errorf("PolicyTypes = %v, want [Ingress]", np.Spec.PolicyTypes)
+	}
+}
+
+func peerHasComponent(rule networkingv1.NetworkPolicyIngressRule, component string) bool {
+	for _, from := range rule.From {
+		if from.PodSelector != nil && from.PodSelector.MatchLabels["app.kubernetes.io/component"] == component {
+			return true
+		}
+	}
+	return false
+}
+
+func ruleAllowsPort(rules []networkingv1.NetworkPolicyIngressRule, port int32) bool {
+	for _, rule := range rules {
+		for _, p := range rule.Ports {
+			if p.Port != nil && p.Port.IntVal == port {
+				if p.Protocol == nil || *p.Protocol == corev1.ProtocolTCP {
+					return true
+				}
+			}
+		}
+	}
+	return false
+}

--- a/internal/resources/networkpolicies_test.go
+++ b/internal/resources/networkpolicies_test.go
@@ -14,7 +14,7 @@ func TestGatewayNetworkPolicy(t *testing.T) {
 		t.Errorf("Name = %q", np.Name)
 	}
 	assertIngressOnly(t, np)
-	if got := np.Spec.PodSelector.MatchLabels["app.kubernetes.io/component"]; got != "gateway" {
+	if got := np.Spec.PodSelector.MatchLabels[labelComponent]; got != "gateway" {
 		t.Errorf("podSelector component = %q", got)
 	}
 	// Router + UI + monitoring rules.
@@ -86,14 +86,18 @@ func TestRBACAPINetworkPolicy(t *testing.T) {
 }
 
 func TestKokuAPINetworkPolicy(t *testing.T) {
+	const (
+		kokuAPIPort     = int32(8000)
+		kokuMetricsPort = int32(9000)
+	)
 	cfg := testCfg()
 	np := KokuAPINetworkPolicy(cfg)
 	assertIngressOnly(t, np)
-	if !ruleAllowsPort(np.Spec.Ingress, 8000) {
-		t.Error("missing koku API port 8000")
+	if !ruleAllowsPort(np.Spec.Ingress, kokuAPIPort) {
+		t.Errorf("missing koku API port %d", kokuAPIPort)
 	}
-	if !ruleAllowsPort(np.Spec.Ingress, 9000) {
-		t.Error("missing koku metrics port 9000")
+	if !ruleAllowsPort(np.Spec.Ingress, kokuMetricsPort) {
+		t.Errorf("missing koku metrics port %d", kokuMetricsPort)
 	}
 	if !peerHasComponent(np.Spec.Ingress[0], "gateway") {
 		t.Error("first rule should allow gateway")
@@ -125,7 +129,7 @@ func assertIngressOnly(t *testing.T, np *networkingv1.NetworkPolicy) {
 
 func peerHasComponent(rule networkingv1.NetworkPolicyIngressRule, component string) bool {
 	for _, from := range rule.From {
-		if from.PodSelector != nil && from.PodSelector.MatchLabels["app.kubernetes.io/component"] == component {
+		if from.PodSelector != nil && from.PodSelector.MatchLabels[labelComponent] == component {
 			return true
 		}
 	}

--- a/internal/resources/ros_test.go
+++ b/internal/resources/ros_test.go
@@ -1,0 +1,140 @@
+package resources
+
+import (
+	"strings"
+	"testing"
+
+	costv1alpha1 "github.com/project-koku/koku-service-operator/api/v1alpha1"
+)
+
+func rosCfg() *costv1alpha1.CostManagementServiceConfig {
+	cfg := testCfg()
+	enabled := true
+	deploy := false
+	cfg.Spec.ROS.Enabled = &enabled
+	cfg.Spec.ROS.Image.Repository = "quay.io/cloudservices/ros-ocp-backend"
+	cfg.Spec.ROS.Image.Tag = "latest"
+	cfg.Spec.Database.Deploy = &deploy
+	cfg.Spec.Database.Host = "postgres.example.svc"
+	cfg.Spec.Database.Port = 5432
+	cfg.Spec.Kafka.BootstrapServers = "kafka.example.com:9092"
+	return cfg
+}
+
+func TestROSServiceAccount(t *testing.T) {
+	cfg := rosCfg()
+	sa := ROSServiceAccount(cfg)
+	if sa.Name != NameROSServiceAccount(cfg) {
+		t.Errorf("Name = %q", sa.Name)
+	}
+	if sa.Namespace != cfg.Namespace {
+		t.Errorf("Namespace = %q", sa.Namespace)
+	}
+}
+
+func TestCdappConfigMap_ContainsDBAndKafka(t *testing.T) {
+	cfg := rosCfg()
+	cm := CdappConfigMap(cfg)
+	if cm.Name != NameCdappConfigMap(cfg) {
+		t.Errorf("Name = %q", cm.Name)
+	}
+	data := cm.Data["cdappconfig.json"]
+	for _, want := range []string{
+		`"hostname": "postgres.example.svc"`,
+		`"name": "costonprem_ros"`,
+		`"hostname": "kafka.example.com"`,
+		`"port": 9092`,
+		uploadTopic,
+		recommendationTopic,
+	} {
+		if !strings.Contains(data, want) {
+			t.Errorf("cdappconfig missing %q\n%s", want, data)
+		}
+	}
+}
+
+func TestROSAPIDeployment_Shape(t *testing.T) {
+	cfg := rosCfg()
+	d := ROSAPIDeployment(cfg)
+	if d.Name != NameROSAPI(cfg) {
+		t.Errorf("Name = %q", d.Name)
+	}
+	if d.Spec.Template.Spec.ServiceAccountName != NameROSServiceAccount(cfg) {
+		t.Errorf("SA = %q", d.Spec.Template.Spec.ServiceAccountName)
+	}
+	if len(d.Spec.Template.Spec.InitContainers) < 2 {
+		t.Fatalf("expected DB+Kafka init containers, got %d", len(d.Spec.Template.Spec.InitContainers))
+	}
+	c := d.Spec.Template.Spec.Containers[0]
+	if c.Image != "quay.io/cloudservices/ros-ocp-backend:latest" {
+		t.Errorf("image = %q", c.Image)
+	}
+	if len(c.Ports) != 2 || c.Ports[0].ContainerPort != rosAPIPort || c.Ports[1].ContainerPort != rosMetricPort {
+		t.Errorf("ports = %+v", c.Ports)
+	}
+	env := map[string]string{}
+	for _, e := range c.Env {
+		if e.Value != "" {
+			env[e.Name] = e.Value
+		}
+	}
+	if env["DB_NAME"] != rosDBName {
+		t.Errorf("DB_NAME = %q", env["DB_NAME"])
+	}
+	if env["RBACHOST"] != NameRBACAPI(cfg) {
+		t.Errorf("RBACHOST = %q", env["RBACHOST"])
+	}
+	if env["SERVICE_NAME"] != "ros-api" {
+		t.Errorf("SERVICE_NAME = %q", env["SERVICE_NAME"])
+	}
+	if c.LivenessProbe == nil || c.LivenessProbe.HTTPGet == nil || c.LivenessProbe.HTTPGet.Path != "/status" {
+		t.Errorf("liveness probe = %+v", c.LivenessProbe)
+	}
+}
+
+func TestROSAPIService_Ports(t *testing.T) {
+	cfg := rosCfg()
+	svc := ROSAPIService(cfg)
+	if svc.Name != NameROSAPI(cfg) {
+		t.Errorf("Name = %q", svc.Name)
+	}
+	if len(svc.Spec.Ports) != 2 || svc.Spec.Ports[0].Port != rosAPIPort || svc.Spec.Ports[1].Port != rosMetricPort {
+		t.Errorf("ports = %+v", svc.Spec.Ports)
+	}
+}
+
+func TestROSProcessorDeployment_Shape(t *testing.T) {
+	cfg := rosCfg()
+	cfg.Spec.ROS.Processor.Replicas = 2
+	cfg.Spec.ROS.Processor.LogLevel = "DEBUG"
+	d := ROSProcessorDeployment(cfg)
+	if d.Name != NameROSProcessor(cfg) {
+		t.Errorf("Name = %q", d.Name)
+	}
+	if d.Spec.Replicas == nil || *d.Spec.Replicas != 2 {
+		t.Errorf("replicas = %v", d.Spec.Replicas)
+	}
+	c := d.Spec.Template.Spec.Containers[0]
+	env := map[string]string{}
+	for _, e := range c.Env {
+		if e.Value != "" {
+			env[e.Name] = e.Value
+		}
+	}
+	if env["SERVICE_NAME"] != "ros-processor" {
+		t.Errorf("SERVICE_NAME = %q", env["SERVICE_NAME"])
+	}
+	if env["UPLOAD_TOPIC"] != uploadTopic {
+		t.Errorf("UPLOAD_TOPIC = %q", env["UPLOAD_TOPIC"])
+	}
+	if env["LOG_LEVEL"] != "DEBUG" {
+		t.Errorf("LOG_LEVEL = %q", env["LOG_LEVEL"])
+	}
+	if env["KRUIZE_HOST"] != NameKruize(cfg) {
+		t.Errorf("KRUIZE_HOST = %q", env["KRUIZE_HOST"])
+	}
+	// Must wait for DB, Kafka, and Kruize before starting.
+	if len(d.Spec.Template.Spec.InitContainers) < 3 {
+		t.Fatalf("expected ≥3 init containers, got %d", len(d.Spec.Template.Spec.InitContainers))
+	}
+}

--- a/internal/resources/ros_test.go
+++ b/internal/resources/ros_test.go
@@ -138,3 +138,66 @@ func TestROSProcessorDeployment_Shape(t *testing.T) {
 		t.Fatalf("expected ≥3 init containers, got %d", len(d.Spec.Template.Spec.InitContainers))
 	}
 }
+
+func TestROSPollerDeployment_Shape(t *testing.T) {
+	cfg := rosCfg()
+	d := ROSPollerDeployment(cfg)
+	if d.Name != NameROSPoller(cfg) {
+		t.Errorf("Name = %q", d.Name)
+	}
+	c := d.Spec.Template.Spec.Containers[0]
+	if c.Name != "ros-rec-poller" {
+		t.Errorf("container = %q", c.Name)
+	}
+	env := map[string]string{}
+	for _, e := range c.Env {
+		if e.Value != "" {
+			env[e.Name] = e.Value
+		}
+	}
+	if env["SERVICE_NAME"] != "ros-recommendation-poller" {
+		t.Errorf("SERVICE_NAME = %q", env["SERVICE_NAME"])
+	}
+	if env["RECOMMENDATION_TOPIC"] != recommendationTopic {
+		t.Errorf("RECOMMENDATION_TOPIC = %q", env["RECOMMENDATION_TOPIC"])
+	}
+}
+
+func TestROSHousekeeperDeployment_WaitsForKoku(t *testing.T) {
+	cfg := rosCfg()
+	d := ROSHousekeeperDeployment(cfg)
+	if d.Name != NameROSHousekeeper(cfg) {
+		t.Errorf("Name = %q", d.Name)
+	}
+	if len(d.Spec.Template.Spec.InitContainers) < 4 {
+		t.Fatalf("expected DB+Kafka+Kruize+Koku inits, got %d", len(d.Spec.Template.Spec.InitContainers))
+	}
+	env := map[string]string{}
+	for _, e := range d.Spec.Template.Spec.Containers[0].Env {
+		if e.Value != "" {
+			env[e.Name] = e.Value
+		}
+	}
+	if env["SERVICE_NAME"] != "ros-housekeeper-sources" {
+		t.Errorf("SERVICE_NAME = %q", env["SERVICE_NAME"])
+	}
+	wantURL := "http://" + NameKokuAPI(cfg) + ":8000"
+	if env["SOURCES_API_BASE_URL"] != wantURL {
+		t.Errorf("SOURCES_API_BASE_URL = %q, want %q", env["SOURCES_API_BASE_URL"], wantURL)
+	}
+}
+
+func TestROSPartitionCleanerCronJob_DefaultSchedule(t *testing.T) {
+	cfg := rosCfg()
+	cj := ROSPartitionCleanerCronJob(cfg)
+	if cj.Name != cfg.Name+"-ros-partition-cleaner" {
+		t.Errorf("Name = %q", cj.Name)
+	}
+	if cj.Spec.Schedule != "0 0 */15 * *" {
+		t.Errorf("Schedule = %q", cj.Spec.Schedule)
+	}
+	c := cj.Spec.JobTemplate.Spec.Template.Spec.Containers[0]
+	if c.Name != "ros-partition-cleaner" {
+		t.Errorf("container = %q", c.Name)
+	}
+}

--- a/internal/resources/ros_test.go
+++ b/internal/resources/ros_test.go
@@ -72,12 +72,7 @@ func TestROSAPIDeployment_Shape(t *testing.T) {
 	if len(c.Ports) != 2 || c.Ports[0].ContainerPort != rosAPIPort || c.Ports[1].ContainerPort != rosMetricPort {
 		t.Errorf("ports = %+v", c.Ports)
 	}
-	env := map[string]string{}
-	for _, e := range c.Env {
-		if e.Value != "" {
-			env[e.Name] = e.Value
-		}
-	}
+	env := envValues(c)
 	if env["DB_NAME"] != rosDBName {
 		t.Errorf("DB_NAME = %q", env["DB_NAME"])
 	}
@@ -101,6 +96,10 @@ func TestROSAPIService_Ports(t *testing.T) {
 	if len(svc.Spec.Ports) != 2 || svc.Spec.Ports[0].Port != rosAPIPort || svc.Spec.Ports[1].Port != rosMetricPort {
 		t.Errorf("ports = %+v", svc.Spec.Ports)
 	}
+	wantSel := SelectorLabels(cfg, "ros-api")
+	if svc.Spec.Selector[labelComponent] != wantSel[labelComponent] {
+		t.Errorf("selector[%s] = %q, want %q", labelComponent, svc.Spec.Selector[labelComponent], wantSel[labelComponent])
+	}
 }
 
 func TestROSProcessorDeployment_Shape(t *testing.T) {
@@ -115,12 +114,7 @@ func TestROSProcessorDeployment_Shape(t *testing.T) {
 		t.Errorf("replicas = %v", d.Spec.Replicas)
 	}
 	c := d.Spec.Template.Spec.Containers[0]
-	env := map[string]string{}
-	for _, e := range c.Env {
-		if e.Value != "" {
-			env[e.Name] = e.Value
-		}
-	}
+	env := envValues(c)
 	if env["SERVICE_NAME"] != "ros-processor" {
 		t.Errorf("SERVICE_NAME = %q", env["SERVICE_NAME"])
 	}
@@ -149,12 +143,7 @@ func TestROSPollerDeployment_Shape(t *testing.T) {
 	if c.Name != "ros-rec-poller" {
 		t.Errorf("container = %q", c.Name)
 	}
-	env := map[string]string{}
-	for _, e := range c.Env {
-		if e.Value != "" {
-			env[e.Name] = e.Value
-		}
-	}
+	env := envValues(c)
 	if env["SERVICE_NAME"] != "ros-recommendation-poller" {
 		t.Errorf("SERVICE_NAME = %q", env["SERVICE_NAME"])
 	}
@@ -172,12 +161,7 @@ func TestROSHousekeeperDeployment_WaitsForKoku(t *testing.T) {
 	if len(d.Spec.Template.Spec.InitContainers) < 4 {
 		t.Fatalf("expected DB+Kafka+Kruize+Koku inits, got %d", len(d.Spec.Template.Spec.InitContainers))
 	}
-	env := map[string]string{}
-	for _, e := range d.Spec.Template.Spec.Containers[0].Env {
-		if e.Value != "" {
-			env[e.Name] = e.Value
-		}
-	}
+	env := envValues(d.Spec.Template.Spec.Containers[0])
 	if env["SERVICE_NAME"] != "ros-housekeeper-sources" {
 		t.Errorf("SERVICE_NAME = %q", env["SERVICE_NAME"])
 	}

--- a/internal/resources/test_helpers_test.go
+++ b/internal/resources/test_helpers_test.go
@@ -1,0 +1,17 @@
+package resources
+
+import (
+	corev1 "k8s.io/api/core/v1"
+)
+
+// envValues returns a map of EnvVar Name→Value for vars with a literal Value set.
+// Secret/ConfigMap refs (Value == "") are omitted.
+func envValues(c corev1.Container) map[string]string {
+	out := make(map[string]string, len(c.Env))
+	for _, e := range c.Env {
+		if e.Value != "" {
+			out[e.Name] = e.Value
+		}
+	}
+	return out
+}


### PR DESCRIPTION
## Summary
- Add pure unit tests for resource builders that were at 0% coverage despite being called from the live reconciler: `cache`, `configmaps`, `ingress`, `ros` (API/Cdapp/processor), and `networkpolicies`
- Raises `./internal/resources` statement coverage from ~41% → ~59%
- Claimed files: `cache.go` / `configmaps.go` / `networkpolicies.go` now fully function-covered; `ingress.go` all funcs exercised; `ros.go` 15/19 funcs covered (poller/housekeeper/cron still open for a follow-up)

Addresses the High test-coverage review finding (builder layer / PR1). Does **not** yet assert the reconciler reaches `Ready` — that is PR2.

## Test plan
- [x] `go test ./internal/resources/ -count=1`
- [x] `go test ./internal/resources/ -coverprofile=… -coverpkg=./internal/resources/` shows claimed builders no longer at 0%
- [ ] CI Test job green

## Summary by Sourcery

Add unit test coverage for previously untested resource builders in the internal resources package.

Tests:
- Add network policy builder unit tests covering gateway, ingress, Kruize, RBAC API, Koku API, and ROS API policies.
- Add ROS resource unit tests for service account, config map, deployments, and services including env, ports, and init containers.
- Add cache resource unit tests for deployment, service, and PVC defaults and overrides, including image, storage, and access modes.
- Add ingress resource unit tests for S3 endpoint/SSL helpers, deployment env wiring, and service ports.
- Increase statement and function coverage across cache, configmaps, ingress, ros, and networkpolicies builders.