### PR TITLE
fix: wire S3_ACCESS_KEY/S3_SECRET for koku object storage

### DIFF
--- a/internal/controller/discovery_s3.go
+++ b/internal/controller/discovery_s3.go
@@ -186,8 +186,8 @@ func (r *CostManagementServiceConfigReconciler) upsertStorageCredentials(ctx con
 		// Use Data (not StringData) so the controller-runtime fake client
 		// round-trips credentials correctly in unit tests.
 		Data: map[string][]byte{
-			"access-key": []byte(accessKey), //nolint:goconst
-			"secret-key": []byte(secretKey),
+			s3SecretKeys[0]: []byte(accessKey),
+			s3SecretKeys[1]: []byte(secretKey),
 		},
 	}
 	setOwnerRef(cfg, desired)

--- a/internal/controller/shared_config_test.go
+++ b/internal/controller/shared_config_test.go
@@ -5,12 +5,14 @@ import (
 	"testing"
 
 	corev1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/api/errors"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
 
 	costv1alpha1 "github.com/project-koku/koku-service-operator/api/v1alpha1"
 	"github.com/project-koku/koku-service-operator/internal/resources"
@@ -92,7 +94,7 @@ func TestEnsureSecretSkippedWhenExternalSecretNameSet(t *testing.T) {
 	got2 := &corev1.Secret{}
 	err := r2.Get(context.Background(),
 		types.NamespacedName{Namespace: ns, Name: generatedName}, got2)
-	if !errors.IsNotFound(err) {
+	if !apierrors.IsNotFound(err) {
 		t.Errorf("FAIL: %q was created even though database.secretName=%q is set — "+
 			"this overwrites external credentials with random passwords",
 			generatedName, cfg.Spec.Database.SecretName)
@@ -125,6 +127,129 @@ func TestEnsureSecretCreatedInBundledMode(t *testing.T) {
 		types.NamespacedName{Namespace: ns, Name: resources.NameDBCredentials(cfg)}, got)
 	if err != nil {
 		t.Errorf("expected db-credentials Secret in bundled mode, got: %v", err)
+	}
+}
+
+// fakeClientWithApplySupport wraps the controller-runtime fake client so
+// client.Apply patches create-or-update. Production uses SSA; the fake client
+// does not implement Apply create semantics without this.
+func fakeClientWithApplySupport(scheme *runtime.Scheme, objs ...client.Object) client.Client {
+	return fake.NewClientBuilder().WithScheme(scheme).WithObjects(objs...).WithInterceptorFuncs(interceptor.Funcs{
+		Patch: func(ctx context.Context, c client.WithWatch, obj client.Object, _ client.Patch, _ ...client.PatchOption) error {
+			key := client.ObjectKeyFromObject(obj)
+			existing := obj.DeepCopyObject().(client.Object)
+			err := c.Get(ctx, key, existing)
+			if apierrors.IsNotFound(err) {
+				return c.Create(ctx, obj)
+			}
+			if err != nil {
+				return err
+			}
+			obj.SetResourceVersion(existing.GetResourceVersion())
+			return c.Update(ctx, obj)
+		},
+	}).Build()
+}
+
+func TestReconcileSharedConfig_CreatesStorageCredentialsPlaceholder(t *testing.T) {
+	const ns = "test"
+	cfg := &costv1alpha1.CostManagementServiceConfig{
+		ObjectMeta: metav1.ObjectMeta{Name: testCRName, Namespace: ns, UID: "uid-shared-1"},
+		// ObjectStorage.SecretName empty → operator creates placeholder.
+	}
+
+	r := &CostManagementServiceConfigReconciler{
+		Client:   fakeClientWithApplySupport(sharedConfigScheme(t)),
+		Recorder: &noopRecorder{},
+	}
+
+	if _, err := r.reconcileSharedConfig(context.Background(), cfg); err != nil {
+		t.Fatalf("reconcileSharedConfig: %v", err)
+	}
+
+	sec := &corev1.Secret{}
+	name := resources.NameStorageSecret(cfg)
+	if err := r.Get(context.Background(), types.NamespacedName{Namespace: ns, Name: name}, sec); err != nil {
+		t.Fatalf("expected storage credentials Secret %q: %v", name, err)
+	}
+	// Keys must match KokuCommonEnv / IngressDeployment SecretKeyRefs.
+	for _, key := range []string{"access-key", "secret-key"} {
+		if _, ok := sec.Data[key]; !ok {
+			if _, ok := sec.StringData[key]; !ok {
+				t.Errorf("storage secret missing key %q", key)
+			}
+		}
+	}
+}
+
+func TestReconcileSharedConfig_SkipsStorageSecretWhenUserProvided(t *testing.T) {
+	const ns = "test"
+	cfg := &costv1alpha1.CostManagementServiceConfig{
+		ObjectMeta: metav1.ObjectMeta{Name: testCRName, Namespace: ns, UID: "uid-shared-2"},
+		Spec: costv1alpha1.CostManagementServiceConfigSpec{
+			ObjectStorage: costv1alpha1.ObjectStorageConfig{
+				SecretName: "my-external-s3",
+			},
+		},
+	}
+
+	r := &CostManagementServiceConfigReconciler{
+		Client:   fakeClientWithApplySupport(sharedConfigScheme(t)),
+		Recorder: &noopRecorder{},
+	}
+
+	if _, err := r.reconcileSharedConfig(context.Background(), cfg); err != nil {
+		t.Fatalf("reconcileSharedConfig: %v", err)
+	}
+
+	// Operator must not create the generated placeholder name.
+	generated := testCRName + "-storage-credentials"
+	got := &corev1.Secret{}
+	err := r.Get(context.Background(), types.NamespacedName{Namespace: ns, Name: generated}, got)
+	if !apierrors.IsNotFound(err) {
+		t.Errorf("generated storage secret %q should not be created when objectStorage.secretName is set", generated)
+	}
+
+	// Operator must not create/overwrite the user-named secret either.
+	err = r.Get(context.Background(), types.NamespacedName{Namespace: ns, Name: "my-external-s3"}, got)
+	if !apierrors.IsNotFound(err) {
+		t.Errorf("user-provided secret %q must not be created by reconcileSharedConfig", "my-external-s3")
+	}
+}
+
+func TestReconcileSharedConfig_DoesNotOverwriteExistingStorageSecret(t *testing.T) {
+	const ns = "test"
+	cfg := &costv1alpha1.CostManagementServiceConfig{
+		ObjectMeta: metav1.ObjectMeta{Name: testCRName, Namespace: ns, UID: "uid-shared-3"},
+	}
+	existing := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      resources.NameStorageSecret(cfg),
+			Namespace: ns,
+		},
+		Data: map[string][]byte{
+			"access-key": []byte("real-access"),
+			"secret-key": []byte("real-secret"),
+		},
+	}
+
+	r := &CostManagementServiceConfigReconciler{
+		Client:   fakeClientWithApplySupport(sharedConfigScheme(t), existing),
+		Recorder: &noopRecorder{},
+	}
+
+	if _, err := r.reconcileSharedConfig(context.Background(), cfg); err != nil {
+		t.Fatalf("reconcileSharedConfig: %v", err)
+	}
+
+	got := &corev1.Secret{}
+	if err := r.Get(context.Background(),
+		types.NamespacedName{Namespace: ns, Name: existing.Name}, got); err != nil {
+		t.Fatalf("get storage secret: %v", err)
+	}
+	if string(got.Data["access-key"]) != "real-access" || string(got.Data["secret-key"]) != "real-secret" {
+		t.Errorf("ensureSecret overwrote storage credentials: access=%q secret=%q",
+			got.Data["access-key"], got.Data["secret-key"])
 	}
 }
 

--- a/internal/resources/env.go
+++ b/internal/resources/env.go
@@ -46,6 +46,13 @@ func KokuCommonEnv(cfg *costv1alpha1.CostManagementServiceConfig) []corev1.EnvVa
 		EnvVal("REQUESTED_ROS_BUCKET", cfg.Spec.CostManagement.Storage.ROSBucketName),
 		EnvVal("AWS_CA_BUNDLE", "/etc/pki/ca-trust/combined/ca-bundle.crt"),
 		EnvVal("REQUESTS_CA_BUNDLE", "/etc/pki/ca-trust/combined/ca-bundle.crt"),
+		// Koku EnvConfigurator reads S3_ACCESS_KEY / S3_SECRET into settings.S3_*
+		// (see koku/koku/configurator.py). Masu builds S3 clients from those
+		// settings explicitly — AWS_* alone is not enough.
+		EnvFromSecretOptional("S3_ACCESS_KEY", storageSecret, "access-key"),
+		EnvFromSecretOptional("S3_SECRET", storageSecret, "secret-key"),
+		// Also set the standard AWS SDK names for boto3's default credential
+		// chain and any code that does not go through settings.S3_*.
 		EnvFromSecretOptional("AWS_ACCESS_KEY_ID", storageSecret, "access-key"),
 		EnvFromSecretOptional("AWS_SECRET_ACCESS_KEY", storageSecret, "secret-key"),
 		EnvVal("S3_REGION", cfg.Spec.ObjectStorage.S3.Region),

--- a/internal/resources/env_test.go
+++ b/internal/resources/env_test.go
@@ -35,9 +35,9 @@ func TestKokuCommonEnvS3CredentialNames(t *testing.T) {
 	// Contract: koku EnvConfigurator reads S3_ACCESS_KEY / S3_SECRET into
 	// settings.S3_*; AWS_* remain for the boto3 default credential chain.
 	want := map[string]string{
-		"S3_ACCESS_KEY":        "access-key",
-		"S3_SECRET":            "secret-key",
-		"AWS_ACCESS_KEY_ID":    "access-key",
+		"S3_ACCESS_KEY":         "access-key",
+		"S3_SECRET":             "secret-key",
+		"AWS_ACCESS_KEY_ID":     "access-key",
 		"AWS_SECRET_ACCESS_KEY": "secret-key",
 	}
 	for name, wantKey := range want {

--- a/internal/resources/env_test.go
+++ b/internal/resources/env_test.go
@@ -4,7 +4,91 @@ import (
 	"testing"
 
 	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	costv1alpha1 "github.com/project-koku/koku-service-operator/api/v1alpha1"
 )
+
+func TestKokuCommonEnvS3CredentialNames(t *testing.T) {
+	cfg := &costv1alpha1.CostManagementServiceConfig{
+		ObjectMeta: metav1.ObjectMeta{Name: "cost-management", Namespace: "cost-onprem"},
+		Spec: costv1alpha1.CostManagementServiceConfigSpec{
+			ObjectStorage: costv1alpha1.ObjectStorageConfig{
+				SecretName: "user-s3-creds",
+			},
+		},
+	}
+	storageSecret := NameStorageSecret(cfg)
+	if storageSecret != "user-s3-creds" {
+		t.Fatalf("NameStorageSecret = %q, want user-s3-creds", storageSecret)
+	}
+
+	env := KokuCommonEnv(cfg)
+	byName := make(map[string]corev1.EnvVar, len(env))
+	for _, e := range env {
+		if _, dup := byName[e.Name]; dup {
+			t.Fatalf("duplicate env var %q", e.Name)
+		}
+		byName[e.Name] = e
+	}
+
+	// Contract: koku EnvConfigurator reads S3_ACCESS_KEY / S3_SECRET into
+	// settings.S3_*; AWS_* remain for the boto3 default credential chain.
+	want := map[string]string{
+		"S3_ACCESS_KEY":        "access-key",
+		"S3_SECRET":            "secret-key",
+		"AWS_ACCESS_KEY_ID":    "access-key",
+		"AWS_SECRET_ACCESS_KEY": "secret-key",
+	}
+	for name, wantKey := range want {
+		e, ok := byName[name]
+		if !ok {
+			t.Fatalf("missing env var %s", name)
+		}
+		if e.ValueFrom == nil || e.ValueFrom.SecretKeyRef == nil {
+			t.Fatalf("%s: expected secretKeyRef, got %#v", name, e)
+		}
+		ref := e.ValueFrom.SecretKeyRef
+		if ref.Name != storageSecret {
+			t.Errorf("%s secret name: got %q, want %q", name, ref.Name, storageSecret)
+		}
+		if ref.Key != wantKey {
+			t.Errorf("%s secret key: got %q, want %q", name, ref.Key, wantKey)
+		}
+		if ref.Optional == nil || !*ref.Optional {
+			t.Errorf("%s: expected Optional=true secretKeyRef", name)
+		}
+	}
+}
+
+func TestKokuWorkloadsCarryS3CredentialEnv(t *testing.T) {
+	cfg := &costv1alpha1.CostManagementServiceConfig{
+		ObjectMeta: metav1.ObjectMeta{Name: "cost-management", Namespace: "cost-onprem"},
+	}
+
+	containers := [][]corev1.Container{
+		KokuAPIDeployment(cfg).Spec.Template.Spec.Containers,
+		MasuDeployment(cfg).Spec.Template.Spec.Containers,
+		ListenerDeployment(cfg).Spec.Template.Spec.Containers,
+		CeleryBeatDeployment(cfg).Spec.Template.Spec.Containers,
+		CeleryWorkerDeployment(cfg, "celery", costv1alpha1.CeleryWorkerSpec{Replicas: 1}).Spec.Template.Spec.Containers,
+		MigrationJob(cfg, "latest").Spec.Template.Spec.Containers,
+	}
+	for i, pods := range containers {
+		found := false
+		for _, c := range pods {
+			for _, e := range c.Env {
+				if e.Name == "S3_ACCESS_KEY" {
+					found = true
+					break
+				}
+			}
+		}
+		if !found {
+			t.Errorf("workload %d missing S3_ACCESS_KEY in container env", i)
+		}
+	}
+}
 
 func TestMergeEnvStableOrder(t *testing.T) {
 	overrides := map[string]string{

--- a/internal/resources/env_test.go
+++ b/internal/resources/env_test.go
@@ -64,28 +64,55 @@ func TestKokuCommonEnvS3CredentialNames(t *testing.T) {
 func TestKokuWorkloadsCarryS3CredentialEnv(t *testing.T) {
 	cfg := &costv1alpha1.CostManagementServiceConfig{
 		ObjectMeta: metav1.ObjectMeta{Name: "cost-management", Namespace: "cost-onprem"},
+		Spec: costv1alpha1.CostManagementServiceConfigSpec{
+			ObjectStorage: costv1alpha1.ObjectStorageConfig{
+				SecretName: "user-s3-creds",
+			},
+		},
+	}
+	wantSecret := NameStorageSecret(cfg)
+	want := map[string]string{
+		"S3_ACCESS_KEY":         "access-key",
+		"S3_SECRET":             "secret-key",
+		"AWS_ACCESS_KEY_ID":     "access-key",
+		"AWS_SECRET_ACCESS_KEY": "secret-key",
 	}
 
-	containers := [][]corev1.Container{
-		KokuAPIDeployment(cfg).Spec.Template.Spec.Containers,
-		MasuDeployment(cfg).Spec.Template.Spec.Containers,
-		ListenerDeployment(cfg).Spec.Template.Spec.Containers,
-		CeleryBeatDeployment(cfg).Spec.Template.Spec.Containers,
-		CeleryWorkerDeployment(cfg, "celery", costv1alpha1.CeleryWorkerSpec{Replicas: 1}).Spec.Template.Spec.Containers,
-		MigrationJob(cfg, "latest").Spec.Template.Spec.Containers,
+	workloads := []struct {
+		name       string
+		containers []corev1.Container
+	}{
+		{"koku-api", KokuAPIDeployment(cfg).Spec.Template.Spec.Containers},
+		{"masu", MasuDeployment(cfg).Spec.Template.Spec.Containers},
+		{"listener", ListenerDeployment(cfg).Spec.Template.Spec.Containers},
+		{"celery-beat", CeleryBeatDeployment(cfg).Spec.Template.Spec.Containers},
+		{"celery-worker", CeleryWorkerDeployment(cfg, "celery", costv1alpha1.CeleryWorkerSpec{Replicas: 1}).Spec.Template.Spec.Containers},
+		{"migration", MigrationJob(cfg, "latest").Spec.Template.Spec.Containers},
 	}
-	for i, pods := range containers {
-		found := false
-		for _, c := range pods {
+	for _, wl := range workloads {
+		byName := map[string]corev1.EnvVar{}
+		for _, c := range wl.containers {
 			for _, e := range c.Env {
-				if e.Name == "S3_ACCESS_KEY" {
-					found = true
-					break
-				}
+				byName[e.Name] = e
 			}
 		}
-		if !found {
-			t.Errorf("workload %d missing S3_ACCESS_KEY in container env", i)
+		for name, wantKey := range want {
+			e, ok := byName[name]
+			if !ok {
+				t.Errorf("%s: missing env var %s", wl.name, name)
+				continue
+			}
+			if e.ValueFrom == nil || e.ValueFrom.SecretKeyRef == nil {
+				t.Errorf("%s: %s expected secretKeyRef, got %#v", wl.name, name, e)
+				continue
+			}
+			ref := e.ValueFrom.SecretKeyRef
+			if ref.Name != wantSecret {
+				t.Errorf("%s: %s secret name = %q, want %q", wl.name, name, ref.Name, wantSecret)
+			}
+			if ref.Key != wantKey {
+				t.Errorf("%s: %s secret key = %q, want %q", wl.name, name, ref.Key, wantKey)
+			}
 		}
 	}
 }

--- a/internal/resources/ingress_test.go
+++ b/internal/resources/ingress_test.go
@@ -3,6 +3,8 @@ package resources
 import (
 	"testing"
 
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
 	costv1alpha1 "github.com/project-koku/koku-service-operator/api/v1alpha1"
 )
 
@@ -117,5 +119,42 @@ func TestIngressService(t *testing.T) {
 	}
 	if svc.Spec.Ports[0].Port != 8080 || svc.Spec.Ports[1].Port != 9000 {
 		t.Errorf("ports = %+v", svc.Spec.Ports)
+	}
+}
+
+func TestIngressDeploymentStorageCredentialEnv(t *testing.T) {
+	cfg := &costv1alpha1.CostManagementServiceConfig{
+		ObjectMeta: metav1.ObjectMeta{Name: "cost-management", Namespace: "cost-onprem"},
+		Spec: costv1alpha1.CostManagementServiceConfigSpec{
+			ObjectStorage: costv1alpha1.ObjectStorageConfig{
+				SecretName: "user-s3-creds",
+			},
+			Ingress: costv1alpha1.IngressConfig{
+				Image: costv1alpha1.ImageSpec{
+					Repository: "quay.io/cloudservices/insights-ingress",
+					Tag:        "latest",
+				},
+			},
+		},
+	}
+
+	dep := IngressDeployment(cfg)
+	byName := map[string]string{}
+	for _, c := range dep.Spec.Template.Spec.Containers {
+		for _, e := range c.Env {
+			if e.ValueFrom != nil && e.ValueFrom.SecretKeyRef != nil {
+				byName[e.Name] = e.ValueFrom.SecretKeyRef.Name + "/" + e.ValueFrom.SecretKeyRef.Key
+			}
+		}
+	}
+
+	want := map[string]string{
+		"INGRESS_MINIOACCESSKEY": "user-s3-creds/access-key",
+		"INGRESS_MINIOSECRETKEY": "user-s3-creds/secret-key",
+	}
+	for name, wantRef := range want {
+		if got := byName[name]; got != wantRef {
+			t.Errorf("%s: got %q, want %q", name, got, wantRef)
+		}
 	}
 }

--- a/internal/resources/secrets_test.go
+++ b/internal/resources/secrets_test.go
@@ -1,0 +1,43 @@
+package resources
+
+import (
+	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	costv1alpha1 "github.com/project-koku/koku-service-operator/api/v1alpha1"
+)
+
+func TestStorageCredentialsSecretKeys(t *testing.T) {
+	cfg := &costv1alpha1.CostManagementServiceConfig{
+		ObjectMeta: metav1.ObjectMeta{Name: "cost-management", Namespace: "cost-onprem"},
+	}
+
+	sec := StorageCredentialsSecret(cfg)
+	if sec.Name != NameStorageSecret(cfg) {
+		t.Errorf("secret name: got %q, want %q", sec.Name, NameStorageSecret(cfg))
+	}
+	if sec.Namespace != cfg.Namespace {
+		t.Errorf("namespace: got %q, want %q", sec.Namespace, cfg.Namespace)
+	}
+	// KokuCommonEnv and IngressDeployment SecretKeyRefs depend on these exact keys.
+	for _, key := range []string{"access-key", "secret-key"} {
+		if _, ok := sec.StringData[key]; !ok {
+			t.Errorf("StorageCredentialsSecret missing key %q required by S3 env wiring", key)
+		}
+	}
+}
+
+func TestNameStorageSecretUsesUserProvided(t *testing.T) {
+	cfg := &costv1alpha1.CostManagementServiceConfig{
+		ObjectMeta: metav1.ObjectMeta{Name: "cost-management"},
+		Spec: costv1alpha1.CostManagementServiceConfigSpec{
+			ObjectStorage: costv1alpha1.ObjectStorageConfig{
+				SecretName: "my-s3-creds",
+			},
+		},
+	}
+	if got := NameStorageSecret(cfg); got != "my-s3-creds" {
+		t.Fatalf("NameStorageSecret = %q, want my-s3-creds", got)
+	}
+}


### PR DESCRIPTION
## Summary
- Set `S3_ACCESS_KEY` / `S3_SECRET` from the storage secret in `KokuCommonEnv` so koku's `EnvConfigurator` → `settings.S3_*` path works (previously only `AWS_*` was set, relying on boto3 fallback).
- Keep `AWS_ACCESS_KEY_ID` / `AWS_SECRET_ACCESS_KEY` for the SDK default credential chain.
- Add regression tests for env names, workload builders, Ingress MinIO keys, storage secret key contract, and `reconcileSharedConfig` create / skip / no-overwrite behavior.

## Note: same pattern in the Helm chart

The cost-onprem Helm chart has the **same pod-env mismatch** today (out of scope for this PR; follow-up in the chart repo).

Verified against `insights-onprem/cost-onprem-chart` `@8d26d81` (`main` as of 2026-08-10):

- [`cost-onprem.koku.commonEnv`](https://github.com/insights-onprem/cost-onprem-chart/blob/8d26d813f5ac86f642e6732cbcce91d7dd1350c0/cost-onprem/templates/_helpers-koku.tpl#L353-L363) sets only `AWS_ACCESS_KEY_ID` / `AWS_SECRET_ACCESS_KEY` from the storage secret (`access-key` / `secret-key`).
- A full-file check of that template on the same commit finds **no** `S3_ACCESS_KEY` or `S3_SECRET` env bindings (only `S3_ENDPOINT` / `S3_REGION`).

Why that matters for on-prem koku (non-Clowder):

- [`EnvConfigurator.get_object_store_access_key` / `…_secret_key`](https://github.com/project-koku/koku/blob/a6a299025c53f39ec1eefbf01730da3b58c8e466/koku/koku/configurator.py#L299-L306) read env vars literally named `S3_ACCESS_KEY` / `S3_SECRET`.
- [`settings.S3_ACCESS_KEY` / `S3_SECRET`](https://github.com/project-koku/koku/blob/a6a299025c53f39ec1eefbf01730da3b58c8e466/koku/koku/settings.py#L609-L610) are populated from those.
- Masu S3 helpers pass those settings into boto3 explicitly, e.g. [`get_s3_resource(settings.S3_ACCESS_KEY, settings.S3_SECRET, …)`](https://github.com/project-koku/koku/blob/a6a299025c53f39ec1eefbf01730da3b58c8e466/koku/masu/util/aws/common.py#L533).

So chart and pre-fix operator both left `settings.S3_*` unset and depended on boto3 falling back to `AWS_*` when explicit keys are `None`.

Not claimed here: the chart *install script* host env vars `S3_ACCESS_KEY` / `S3_SECRET_KEY` (different name for the secret!) — those only populate the Kubernetes Secret; they are not the koku container env this bug is about.

## Test plan
- [x] `go test ./internal/resources/ ./internal/controller/ -count=1`
- [x] Confirm `TestKokuCommonEnvS3CredentialNames` fails without the `S3_*` env vars
- [ ] CI green on the PR