### PR TITLE
ci: push operator image to quay on main

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -150,18 +150,40 @@ jobs:
   container-build:
     name: Container Build
     runs-on: ubuntu-latest
+    env:
+      PUSH_IMAGE: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
     steps:
       - uses: actions/checkout@v7
 
       - uses: docker/setup-buildx-action@v4
 
-      - name: Build container image
+      - name: Log in to Quay.io
+        if: env.PUSH_IMAGE == 'true'
+        uses: docker/login-action@v3
+        with:
+          registry: quay.io
+          username: ${{ secrets.QUAY_USER }}
+          password: ${{ secrets.QUAY_TOKEN }}
+
+      - name: Docker metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: quay.io/project-koku/koku-service-operator
+          tags: |
+            type=raw,value=latest,enable=${{ env.PUSH_IMAGE }}
+            type=raw,value=main,enable=${{ env.PUSH_IMAGE }}
+            type=raw,value={{sha}},enable=${{ env.PUSH_IMAGE }}
+            type=raw,value=ci,enable=${{ env.PUSH_IMAGE != 'true' }}
+
+      - name: Build and push container image
         uses: docker/build-push-action@v7
         with:
           context: .
           file: Dockerfile
-          push: false
-          tags: koku-service-operator:ci
+          push: ${{ env.PUSH_IMAGE }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
 


### PR DESCRIPTION
## Summary by Sourcery

Configure CI to build the operator container image for Quay and push it only on main branch pushes.

CI:
- Update container-build workflow to conditionally push images to Quay.io when changes are pushed to the main branch.
- Add Quay.io authentication and Docker metadata generation to manage tags and labels for operator images built in CI.