### PR TITLE
[COST-7678] Add OpenAPI validation for ports and database sslMode (G2-a)

### DIFF
--- a/api/v1alpha1/costmanagementserviceconfig_types.go
+++ b/api/v1alpha1/costmanagementserviceconfig_types.go
@@ -123,8 +123,11 @@ type DatabaseConfig struct {
 	// Host for an external PostgreSQL instance (only used when Deploy is false).
 	Host string `json:"host,omitempty"`
 	// +kubebuilder:default:=5432
+	// +kubebuilder:validation:Minimum=1
+	// +kubebuilder:validation:Maximum=65535
 	Port int32 `json:"port,omitempty"`
 	// +kubebuilder:default:=disable
+	// +kubebuilder:validation:Enum=disable;require;verify-ca;verify-full
 	SSLMode string `json:"sslMode,omitempty"`
 
 	// Name of an existing Secret containing DB credentials.
@@ -155,6 +158,8 @@ type CacheConfig struct {
 	// Host for an external cache (only used when Deploy is false).
 	Host string `json:"host,omitempty"`
 	// +kubebuilder:default:=6379
+	// +kubebuilder:validation:Minimum=1
+	// +kubebuilder:validation:Maximum=65535
 	Port int32 `json:"port,omitempty"`
 
 	Auth        CacheAuthSpec               `json:"auth,omitempty"`
@@ -218,6 +223,8 @@ type ObjectStorageConfig struct {
 	// +kubebuilder:default:="s3.openshift-storage.svc.cluster.local"
 	Endpoint string `json:"endpoint,omitempty"`
 	// +kubebuilder:default:=443
+	// +kubebuilder:validation:Minimum=1
+	// +kubebuilder:validation:Maximum=65535
 	Port int32 `json:"port,omitempty"`
 	// +kubebuilder:default:=true
 	UseSSL *bool `json:"useSSL,omitempty"`

--- a/config/crd/bases/service.costmanagement.openshift.io_costmanagementserviceconfigs.yaml
+++ b/config/crd/bases/service.costmanagement.openshift.io_costmanagementserviceconfigs.yaml
@@ -258,6 +258,8 @@ spec:
                   port:
                     default: 6379
                     format: int32
+                    maximum: 65535
+                    minimum: 1
                     type: integer
                   resources:
                     description: ResourceRequirements describes the compute resource
@@ -1376,6 +1378,8 @@ spec:
                   port:
                     default: 5432
                     format: int32
+                    maximum: 65535
+                    minimum: 1
                     type: integer
                   resources:
                     description: ResourceRequirements describes the compute resource
@@ -1446,6 +1450,11 @@ spec:
                     type: string
                   sslMode:
                     default: disable
+                    enum:
+                    - disable
+                    - require
+                    - verify-ca
+                    - verify-full
                     type: string
                   storage:
                     properties:
@@ -1828,6 +1837,8 @@ spec:
                   port:
                     default: 443
                     format: int32
+                    maximum: 65535
+                    minimum: 1
                     type: integer
                   s3:
                     properties:

--- a/docs/gap_analysis/COST-7678.md
+++ b/docs/gap_analysis/COST-7678.md
@@ -7,7 +7,17 @@
 
 ## Verdict
 
-Types are largely implemented and richer than the JIRA description, but COST-7678 is **not done**. Remaining ticket gaps are admission webhooks, CEL/OpenAPI validation, profile sizing maps, and the missing `dataRetentionMonths` field. Related API security gaps (`RealmUser.Password`, raw `Env` maps) also remain in the type surface.
+Types are largely implemented and richer than the JIRA description, but COST-7678 is **not done**. Open ticket gaps: admission webhooks (G1), remaining CEL/OpenAPI validation (G2), profile sizing maps (G4), and `dataRetentionMonths` (G3, [#16](https://github.com/project-koku/koku-service-operator/pull/16)). Related API security gaps (`RealmUser.Password`, raw `Env` maps) also remain in the type surface.
+
+**In-flight PRs (2026-08-13):**
+
+| PR | Gap | Closes |
+|----|-----|--------|
+| [#50](https://github.com/project-koku/koku-service-operator/pull/50) | G2-a | Port min/max (database, cache, objectStorage); `database.sslMode` enum |
+| [#51](https://github.com/project-koku/koku-service-operator/pull/51) | G2-b | CEL: BYOI `deploy=false` → host/secret; Keycloak `issuerURL` https + non-empty `audiences` |
+| [#52](https://github.com/project-koku/koku-service-operator/pull/52) | G1 + G2-c | Admission webhooks scaffold; `requests ≤ limits` via validating webhook |
+
+G2-a in #50 does **not** close all of G2 — conditional BYOI rules (#51) and `requests ≤ limits` (#52 webhook) remain open until those PRs merge.
 
 ## Sources
 
@@ -31,8 +41,8 @@ Out of scope per ticket: reconciler logic, resource builders.
 | Status: phase, conditions, DiscoveredConfig | Done with intentional phase rename |
 | `ComponentStatus` | Removed (intentional; conditions instead) |
 | `profiles.go`: enum + resource sizing maps | Partial — enum only; **no sizing maps** |
-| `defaults.go` mutating webhook | **Missing** |
-| `validation.go` webhook + CEL | **Missing** |
+| `defaults.go` mutating webhook | **In progress** — [#52](https://github.com/project-koku/koku-service-operator/pull/52) (scaffold; `dataRetentionMonths` default deferred until #16) |
+| `validation.go` webhook + CEL | **Partial** — G2-a [#50](https://github.com/project-koku/koku-service-operator/pull/50), G2-b [#51](https://github.com/project-koku/koku-service-operator/pull/51), G2-c + G1 [#52](https://github.com/project-koku/koku-service-operator/pull/52) |
 | External-only infra (no type field) | Deviated — `deploy *bool` for DB/cache |
 
 ---
@@ -87,9 +97,9 @@ Documented in [design-vs-jira.md](../design/design-vs-jira.md) §1–3:
 
 ## Remaining gaps (ticket-scoped)
 
-### G1. Admission webhooks — missing
+### G1. Admission webhooks — in progress ([#52](https://github.com/project-koku/koku-service-operator/pull/52))
 
-No `api/v1alpha1/defaults.go`, no `api/v1alpha1/validation.go`, no `config/webhook/`, no `SetupWebhookWithManager` in `cmd/main.go`. Only commented `[WEBHOOK]` kustomize scaffolding and a `controller-gen ... webhook` Makefile flag that generates nothing without webhook types.
+[#52](https://github.com/project-koku/koku-service-operator/pull/52) adds `costmanagementserviceconfig_webhook.go`, `SetupWebhookWithManager` in `cmd/main.go`, and `config/webhook/` + cert-manager kustomize overlays. Mutating webhook is a scaffold (noop default) until G3 ([#16](https://github.com/project-koku/koku-service-operator/pull/16)) adds `dataRetentionMonths`.
 
 `internal/controller/validation.go` is **reconciler** connectivity/secret probing (COST-7684), not admission.
 
@@ -97,24 +107,22 @@ No `api/v1alpha1/defaults.go`, no `api/v1alpha1/validation.go`, no `config/webho
 |---------|-------------------|------------------------|
 | `spec.profile` → `standard` | Yes | No for this value |
 | `monitoring.enabled` → `true` | Yes (`spec.monitoring`, not `spec.infra.monitoring`) | No for this value |
-| `dataRetentionMonths` → `3` | Field missing | Yes — after field added |
+| `dataRetentionMonths` → `3` | Field missing ([#16](https://github.com/project-koku/koku-service-operator/pull/16)) | Yes — after field added |
 
-### G2. CEL / OpenAPI validation — missing
-
-No `+kubebuilder:validation:XValidation`, no Min/Max on ports, no `sslMode` enum marker.
+### G2. CEL / OpenAPI validation — partial (G2-a [#50](https://github.com/project-koku/koku-service-operator/pull/50), G2-b [#51](https://github.com/project-koku/koku-service-operator/pull/51))
 
 | JIRA rule | Status |
 |-----------|--------|
-| Required: `database.host`, `database.credentialsSecretRef`, `cache.host`, `cache.credentialsSecretRef` | Not CRD-required (and cannot be unconditionally required while `deploy: true` exists); API uses `secretName` |
+| Required: `database.host`, `database.credentialsSecretRef`, `cache.host`, `cache.credentialsSecretRef` | **G2-b [#51](https://github.com/project-koku/koku-service-operator/pull/51)** — CEL when `deploy=false` (`secretName` not `credentialsSecretRef`) |
 | Required: `kafka.bootstrapServers` | CRD-required today |
 | Required: `authentication.issuerUrl` | Not required; field is `auth.keycloak.issuerURL` optional |
-| `database.port` 1–65535 | No Min/Max |
-| `sslMode` ∈ disable/require/verify-ca/verify-full | Default `disable` only; no Enum |
-| issuerUrl must be HTTPS | Not enforced |
-| audiences non-empty | Not enforced |
+| `database.port` 1–65535 | **Done in [#50](https://github.com/project-koku/koku-service-operator/pull/50)** (cache + objectStorage ports too) |
+| `sslMode` ∈ disable/require/verify-ca/verify-full | **Done in [#50](https://github.com/project-koku/koku-service-operator/pull/50)** |
+| issuerUrl must be HTTPS | **G2-b [#51](https://github.com/project-koku/koku-service-operator/pull/51)** |
+| audiences non-empty | **G2-b [#51](https://github.com/project-koku/koku-service-operator/pull/51)** |
 | profile ∈ standard/ha | Done (Enum) |
-| `dataRetentionMonths` 1–60 | Field missing |
-| requests ≤ limits | Not enforced |
+| `dataRetentionMonths` 1–60 | Field missing ([#16](https://github.com/project-koku/koku-service-operator/pull/16)) |
+| requests ≤ limits | **G2-c [#52](https://github.com/project-koku/koku-service-operator/pull/52)** — validating webhook |
 
 **Implication for BYOI:** validation must be conditional (`deploy == false` ⇒ host + secret required). That is webhook and/or CEL `XValidation`, not simple `required:`.
 


### PR DESCRIPTION
## Summary

First slice of COST-7678 G2 (CEL/OpenAPI validation): static kubebuilder markers only.

- `spec.database.port` — minimum 1, maximum 65535
- `spec.cache.port` — minimum 1, maximum 65535
- `spec.objectStorage.port` — minimum 1, maximum 65535
- `spec.database.sslMode` — enum: disable, require, verify-ca, verify-full

No behavior change in the reconciler. Invalid values are rejected at CR admission.

Follow-up PR (G2-b) will add conditional CEL rules (BYOI required fields, issuer HTTPS, audiences).

Branched from `worktree-gold` locally; PR targets `main` (consistent with #16 / #48).

## Test plan

- [x] `make manifests` — CRD YAML regenerated
- [x] `make test` — all packages pass
- [ ] Manual: `kubectl apply` a CR with `database.port: 0` or `sslMode: invalid` should be rejected after CRD install


Made with [Cursor](https://cursor.com)

## Summary by Sourcery

Add OpenAPI validation constraints for ports and database SSL mode in the CostManagementServiceConfig CRD.

Bug Fixes:
- Prevent invalid port ranges and unsupported database SSL modes from being admitted via CRD validation.

Enhancements:
- Constrain database, cache, and object storage ports to the valid TCP port range using kubebuilder markers and regenerated CRD schema.
- Restrict database sslMode to a fixed set of supported values via enum validation in the API type and CRD.