### PR TITLE
docs: update CLAUDE.md with build/test workflow and design conventions

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -17,14 +17,14 @@ external infrastructure.
 | Leader election ID | `costmanagementserviceconfigs.service.costmanagement.openshift.io` |
 | Finalizer | `costmanagementserviceconfigs.service.costmanagement.openshift.io/cleanup` |
 
-## Build
+## Build and test
 
 ```bash
 make generate          # regenerate deep-copy methods
 make manifests         # regenerate CRD YAML + RBAC ClusterRole
 make build             # compile manager binary to bin/manager
 make run               # run locally against current kubeconfig
-go test -race ./internal/...
+make test              # generate, fmt, vet, setup-envtest, run all tests with coverage
 golangci-lint run ./...
 govulncheck ./...
 ```
@@ -32,6 +32,11 @@ govulncheck ./...
 The `bin/controller-gen` binary is checked in (v0.18.0 arm64). CI
 (`.github/workflows/ci.yml`) runs lint, govulncheck, build, `make test`,
 generated-file drift checks, link checks, container build, and Kind e2e.
+
+`make test` automatically runs the `setup-envtest` target which downloads
+etcd + kube-apiserver binaries needed by the controller integration tests
+(envtest). Without these, `internal/controller` tests fail with
+"no such file or directory: etcd".
 
 ## Production design target
 
@@ -46,21 +51,26 @@ or reconciler logic around the bundled path.
 
 See [docs/design/design-vs-jira.md](docs/design/design-vs-jira.md) for the full rationale.
 
-## Reconciler stages
+## Reconciler architecture
 
-The controller uses a phase-gated pipeline (internal stages, not exposed as
-Phase values):
+The controller uses a phase-gated pipeline. The ordered list of `PhaseFn`
+calls lives in the `reconcile()` method in
+`internal/controller/costmanagementserviceconfig_controller.go` — look at the
+`runPhases([]PhaseFn{...})` call for the authoritative stage order.
 
-1. **Shared config** — secrets (create-only), ConfigMaps, ServiceAccount
-2. **Infrastructure** — validate/provision DB and cache; readiness gate
-3. **Migration** — Koku schema migration Job; blocks stage 4 until complete
-4. **Core services** — Koku API, Masu, Listener
-5. **Workers** — Celery beat + workers, ROS, RBAC, Kruize, Ingress
-6. **Edge** — Envoy gateway, UI, OpenShift Routes
+Key conventions:
 
-Stages 1–4 are implemented and tested on CRC. Stages 5–6 are partially
-implemented (Celery workers done; ROS, RBAC, Kruize, Ingress, gateway, UI
-are stubs).
+- **Server-Side Apply (SSA)** with `ForceOwnership` is used for all
+  namespace-scoped resources (`r.apply()`). This means the operator owns
+  every field it sets and will revert manual edits on the next reconcile.
+- **Secrets are create-only** — `r.ensureSecret()` creates if absent but
+  never overwrites. This preserves generated credentials across reconciles.
+- **Cluster-scoped resources** (ConsoleLink, Kruize ClusterRole/Binding)
+  cannot use `ownerReferences` for GC. They are cleaned up by the CR
+  finalizer in `reconcileDelete()`. Any new cluster-scoped resource must
+  be added to that list.
+- **Drift correction** — the reconciler re-applies desired state every 5
+  minutes (`requeueDrift`) so manual edits to managed resources are reverted.
 
 ## Status API
 
@@ -71,13 +81,12 @@ conditions follow the OpenShift/Kubernetes operator convention:
 - `Progressing` — operator is actively reconciling
 - `Degraded` — operator cannot make progress without intervention
 
-Component-specific conditions (`DatabaseReady`, `CacheReady`, `SchemaUpToDate`,
-etc.) go into the same `status.conditions` slice as `metav1.Condition` entries.
-The `Phase` field (`Provisioning` / `Running` / `Degraded`) is a human-readable
-convenience only — not for machine consumption.
+Component-specific conditions (e.g. `DatabaseReady`, `CacheReady`,
+`SchemaUpToDate`) go into the same `status.conditions` slice. The full list
+of condition type constants is in `api/v1alpha1/costmanagementserviceconfig_types.go`.
 
-The current `ComponentStatuses` struct (with `Ready bool`) is a known gap
-and will be replaced by proper `metav1.Condition` entries.
+The `Phase` field is a human-readable convenience only — not for machine
+consumption. Phase values are defined by the `Phase` type in the same file.
 
 ## Key design decisions (vs JIRA spec)
 
@@ -91,13 +100,58 @@ Full analysis in [docs/design/design-vs-jira.md](docs/design/design-vs-jira.md).
 | No passwords in CR spec | etcd stores CR plaintext; use Secret references |
 | Finalizers required for cluster-scoped resources | `ownerReferences` don't work cross-namespace |
 
