### PR TITLE
fix: remove unimplemented profile=ha from CRD enum

### DIFF
--- a/api/v1alpha1/costmanagementserviceconfig_types.go
+++ b/api/v1alpha1/costmanagementserviceconfig_types.go
@@ -36,15 +36,15 @@ const (
 // -----------------------------------------------------------------------------
 
 // Profile selects a pre-defined resource sizing tier for all components.
-// +kubebuilder:validation:Enum=standard;ha
+// Only "standard" is accepted today; HA sizing maps are not implemented yet
+// (COST-7678 / COST-7693), so "ha" was removed from the enum to avoid a
+// silently no-op API.
+// +kubebuilder:validation:Enum=standard
 type Profile string
 
 const (
 	// ProfileStandard is suitable for single-node or small clusters.
 	ProfileStandard Profile = "standard"
-	// ProfileHA provides higher replica counts and resource requests for
-	// production multi-node deployments.
-	ProfileHA Profile = "ha"
 )
 
 // -----------------------------------------------------------------------------
@@ -580,6 +580,7 @@ type MonitoringConfig struct {
 
 type CostManagementServiceConfigSpec struct {
 	// Profile selects pre-defined resource sizing. Defaults to standard.
+	// Only "standard" is valid until profile sizing maps are implemented.
 	// +kubebuilder:default:=standard
 	Profile        Profile              `json:"profile,omitempty"`
 	Global         GlobalConfig         `json:"global,omitempty"`

--- a/config/crd/bases/service.costmanagement.openshift.io_costmanagementserviceconfigs.yaml
+++ b/config/crd/bases/service.costmanagement.openshift.io_costmanagementserviceconfigs.yaml
@@ -1862,11 +1862,11 @@ spec:
                 type: object
               profile:
                 default: standard
-                description: Profile selects pre-defined resource sizing. Defaults
-                  to standard.
+                description: |-
+                  Profile selects pre-defined resource sizing. Defaults to standard.
+                  Only "standard" is valid until profile sizing maps are implemented.
                 enum:
                 - standard
-                - ha
                 type: string
               rbac:
                 properties:


### PR DESCRIPTION
## Summary
- Drop `ha` from `spec.profile` enum (and `ProfileHA` constant)
- Keep `standard` as the only accepted value until profile sizing maps exist (COST-7678 / COST-7693)
- Update CRD description so the API does not advertise a silently no-op HA mode

## Test plan
- [ ] CRD schema shows `profile` enum as `[standard]` only
- [ ] Applying a CR with `profile: ha` is rejected by the API server
- [ ] Existing samples with default/`standard` still apply

## Summary by Sourcery

Restrict the CostManagementServiceConfig profile to the standard tier and update API documentation to reflect that HA sizing is not yet implemented.

Bug Fixes:
- Prevent users from selecting the unimplemented 'ha' profile value, which previously behaved as a no-op.

Enhancements:
- Clarify CRD and Go type documentation to state that only the 'standard' profile is currently valid.