### PR TITLE
fix: honor ServiceAccountSpec.create=false

### DIFF
--- a/api/v1alpha1/costmanagementserviceconfig_types.go
+++ b/api/v1alpha1/costmanagementserviceconfig_types.go
@@ -59,9 +59,14 @@ type ImageSpec struct {
 }
 
 type ServiceAccountSpec struct {
+	// Create controls whether the operator creates and owns the ServiceAccount.
+	// When false, the operator references Name (or the default name) without
+	// applying or adopting the object — the SA must already exist.
 	// +kubebuilder:default:=true
-	Create *bool  `json:"create,omitempty"`
-	Name   string `json:"name,omitempty"`
+	Create *bool `json:"create,omitempty"`
+	// Name is the ServiceAccount name used by pods. When empty, a default
+	// name derived from the CR is used.
+	Name string `json:"name,omitempty"`
 }
 
 // SecretKeyRef points to a key inside a named Secret.

--- a/config/crd/bases/service.costmanagement.openshift.io_costmanagementserviceconfigs.yaml
+++ b/config/crd/bases/service.costmanagement.openshift.io_costmanagementserviceconfigs.yaml
@@ -1325,8 +1325,15 @@ spec:
                     properties:
                       create:
                         default: true
+                        description: |-
+                          Create controls whether the operator creates and owns the ServiceAccount.
+                          When false, the operator references Name (or the default name) without
+                          applying or adopting the object — the SA must already exist.
                         type: boolean
                       name:
+                        description: |-
+                          Name is the ServiceAccount name used by pods. When empty, a default
+                          name derived from the CR is used.
                         type: string
                     type: object
                   storage:
@@ -2475,8 +2482,15 @@ spec:
                     properties:
                       create:
                         default: true
+                        description: |-
+                          Create controls whether the operator creates and owns the ServiceAccount.
+                          When false, the operator references Name (or the default name) without
+                          applying or adopting the object — the SA must already exist.
                         type: boolean
                       name:
+                        description: |-
+                          Name is the ServiceAccount name used by pods. When empty, a default
+                          name derived from the CR is used.
                         type: string
                     type: object
                 type: object

--- a/internal/controller/costmanagementserviceconfig_controller.go
+++ b/internal/controller/costmanagementserviceconfig_controller.go
@@ -213,8 +213,8 @@ func (r *CostManagementServiceConfigReconciler) reconcileSharedConfig(ctx contex
 		}
 	}
 
-	// ServiceAccount
-	if err := r.apply(ctx, cfg, resources.KokuServiceAccount(cfg)); err != nil {
+	// ServiceAccount (skipped when costManagement.serviceAccount.create=false).
+	if err := r.ensureServiceAccount(ctx, cfg, cfg.Spec.CostManagement.ServiceAccount, resources.KokuServiceAccount(cfg)); err != nil {
 		return Result{}, fmt.Errorf("koku serviceaccount: %w", err)
 	}
 
@@ -424,10 +424,14 @@ func (r *CostManagementServiceConfigReconciler) reconcileCoreServices(ctx contex
 		}
 	}
 
