### PR TITLE
[COST-7678] Add CEL validation for BYOI and Keycloak fields (G2-b)

### DIFF
--- a/api/v1alpha1/costmanagementserviceconfig_types.go
+++ b/api/v1alpha1/costmanagementserviceconfig_types.go
@@ -260,7 +260,7 @@ type EnvoySpec struct {
 	Resources corev1.ResourceRequirements `json:"resources,omitempty"`
 }
 
-// +kubebuilder:validation:XValidation:rule="!has(self.issuerURL) || self.issuerURL == '' || self.issuerURL.startsWith('https://')",message="issuerURL must use https when set"
+// +kubebuilder:validation:XValidation:rule="!has(self.issuerURL) || size(self.issuerURL) == 0 || self.issuerURL.startsWith('https://')",message="issuerURL must use https when set"
 // +kubebuilder:validation:XValidation:rule="!has(self.audiences) || size(self.audiences) > 0",message="audiences must not be empty when set"
 type KeycloakSpec struct {
 	// Full URL of the Keycloak instance used for JWKS fetch (and issuer when

--- a/api/v1alpha1/costmanagementserviceconfig_types.go
+++ b/api/v1alpha1/costmanagementserviceconfig_types.go
@@ -112,6 +112,7 @@ type GlobalConfig struct {
 // DatabaseConfig
 // -----------------------------------------------------------------------------
 
+// +kubebuilder:validation:XValidation:rule="self.deploy != false || (size(self.host) > 0 && size(self.secretName) > 0)",message="host and secretName are required when database.deploy is false"
 type DatabaseConfig struct {
 	// Deploy the bundled PostgreSQL StatefulSet (dev/CI only — not for production).
 	// Set false to connect to an external database.
@@ -148,6 +149,7 @@ type DatabaseStorageSpec struct {
 // CacheConfig (Valkey / Redis)
 // -----------------------------------------------------------------------------
 
+// +kubebuilder:validation:XValidation:rule="self.deploy != false || (size(self.host) > 0 && has(self.auth.secretName) && size(self.auth.secretName) > 0)",message="host and auth.secretName are required when cache.deploy is false"
 type CacheConfig struct {
 	// Deploy the bundled Valkey instance (dev/CI only — not for production).
 	// Set false to connect to an external Redis/Valkey endpoint.
@@ -258,6 +260,8 @@ type EnvoySpec struct {
 	Resources corev1.ResourceRequirements `json:"resources,omitempty"`
 }
 
+// +kubebuilder:validation:XValidation:rule="!has(self.issuerURL) || self.issuerURL == ” || self.issuerURL.startsWith('https://')",message="issuerURL must use https when set"
+// +kubebuilder:validation:XValidation:rule="!has(self.audiences) || size(self.audiences) > 0",message="audiences must not be empty when set"
 type KeycloakSpec struct {
 	// Full URL of the Keycloak instance used for JWKS fetch (and issuer when
 	// issuerURL is unset). Prefer an in-cluster http(s) Service URL so Envoy

--- a/api/v1alpha1/costmanagementserviceconfig_types.go
+++ b/api/v1alpha1/costmanagementserviceconfig_types.go
@@ -260,7 +260,7 @@ type EnvoySpec struct {
 	Resources corev1.ResourceRequirements `json:"resources,omitempty"`
 }
 
-// +kubebuilder:validation:XValidation:rule="!has(self.issuerURL) || self.issuerURL == ” || self.issuerURL.startsWith('https://')",message="issuerURL must use https when set"
+// +kubebuilder:validation:XValidation:rule="!has(self.issuerURL) || self.issuerURL == '' || self.issuerURL.startsWith('https://')",message="issuerURL must use https when set"
 // +kubebuilder:validation:XValidation:rule="!has(self.audiences) || size(self.audiences) > 0",message="audiences must not be empty when set"
 type KeycloakSpec struct {
 	// Full URL of the Keycloak instance used for JWKS fetch (and issuer when

--- a/config/crd/bases/service.costmanagement.openshift.io_costmanagementserviceconfigs.yaml
+++ b/config/crd/bases/service.costmanagement.openshift.io_costmanagementserviceconfigs.yaml
@@ -185,7 +185,8 @@ spec:
                     type: object
                     x-kubernetes-validations:
                     - message: issuerURL must use https when set
-                      rule: '!has(self.issuerURL) || self.issuerURL == ” || self.issuerURL.startsWith(''https://'')'
+                      rule: '!has(self.issuerURL) || size(self.issuerURL) == 0 ||
+                        self.issuerURL.startsWith(''https://'')'
                     - message: audiences must not be empty when set
                       rule: '!has(self.audiences) || size(self.audiences) > 0'
                 type: object

--- a/config/crd/bases/service.costmanagement.openshift.io_costmanagementserviceconfigs.yaml
+++ b/config/crd/bases/service.costmanagement.openshift.io_costmanagementserviceconfigs.yaml
@@ -183,6 +183,11 @@ spec:
                         pattern: ^[^\x00-\x1f\x7f]*$
                         type: string
                     type: object
+                    x-kubernetes-validations:
+                    - message: issuerURL must use https when set
+                      rule: '!has(self.issuerURL) || self.issuerURL == ” || self.issuerURL.startsWith(''https://'')'
+                    - message: audiences must not be empty when set
+                      rule: '!has(self.audiences) || size(self.audiences) > 0'
                 type: object
               cache:
                 properties:
@@ -306,6 +311,11 @@ spec:
                         type: boolean
                     type: object
                 type: object
+                x-kubernetes-validations:
+                - message: host and auth.secretName are required when cache.deploy
+                    is false
+                  rule: self.deploy != false || (size(self.host) > 0 && has(self.auth.secretName)
+                    && size(self.auth.secretName) > 0)
               costManagement:
                 properties:
                   api:
@@ -1442,6 +1452,11 @@ spec:
                         x-kubernetes-int-or-string: true
                     type: object
                 type: object
+                x-kubernetes-validations:
+                - message: host and secretName are required when database.deploy is
+                    false
+                  rule: self.deploy != false || (size(self.host) > 0 && size(self.secretName)
+                    > 0)
               gatewayRoute:
                 properties:
                   annotations:


### PR DESCRIPTION
## Summary

Second slice of COST-7678 G2 — conditional CEL (`x-kubernetes-validations`):

- **DatabaseConfig:** when `deploy` is `false`, `host` and `secretName` are required
- **CacheConfig:** when `deploy` is `false`, `host` and `auth.secretName` are required
- **KeycloakSpec:** `issuerURL` must use `https://` when set; explicit empty `audiences` is rejected

Uses `has()` guards so empty nested objects (e.g. scaffold controller tests) still pass admission.

Depends on / complements G2-a (#50) but is independently mergeable (branched from `main`).

G2-c (`requests <= limits`) remains follow-up.

## Test plan

- [x] `make manifests` — CRD YAML regenerated with `x-kubernetes-validations`
- [x] `make test` — all packages pass (including envtest controller suite)
- [ ] Manual: apply BYOI CR with `database.deploy: false` and no `host` → rejected
- [ ] Manual: apply CR with `auth.keycloak.issuerURL: http://...` → rejected


Made with [Cursor](https://cursor.com)

## Summary by Sourcery

Add CEL-based kubebuilder validations to enforce conditional requirements for BYOI database and cache configs and tighten Keycloak issuer and audience constraints.

New Features:
- Introduce conditional validation that requires database host and secretName when external databases are used instead of the bundled deployment.
- Introduce conditional validation that requires cache host and auth.secretName when an external cache is used instead of the bundled deployment.
- Enforce that Keycloak issuerURL uses HTTPS when set and that audiences, when present, are non-empty.

Enhancements:
- Regenerate CRD schemas to include the new x-kubernetes-validations rules for database, cache, and Keycloak specifications.