### PR TITLE
fix: wire ROS API logLevel from the CR

### DIFF
--- a/internal/resources/ros.go
+++ b/internal/resources/ros.go
@@ -258,7 +258,7 @@ func ROSAPIDeployment(cfg *costv1alpha1.CostManagementServiceConfig) *appsv1.Dep
 		EnvVal("DB_POOL_SIZE", "10"),
 		EnvVal("DB_MAX_OVERFLOW", "20"),
 		EnvVal("SERVICE_NAME", "ros-api"),
-		EnvVal("LOG_LEVEL", "INFO"),
+		EnvVal("LOG_LEVEL", cfg.Spec.ROS.API.LogLevel),
 	)
 
 	volumes, mounts := rosAPIVolumes(cfg)

--- a/internal/resources/ros_test.go
+++ b/internal/resources/ros_test.go
@@ -55,6 +55,7 @@ func TestCdappConfigMap_ContainsDBAndKafka(t *testing.T) {
 
 func TestROSAPIDeployment_Shape(t *testing.T) {
 	cfg := rosCfg()
+	cfg.Spec.ROS.API.LogLevel = "DEBUG"
 	d := ROSAPIDeployment(cfg)
 	if d.Name != NameROSAPI(cfg) {
 		t.Errorf("Name = %q", d.Name)
@@ -81,6 +82,9 @@ func TestROSAPIDeployment_Shape(t *testing.T) {
 	}
 	if env["SERVICE_NAME"] != "ros-api" {
 		t.Errorf("SERVICE_NAME = %q", env["SERVICE_NAME"])
+	}
+	if env["LOG_LEVEL"] != "DEBUG" {
+		t.Errorf("LOG_LEVEL = %q, want DEBUG from spec.ros.api.logLevel", env["LOG_LEVEL"])
 	}
 	if c.LivenessProbe == nil || c.LivenessProbe.HTTPGet == nil || c.LivenessProbe.HTTPGet.Path != "/status" {
 		t.Errorf("liveness probe = %+v", c.LivenessProbe)


### PR DESCRIPTION
## Summary
- Wire `spec.ros.api.logLevel` into the ROS API Deployment `LOG_LEVEL` env var (was hardcoded `INFO` despite the CR field existing).
- Extend the existing ROS API builder test to assert the CR value is applied.

## Test plan
- [x] `go test ./internal/resources/ -run TestROSAPIDeployment_Shape`
- [ ] Confirm `spec.ros.api.logLevel: DEBUG` shows up on the ros-api Deployment env after reconcile

## Summary by Sourcery

Wire the ROS API deployment log level from the CostManagementServiceConfig CR and validate it via tests.

New Features:
- Allow configuring the ROS API deployment LOG_LEVEL via spec.ros.api.logLevel in the CostManagementServiceConfig CR.

Tests:
- Extend the ROSAPIDeployment_Shape test to verify that the ROS API deployment LOG_LEVEL reflects spec.ros.api.logLevel.