+	// ROS ServiceAccount (skipped when ros.serviceAccount.create=false).
+	if err := r.ensureServiceAccount(ctx, cfg, cfg.Spec.ROS.ServiceAccount, resources.ROSServiceAccount(cfg)); err != nil {
+		return Result{}, fmt.Errorf("ros serviceaccount: %w", err)
+	}
+
 	// Koku core + ROS shared config.
 	objs := []client.Object{
 		resources.CdappConfigMap(cfg),
-		resources.ROSServiceAccount(cfg),
 		resources.KokuAPIDeployment(cfg),
 		resources.KokuAPIService(cfg),
 		resources.MasuDeployment(cfg),
@@ -687,6 +691,30 @@ func (r *CostManagementServiceConfigReconciler) apply(ctx context.Context, cfg *
 	obj.SetNamespace(cfg.Namespace)
 	setOwnerRef(cfg, obj)
 	return r.Patch(ctx, obj, client.Apply, client.ForceOwnership, client.FieldOwner(fieldOwner))
+}
+
+// ensureServiceAccount applies sa when spec.Create is true (the default).
+// When create=false, it only verifies the named ServiceAccount already exists —
+// it never applies, sets ownerRefs, or otherwise mutates the object (so deleting
+// the CR cannot garbage-collect a user-managed SA).
+func (r *CostManagementServiceConfigReconciler) ensureServiceAccount(
+	ctx context.Context,
+	cfg *costv1alpha1.CostManagementServiceConfig,
+	spec costv1alpha1.ServiceAccountSpec,
+	sa *corev1.ServiceAccount,
+) error {
+	if !costv1alpha1.BoolVal(spec.Create, true) {
+		existing := &corev1.ServiceAccount{}
+		key := types.NamespacedName{Namespace: cfg.Namespace, Name: sa.Name}
+		if err := r.Get(ctx, key, existing); err != nil {
+			if errors.IsNotFound(err) {
+				return fmt.Errorf("serviceaccount %q not found (create=false); create it manually or set create=true", sa.Name)
+			}
+			return fmt.Errorf("get serviceaccount %q: %w", sa.Name, err)
+		}
+		return nil
+	}
+	return r.apply(ctx, cfg, sa)
 }
 
 // applyStatefulSet applies a StatefulSet, handling the VolumeClaimTemplate

--- a/internal/controller/costmanagementserviceconfig_controller.go
+++ b/internal/controller/costmanagementserviceconfig_controller.go
@@ -708,9 +708,9 @@ func (r *CostManagementServiceConfigReconciler) ensureServiceAccount(
 		key := types.NamespacedName{Namespace: cfg.Namespace, Name: sa.Name}
 		if err := r.Get(ctx, key, existing); err != nil {
 			if errors.IsNotFound(err) {
-				return fmt.Errorf("serviceaccount %q not found (create=false); create it manually or set create=true", sa.Name)
+				return fmt.Errorf("serviceaccount %s/%s not found (create=false); create it manually or set create=true", key.Namespace, key.Name)
 			}
-			return fmt.Errorf("get serviceaccount %q: %w", sa.Name, err)
+			return fmt.Errorf("get serviceaccount %s/%s: %w", key.Namespace, key.Name, err)
 		}
 		return nil
 	}

--- a/internal/controller/ros_cleanup.go
+++ b/internal/controller/ros_cleanup.go
@@ -18,7 +18,7 @@ import (
 // rosCleanupObjects returns every ROS/Kruize object the operator creates.
 // Used to tear the stack down when spec.ros.enabled flips to false.
 func rosCleanupObjects(cfg *costv1alpha1.CostManagementServiceConfig) []client.Object {
-	return []client.Object{
+	objs := []client.Object{
 		// Cluster-scoped (no ownerRef — must delete explicitly).
 		resources.KruizeClusterRoleBinding(cfg),
 		resources.KruizeClusterRole(cfg),
@@ -40,7 +40,6 @@ func rosCleanupObjects(cfg *costv1alpha1.CostManagementServiceConfig) []client.O
 		resources.ROSHousekeeperDeployment(cfg),
 		resources.ROSPartitionCleanerCronJob(cfg),
 		resources.CdappConfigMap(cfg),
-		resources.ROSServiceAccount(cfg),
 
 		// Completed ROS migration Job (if any).
 		&batchv1.Job{
@@ -50,6 +49,11 @@ func rosCleanupObjects(cfg *costv1alpha1.CostManagementServiceConfig) []client.O
 			},
 		},
 	}
+	// Only delete the ROS ServiceAccount when the operator created it.
+	if costv1alpha1.BoolVal(cfg.Spec.ROS.ServiceAccount.Create, true) {
+		objs = append(objs, resources.ROSServiceAccount(cfg))
+	}
+	return objs
 }
 
 // reconcileROSFeature is reconciler policy bookkeeping, not a provisioning

--- a/internal/controller/serviceaccount_create_test.go
+++ b/internal/controller/serviceaccount_create_test.go
@@ -2,6 +2,7 @@ package controller
 
 import (
 	"context"
+	"fmt"
 	"strings"
 	"testing"
 
@@ -94,6 +95,104 @@ func TestEnsureServiceAccount_CreateFalseMissingErrors(t *testing.T) {
 	}
 }
 
+func TestEnsureServiceAccount_CreateFalseGetError(t *testing.T) {
+	cfg := minimalCR(testCRName, testNamespace)
+	cfg.Spec.CostManagement.ServiceAccount.Create = boolPtr(false)
+
+	c := fake.NewClientBuilder().
+		WithScheme(sharedConfigScheme(t)).
+		WithInterceptorFuncs(interceptor.Funcs{
+			Get: func(ctx context.Context, c client.WithWatch, key client.ObjectKey, obj client.Object, opts ...client.GetOption) error {
+				return fmt.Errorf("apiserver unavailable")
+			},
+		}).
+		Build()
+
+	r := &CostManagementServiceConfigReconciler{Client: c, Recorder: &noopRecorder{}}
+	err := r.ensureServiceAccount(context.Background(), cfg, cfg.Spec.CostManagement.ServiceAccount, resources.KokuServiceAccount(cfg))
+	if err == nil || !strings.Contains(err.Error(), "get serviceaccount") {
+		t.Fatalf("expected wrapped get error, got: %v", err)
+	}
+}
+
+func TestEnsureServiceAccount_ROSCreateFalseSkipsApply(t *testing.T) {
+	cfg := minimalCR(testCRName, testNamespace)
+	cfg.Spec.ROS.ServiceAccount.Create = boolPtr(false)
+	cfg.Spec.ROS.ServiceAccount.Name = "external-ros-sa"
+
+	existing := &corev1.ServiceAccount{
+		ObjectMeta: metav1.ObjectMeta{Name: "external-ros-sa", Namespace: testNamespace},
+	}
+
+	var patched bool
+	c := fake.NewClientBuilder().
+		WithScheme(sharedConfigScheme(t)).
+		WithObjects(existing).
+		WithInterceptorFuncs(interceptor.Funcs{
+			Patch: func(ctx context.Context, c client.WithWatch, obj client.Object, patch client.Patch, opts ...client.PatchOption) error {
+				patched = true
+				return c.Patch(ctx, obj, patch, opts...)
+			},
+		}).
+		Build()
+
+	r := &CostManagementServiceConfigReconciler{Client: c, Recorder: &noopRecorder{}}
+	if err := r.ensureServiceAccount(context.Background(), cfg, cfg.Spec.ROS.ServiceAccount, resources.ROSServiceAccount(cfg)); err != nil {
+		t.Fatalf("ensureServiceAccount: %v", err)
+	}
+	if patched {
+		t.Fatal("create=false must not Patch/apply the ROS ServiceAccount")
+	}
+}
+
+func TestReconcileSharedConfig_CreateFalseSkipsKokuSA(t *testing.T) {
+	cfg := minimalCR(testCRName, testNamespace)
+	cfg.Spec.CostManagement.ServiceAccount.Create = boolPtr(false)
+	cfg.Spec.CostManagement.ServiceAccount.Name = "external-koku-sa"
+
+	existing := &corev1.ServiceAccount{
+		ObjectMeta: metav1.ObjectMeta{Name: "external-koku-sa", Namespace: testNamespace},
+	}
+	r := &CostManagementServiceConfigReconciler{
+		Client:   fakeClientWithApplySupport(sharedConfigScheme(t), existing),
+		Recorder: &noopRecorder{},
+	}
+
+	if _, err := r.reconcileSharedConfig(context.Background(), cfg); err != nil {
+		t.Fatalf("reconcileSharedConfig: %v", err)
+	}
+
+	got := &corev1.ServiceAccount{}
+	if err := r.Get(context.Background(), types.NamespacedName{Namespace: testNamespace, Name: "external-koku-sa"}, got); err != nil {
+		t.Fatalf("Get SA: %v", err)
+	}
+	if len(got.OwnerReferences) != 0 {
+		t.Fatalf("external SA must not gain ownerRefs via reconcileSharedConfig, got %#v", got.OwnerReferences)
+	}
+}
+
+func TestReconcileSharedConfig_CreateFalseMissingSAErrors(t *testing.T) {
+	cfg := minimalCR(testCRName, testNamespace)
+	cfg.Spec.CostManagement.ServiceAccount.Create = boolPtr(false)
+	cfg.Spec.CostManagement.ServiceAccount.Name = "missing-koku-sa"
+
+	r := &CostManagementServiceConfigReconciler{
+		Client:   fakeClientWithApplySupport(sharedConfigScheme(t)),
+		Recorder: &noopRecorder{},
+	}
+
+	_, err := r.reconcileSharedConfig(context.Background(), cfg)
+	if err == nil {
+		t.Fatal("expected reconcileSharedConfig error when create=false SA is missing")
+	}
+	if !strings.Contains(err.Error(), "koku serviceaccount") {
+		t.Fatalf("error should wrap koku serviceaccount call site, got: %v", err)
+	}
+	if !strings.Contains(err.Error(), "create=false") {
+		t.Fatalf("error should mention create=false, got: %v", err)
+	}
+}
+
 func TestROSCleanupObjects_OmitsSAWhenCreateFalse(t *testing.T) {
 	cfg := minimalCR(testCRName, testNamespace)
 	cfg.Spec.ROS.ServiceAccount.Create = boolPtr(false)
@@ -102,5 +201,20 @@ func TestROSCleanupObjects_OmitsSAWhenCreateFalse(t *testing.T) {
 		if obj.GetName() == resources.NameROSServiceAccount(cfg) {
 			t.Fatalf("rosCleanupObjects must not delete external ROS SA when create=false")
 		}
+	}
+}
+
+func TestROSCleanupObjects_IncludesSAWhenCreateTrue(t *testing.T) {
+	cfg := minimalCR(testCRName, testNamespace)
+	// Default Create=true (nil) must keep the operator-managed SA on the cleanup list.
+	found := false
+	for _, obj := range rosCleanupObjects(cfg) {
+		if obj.GetName() == resources.NameROSServiceAccount(cfg) {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Fatal("rosCleanupObjects must include ROS SA when create=true")
 	}
 }

--- a/internal/controller/serviceaccount_create_test.go
+++ b/internal/controller/serviceaccount_create_test.go
@@ -1,0 +1,106 @@
+package controller
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
+
+	"github.com/project-koku/koku-service-operator/internal/resources"
+)
+
+func TestEnsureServiceAccount_CreateTrueApplies(t *testing.T) {
+	cfg := minimalCR(testCRName, testNamespace)
+	r := &CostManagementServiceConfigReconciler{
+		Client:   fakeClientWithApplySupport(sharedConfigScheme(t)),
+		Recorder: &noopRecorder{},
+	}
+
+	sa := resources.KokuServiceAccount(cfg)
+	if err := r.ensureServiceAccount(context.Background(), cfg, cfg.Spec.CostManagement.ServiceAccount, sa); err != nil {
+		t.Fatalf("ensureServiceAccount: %v", err)
+	}
+
+	got := &corev1.ServiceAccount{}
+	if err := r.Get(context.Background(), types.NamespacedName{Namespace: testNamespace, Name: sa.Name}, got); err != nil {
+		t.Fatalf("Get SA: %v", err)
+	}
+	if len(got.OwnerReferences) != 1 {
+		t.Fatalf("expected ownerRef on managed SA, got %d", len(got.OwnerReferences))
+	}
+}
+
+func TestEnsureServiceAccount_CreateFalseSkipsApply(t *testing.T) {
+	cfg := minimalCR(testCRName, testNamespace)
+	cfg.Spec.CostManagement.ServiceAccount.Create = boolPtr(false)
+	cfg.Spec.CostManagement.ServiceAccount.Name = "external-koku-sa"
+
+	existing := &corev1.ServiceAccount{
+		ObjectMeta: metav1.ObjectMeta{Name: "external-koku-sa", Namespace: testNamespace},
+	}
+
+	var patched bool
+	c := fake.NewClientBuilder().
+		WithScheme(sharedConfigScheme(t)).
+		WithObjects(existing).
+		WithInterceptorFuncs(interceptor.Funcs{
+			Patch: func(ctx context.Context, c client.WithWatch, obj client.Object, patch client.Patch, opts ...client.PatchOption) error {
+				patched = true
+				return c.Patch(ctx, obj, patch, opts...)
+			},
+		}).
+		Build()
+
+	r := &CostManagementServiceConfigReconciler{Client: c, Recorder: &noopRecorder{}}
+	sa := resources.KokuServiceAccount(cfg)
+	if err := r.ensureServiceAccount(context.Background(), cfg, cfg.Spec.CostManagement.ServiceAccount, sa); err != nil {
+		t.Fatalf("ensureServiceAccount: %v", err)
+	}
+	if patched {
+		t.Fatal("create=false must not Patch/apply the ServiceAccount")
+	}
+
+	got := &corev1.ServiceAccount{}
+	if err := r.Get(context.Background(), types.NamespacedName{Namespace: testNamespace, Name: "external-koku-sa"}, got); err != nil {
+		t.Fatalf("Get SA: %v", err)
+	}
+	if len(got.OwnerReferences) != 0 {
+		t.Fatalf("external SA must not gain ownerRefs, got %#v", got.OwnerReferences)
+	}
+}
+
+func TestEnsureServiceAccount_CreateFalseMissingErrors(t *testing.T) {
+	cfg := minimalCR(testCRName, testNamespace)
+	cfg.Spec.ROS.ServiceAccount.Create = boolPtr(false)
+	cfg.Spec.ROS.ServiceAccount.Name = "missing-ros-sa"
+
+	r := &CostManagementServiceConfigReconciler{
+		Client:   fake.NewClientBuilder().WithScheme(sharedConfigScheme(t)).Build(),
+		Recorder: &noopRecorder{},
+	}
+	sa := resources.ROSServiceAccount(cfg)
+	err := r.ensureServiceAccount(context.Background(), cfg, cfg.Spec.ROS.ServiceAccount, sa)
+	if err == nil {
+		t.Fatal("expected error when create=false and SA is missing")
+	}
+	if !strings.Contains(err.Error(), "create=false") {
+		t.Fatalf("error should mention create=false, got: %v", err)
+	}
+}
+
+func TestROSCleanupObjects_OmitsSAWhenCreateFalse(t *testing.T) {
+	cfg := minimalCR(testCRName, testNamespace)
+	cfg.Spec.ROS.ServiceAccount.Create = boolPtr(false)
+
+	for _, obj := range rosCleanupObjects(cfg) {
+		if obj.GetName() == resources.NameROSServiceAccount(cfg) {
+			t.Fatalf("rosCleanupObjects must not delete external ROS SA when create=false")
+		}
+	}
+}

--- a/internal/controller/serviceaccount_create_test.go
+++ b/internal/controller/serviceaccount_create_test.go
@@ -93,6 +93,9 @@ func TestEnsureServiceAccount_CreateFalseMissingErrors(t *testing.T) {
 	if !strings.Contains(err.Error(), "create=false") {
 		t.Fatalf("error should mention create=false, got: %v", err)
 	}
+	if !strings.Contains(err.Error(), testNamespace+"/missing-ros-sa") {
+		t.Fatalf("error should include namespace/name, got: %v", err)
+	}
 }
 
 func TestEnsureServiceAccount_CreateFalseGetError(t *testing.T) {
@@ -109,9 +112,13 @@ func TestEnsureServiceAccount_CreateFalseGetError(t *testing.T) {
 		Build()
 
 	r := &CostManagementServiceConfigReconciler{Client: c, Recorder: &noopRecorder{}}
-	err := r.ensureServiceAccount(context.Background(), cfg, cfg.Spec.CostManagement.ServiceAccount, resources.KokuServiceAccount(cfg))
+	sa := resources.KokuServiceAccount(cfg)
+	err := r.ensureServiceAccount(context.Background(), cfg, cfg.Spec.CostManagement.ServiceAccount, sa)
 	if err == nil || !strings.Contains(err.Error(), "get serviceaccount") {
 		t.Fatalf("expected wrapped get error, got: %v", err)
+	}
+	if !strings.Contains(err.Error(), testNamespace+"/"+sa.Name) {
+		t.Fatalf("error should include namespace/name, got: %v", err)
 	}
 }
 


### PR DESCRIPTION
## Summary
- Wire `ServiceAccountSpec.Create` for Koku and ROS: when `create: false`, reference the existing SA without apply/ownerRefs.
- Skip deleting the ROS SA during `ros.enabled=false` cleanup when the operator did not create it.
- Document the field on the API/CRD; add unit tests for apply, skip, missing-SA error, and cleanup omission.

## Test plan
- [x] `go test ./internal/controller/ -skip TestControllers`
- [ ] Apply a CR with `costManagement.serviceAccount.create: false` + existing SA; confirm no ownerRef is added
- [ ] Confirm missing SA with `create: false` surfaces a clear reconcile error

## Summary by Sourcery

Honor ServiceAccountSpec.create for Koku and ROS by only creating and managing ServiceAccounts when requested, and treating user-provided ServiceAccounts as external dependencies.

New Features:
- Allow referencing existing ServiceAccounts for Koku and ROS via ServiceAccountSpec when create=false without operator ownership or mutation.

Bug Fixes:
- Prevent deletion of ROS ServiceAccounts during ros.enabled=false cleanup when they were not created by the operator.
- Surface a clear error when create=false is set but the referenced ServiceAccount does not exist.

Enhancements:
- Add ensureServiceAccount helper to centralize ServiceAccount creation vs. external reference behavior.
- Clarify ServiceAccountSpec.create and name semantics in the API type and generated CRD descriptions.

Tests:
- Add unit tests covering ServiceAccount creation, skipping apply for external ServiceAccounts, error behavior for missing ServiceAccounts with create=false, and ROS cleanup omission for external ServiceAccounts.