+## PR review checklist
+
+### Coverage analysis
+
+Before submitting or updating any PR, run coverage on the packages touched
+by the change and look for 0% functions in the diff area:
+
+```bash
+go test ./internal/resources/... -coverprofile /tmp/cover.out
+go tool cover -func /tmp/cover.out
+```
+
+Adjust the package path to whatever the PR touches. If a builder/constructor
+is at 0% but the pattern for testing it already exists in the same test file,
+close the gap before pushing.
+
+### LSP call hierarchy checks
+
+Use the LSP tool (gopls) to trace call graphs on every new or modified
+function:
+
+- **Blast radius** — `incomingCalls` on any changed function to find all
+  callers. Every caller is potentially affected and needs review.
+- **Data flow tracing** — `outgoingCalls` from entry points on
+  security-sensitive paths (CR spec fields that reach shell scripts, DB
+  queries, env vars).
+- **Dead code** — `incomingCalls` on every new function. Zero callers =
+  dead code or forgotten wiring.
+- **Coverage gap diagnosis** — `incomingCalls` to find which builder/caller
+  to test, `outgoingCalls` to understand what setup the test needs.
+
+### YAML round-trip validation
+
+Any test that asserts on generated YAML (Envoy config, Kubernetes manifests)
+must round-trip through `yaml.Unmarshal` — not just `strings.Contains`.
+String matching misses silent type confusion where YAML parses without error
+but produces the wrong Go types. `err == nil` alone is NOT sufficient.
+
+### Static analysis
+
+```bash
+golangci-lint run ./...
+govulncheck ./...
+```
+
 ## Reference material
 
 - [docs/development/crc-testing.md](docs/development/crc-testing.md) — local development and CRC testing guide
 - [docs/tasks.md](docs/tasks.md) — implementation status per JIRA ticket
 - [docs/design/design-vs-jira.md](docs/design/design-vs-jira.md) — design decisions and best-practice analysis
-- [docs/design/security-context-strategy.md](docs/design/security-context-strategy.md) — OpenShift SCC strategy: why no runAsUser, restricted-v2 vs anyuid, comparison with Helm chart and SaaS
-- [docs/design/koku-django-log-handler-problem.md](docs/design/koku-django-log-handler-problem.md) — why readOnlyRootFilesystem is blocked on koku containers; fix required in koku
+- [docs/design/security-context-strategy.md](docs/design/security-context-strategy.md) — OpenShift SCC strategy
+- [docs/design/koku-django-log-handler-problem.md](docs/design/koku-django-log-handler-problem.md) — why readOnlyRootFilesystem is blocked on koku containers
 - [docs/jira/](docs/jira/) — JIRA ticket source (COST-7678–7700)
 - `../cost-onprem-chart/cost-onprem/` — Helm chart this operator replaces (reference for resource shapes, env vars, volumes)
 - [config/samples/byoi/README.md](config/samples/byoi/README.md) — BYOI dev fixture (PostgreSQL, Valkey, Kafka, MinIO, optional Prometheus + Grafana)


### PR DESCRIPTION
## Summary

- Merge project-local (uncommitted) CLAUDE.md instructions into the committed one
- Fix several stale/wrong claims verified against the actual codebase
- Add design conventions that prevent common mistakes

## What changed

**Fixed (was wrong/stale):**
- Phase values were `Provisioning / Running / Degraded` — actual code has `Pending / Progressing / Ready / Degraded`
- Stage list was 6 stages with some marked "stubs" — now 9 fully implemented stages; points to `runPhases()` as source of truth
- `ComponentStatuses` struct "known gap" — removed, struct no longer exists

**Added from local instructions:**
- `setup-envtest` / `make test` build instructions
- PR review checklist: coverage analysis, LSP call hierarchy checks, YAML round-trip validation, static analysis
- Reconciler conventions: SSA with ForceOwnership, create-only secrets, cluster-scoped cleanup via finalizer, drift correction

**Removed:**
- References to non-existent code (`assertValidYAMLWithStringAudiences`, `cmd/wait-for/`)
- Person names and specific PR numbers

## Test plan

- [x] Every claim verified against the actual codebase (Phase values, conditions, stage list, file paths, build targets)
- [ ] Review for completeness and accuracy

## Summary by Sourcery

Update CLAUDE.md to reflect the current build/test workflow, reconciler architecture, and status/phase definitions, and to add review and design conventions for contributors.

Documentation:
- Document the consolidated build and test workflow, including make targets and envtest setup.
- Describe the reconciler architecture, including phase ordering, SSA usage, secret handling, cluster-scoped cleanup, and drift correction conventions.
- Clarify status conditions and phase values, pointing to the authoritative type definitions in the API package.
- Add a PR review checklist covering coverage analysis, LSP call hierarchy checks, YAML round-trip validation, and static analysis expectations.
- Simplify and update reference material descriptions to match current design docs and constraints.