### PR TITLE
Use ubi9 go toolset builder

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM golang:1.25 AS builder
+FROM registry.access.redhat.com/ubi9/go-toolset:9.8-1786522985 AS builder
 ARG TARGETOS
 ARG TARGETARCH
 

--- a/go.mod
+++ b/go.mod
@@ -2,6 +2,8 @@ module github.com/project-koku/koku-service-operator
 
 go 1.25.0
 
+toolchain go1.26.5
+
 require (
 	github.com/onsi/ginkgo/v2 v2.22.0
 	github.com/onsi/gomega v1.36.1

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.25.0
 require (
 	github.com/onsi/ginkgo/v2 v2.22.0
 	github.com/onsi/gomega v1.36.1
+	gopkg.in/yaml.v3 v3.0.1
 	k8s.io/api v0.33.0
 	k8s.io/apimachinery v0.33.0
 	k8s.io/client-go v0.33.0
@@ -59,7 +60,6 @@ require (
 	google.golang.org/protobuf v1.36.5 // indirect
 	gopkg.in/evanphx/json-patch.v4 v4.12.0 // indirect
 	gopkg.in/inf.v0 v0.9.1 // indirect
-	gopkg.in/yaml.v3 v3.0.1 // indirect
 	k8s.io/apiextensions-apiserver v0.33.0 // indirect
 	k8s.io/klog/v2 v2.130.1 // indirect
 	k8s.io/kube-openapi v0.0.0-20250318190949-c8a335a9a2ff // indirect


### PR DESCRIPTION
## Summary by Sourcery

Adopt the Red Hat UBI9 Go toolset image for building the manager and align Go tooling and dependencies accordingly.

New Features:
- Declare gopkg.in/yaml.v3 as a direct dependency in go.mod.

Enhancements:
- Specify the Go toolchain version in go.mod to match the updated build environment.
- Switch the Dockerfile builder stage from the upstream golang image to the UBI9 go-toolset image.