### PR TITLE
Add gap analysis for COST-7686

### DIFF
--- a/docs/gap_analysis/COST-7686.md
+++ b/docs/gap_analysis/COST-7686.md
@@ -1,0 +1,111 @@
+# COST-7686 Gap Analysis: Implement application services
+
+**Jira:** [COST-7686](https://redhat.atlassian.net/browse/COST-7686)
+**Audited:** 2026-08-13
+**Purpose:** Handoff audit vs ticket acceptance criteria. Does not update `docs/tasks.md` or other trackers.
+**Beta scope:** Per [BETA-PRIORITY.md](BETA-PRIORITY.md) and [docs/tasks.md](../tasks.md), ROS/Kruize readiness and profile sizing are **not Cost beta blockers**. This audit still reports them as ticket-scoped gaps because they are named acceptance criteria in COST-7686, and flags one item — **G1** — as urgent regardless of beta scope because it silently breaks the documented `spec.ros.enabled=false` opt-out.
+
+## Verdict
+
+Koku API/Masu/Listener, ROS API/Processor, and Kruize Deployment+Service+cluster RBAC (with finalizer cleanup) all exist in `internal/resources/` and are wired into the reconciler, and the Django key generator matches the ticket's exact 50-character/charset/create-once spec. However, three acceptance criteria are **not met**: (1) **`spec.ros.enabled=false` no longer skips anything** — the gating that `docs/tasks.md` and prior gap docs describe as "done" was reverted by a merge-conflict resolution and is now dead code, so ROS/Kruize Deployments, the ROS migration Job, and Kruize's ServiceMonitor always run; (2) **profile-based sizing** is entirely unimplemented (confirmed pre-existing gap, tracked in COST-7678); (3) **the 5-minute readiness timeout → Degraded condition** does not exist — only 3 of the ~14 Deployments this ticket delivers (Koku API, Valkey cache, Envoy) are readiness-gated at all, there is no timeout/backoff tracking, and the CR can reach `Ready`/`Available` while Masu, Listener, ROS, Kruize, and RBAC pods are still down.
+
+## Sources
+
+- [Jira COST-7686](https://redhat.atlassian.net/browse/COST-7686)
+- [docs/jira/COST-7686.md](../jira/COST-7686.md)
+- [internal/resources/koku.go](../../internal/resources/koku.go) — Koku API, Masu, Listener, Celery Beat/Workers
+- [internal/resources/ros.go](../../internal/resources/ros.go) — ROS API, Processor, Poller, Housekeeper, partition-cleaner CronJob
+- [internal/resources/kruize.go](../../internal/resources/kruize.go) — Kruize Deployment/Service/ClusterRole/ClusterRoleBinding
+- [internal/resources/secrets.go](../../internal/resources/secrets.go) — Django key + DB credentials Secret generation
+- [internal/controller/costmanagementserviceconfig_controller.go](../../internal/controller/costmanagementserviceconfig_controller.go) — `reconcileCoreServices`, `reconcileWorkers`, `reconcileMigration`, readiness gates
+- [internal/controller/ros_cleanup.go](../../internal/controller/ros_cleanup.go) — `reconcileROSFeature` / `reconcileROSCleanup` (currently unreferenced by `reconcile()`)
+- [api/v1alpha1/costmanagementserviceconfig_types.go](../../api/v1alpha1/costmanagementserviceconfig_types.go) — `Profile` type (documented not-yet-implemented), per-component `Resources` fields
+- [docs/tasks.md](../tasks.md), [docs/gap_analysis/BETA-PRIORITY.md](BETA-PRIORITY.md), [docs/gap_analysis/COST-7685.md](COST-7685.md), [docs/gap_analysis/COST-7687.md](COST-7687.md) — prior status claims, several of which G1 below invalidates
+
+Out of scope per ticket: *"Workers, CronJobs, Gateway"* (i.e. Celery workers/scheduled jobs are COST-7687; Envoy gateway is COST-7688). ROS API/Processor themselves are explicitly **in scope** for this ticket even though the reconciler applies them from the internal "Workers" pipeline stage — that is an implementation-staging detail, not a ticket deviation.
+
+---
+
+## Ticket acceptance criteria
+
+| Deliverable | Status |
+|-------------|--------|
+| Koku — API, Masu, Listener Deployments + Services | Done |
+| ROS — API, Processor Deployments (+ Service for API) | Done, but see G1 (not actually optional) |
+| Kruize — Deployment + Service + cluster-scoped ClusterRole/ClusterRoleBinding, finalizer cleanup | Done, but see G1 (not actually optional) |
+| Django key — 50 chars, `crypto/rand`, exact charset, Secret, created once, never regenerated | Done |
+| Deployments wired with env vars from CR spec | Done |
+| Profile-based sizing | Missing |
+| Per-component resource overrides | Done |
+| 5-minute readiness timeout → Degraded with non-ready component name, requeue with backoff | Missing |
+| Ungate Platform (Ready) phase only when all service pods are ready | Partial — phase model exists (intentional rename, see design-vs-jira.md §1) but only 3 of ~14 Deployments actually gate it |
+
+---
+
+## Done (meets or supersedes ticket intent)
+
+- **Koku API** (`KokuAPIDeployment`/`KokuAPIService`), **Masu** (`MasuDeployment`/`MasuService`), **Listener** (`ListenerDeployment`) — [`internal/resources/koku.go`](../../internal/resources/koku.go). All wired with `KokuCommonEnv` (DB, cache, S3, Kafka, Django key, RBAC service, CA bundle) plus per-deployment env additions and `MergeEnv(spec.Env)` overrides. `100%` unit-test coverage on all three deployment builders.
+- **ROS API** (`ROSAPIDeployment`/`ROSAPIService`) and **ROS Processor** (`ROSProcessorDeployment`) — [`internal/resources/ros.go`](../../internal/resources/ros.go). DB/Kafka env, Kruize wait-for init container on the Processor, CA-bundle mount, liveness/readiness probes.
+- **Kruize** — `KruizeDeployment`, `KruizeService`, `KruizeServiceAccount`, `KruizeConfigMap`, `KruizeClusterRole`, `KruizeClusterRoleBinding` in [`internal/resources/kruize.go`](../../internal/resources/kruize.go); cluster-scoped ClusterRole/Binding are deleted via the CR finalizer in `reconcileDelete()` ([`costmanagementserviceconfig_controller.go:108-112`](../../internal/controller/costmanagementserviceconfig_controller.go)), matching the COST-7681 finalizer pattern since ownerReferences cannot cross the cluster/namespace boundary.
+- **Django secret key** — `djangoSecretKey(50)` in [`internal/resources/secrets.go`](../../internal/resources/secrets.go) uses `crypto/rand` and the exact charset `abcdefghijklmnopqrstuvwxyz0123456789!@#$%^&*(-_=+)` specified in the ticket (also matches COST-7694's charset fix). `DjangoSecret(cfg)` is applied via `r.ensureSecret()`, which is **create-only** ([`costmanagementserviceconfig_controller.go:749-759`](../../internal/controller/costmanagementserviceconfig_controller.go)) — never regenerated on subsequent reconciles, matching "created once ... never regenerated unless rotation is triggered."
+- **Env vars from CR spec** — `KokuCommonEnv()` ([`internal/resources/env.go`](../../internal/resources/env.go)) reads directly from `cfg.Spec.*` (Database, Cache, Kafka, ObjectStorage, CostManagement) and every Deployment additionally applies `spec.<component>.Env` overrides via `MergeEnv` with sorted/deduped keys.
+- **Per-component resource overrides** — every component spec (`KokuAPISpec`, `MasuSpec`, `ListenerSpec`, `ROSAPISpec`, `ROSProcessorSpec`, `ROSPollerSpec`, `ROSHousekeeperSpec`, `KruizeSpec`) carries its own `Resources corev1.ResourceRequirements` field, threaded into the container spec by the resource builders.
+- Koku API is the one Deployment that **is** readiness-gated before the pipeline proceeds ([`reconcileCoreServices`](../../internal/controller/costmanagementserviceconfig_controller.go), `isDeploymentReady` on `NameKokuAPI`), which is a real (if partial) implementation of "gate on service pods ready."
+
+---
+
+## Intentional deviations (do not treat as bugs)
+
+| JIRA | Implementation | Rationale |
+|------|----------------|-----------|
+| Linear `Deploying`/`Ready` phase | `Phase{Pending,Progressing,Ready,Degraded}` derived from `Available`/`Progressing`/`Degraded` conditions | Documented Kubernetes-API-conventions deviation; see [design-vs-jira.md §1](../design/design-vs-jira.md#1-status-api-conditions-over-phase-enum). "Ungate the Platform phase" maps to `cfg.Status.Phase = PhaseReady` at the end of `reconcile()` — the naming differs intentionally, the mechanism is the gap (G2 below), not the rename. |
+| ROS API/Processor treated as "application services" | Applied from the reconciler's internal "Workers" stage (`reconcileWorkers`), alongside Celery workers that COST-7687 owns | Cosmetic — internal pipeline staging, not a functional gap. The ticket's own scope line lists ROS API/Processor as deliverables of *this* ticket regardless of which internal stage applies them. |
+
+---
+
+## Remaining gaps (ticket-scoped)
+
+### G1. `spec.ros.enabled=false` no longer skips ROS/Kruize — regression, contradicts `docs/tasks.md`
+
+**Missing / broken.** `docs/tasks.md` states ROS/Kruize are "optional via `spec.ros.enabled`" and `BETA-PRIORITY.md` / [COST-7685](COST-7685.md) / [COST-7687](COST-7687.md) describe the gating as "landed." This is no longer true on `main`:
+
+- `reconcileROSFeature(ctx, cfg)` — the function that sets the `ROSEnabled` condition and deletes leftover ROS/Kruize objects — is defined in [`internal/controller/ros_cleanup.go`](../../internal/controller/ros_cleanup.go) but is **never called** from `reconcile()`. It is only invoked directly by [`ros_cleanup_test.go`](../../internal/controller/ros_cleanup_test.go), so the tests pass while the production code path never exercises it.
+- `reconcileMigration()` builds the ROS migration step unconditionally — no `costv1alpha1.ROSEnabled(cfg)` check (compare [`costmanagementserviceconfig_controller.go:295-311`](../../internal/controller/costmanagementserviceconfig_controller.go)).
+- `reconcileCoreServices()` applies `kruizeObjs` (ServiceAccount, ConfigMap, Deployment, Service) and the Kruize ClusterRole/ClusterRoleBinding unconditionally (lines 400-417).
+- `reconcileWorkers()` applies `ROSAPIDeployment`, `ROSProcessorDeployment`, `ROSPollerDeployment`, `ROSHousekeeperDeployment` unconditionally (lines 479-486).
+- `internal/resources/monitoring.go` applies `KruizeServiceMonitor` unconditionally — no `ROSEnabled` check.
+
+Root cause, confirmed via `git log -m -S"reconcileROSFeature"`: PR #13 (`feat/ros-enabled-switch`) added all of this gating, but the merge-conflict resolution commit `c43b910` ("resolve merge conflict... by taking our main's version") reverted every one of these checks back to the unconditional pre-PR-13 code while *keeping* `ros_cleanup.go` and its tests in the tree. The dead code and passing tests mask the regression — nothing fails CI because the tests call `reconcileROSFeature` directly rather than through `Reconcile()`.
+
+**Still gated correctly (survived the revert):** `internal/resources/envoy.go` — Envoy's `/api/cost-management/v1/recommendations/openshift` route and the `ros-api-backend` cluster are still conditional on `ROSEnabled(cfg)` (per `envoy_test.go`).
+
+**Impact:** Any BYOI CR that sets `ros.enabled: false` (as the sample CRs in `config/samples/byoi/` do, per COST-7679) will still get a full ROS/Kruize install — extra migration Job, Deployments, cluster-scoped RBAC, and a `KruizeServiceMonitor` the customer did not ask for and that COST-8054 says is explicitly out of Cost-only beta scope. This silently invalidates the "Beta scope" section of `docs/tasks.md` and the "Landed" table in `BETA-PRIORITY.md` §"COST-8054."
+
+**Fix:** Re-wire `reconcileROSFeature` into `reconcile()` (the original 8-line hunk from commit `4b38da2`, adjusted for the current `reconcile()` shape — note the original call signature `(ctx, cfg) error` doesn't match the erroneous `if _, err := ...` from that commit's own diff, so re-check the signature when restoring it) and reinstate the `ROSEnabled(cfg)` guards in `reconcileMigration`, `reconcileCoreServices`, `reconcileWorkers`, and `KruizeServiceMonitor`.
+
+### G2. No 5-minute readiness timeout, no Degraded-on-timeout, no backoff — missing
+
+The ticket requires: *"If any Deployment does not reach Ready within 5 minutes, set Degraded condition with the non-ready component name and requeue with backoff."* None of this exists:
+
+- Only **3 of ~14** Deployments this ticket (plus its ROS/Kruize half) delivers are ever checked for readiness: Valkey cache (`reconcileInfrastructure`), Koku API (`reconcileCoreServices`), and Envoy (`reconcileEdge` — COST-7688, not this ticket). Masu, Listener, ROS API, ROS Processor, ROS Poller, ROS Housekeeper, Kruize, RBAC API, and RBAC Worker are applied but never checked with `isDeploymentReady`.
+- There is no timestamp/duration tracking anywhere in the controller (no `LastTransitionTime`-based timeout, no annotation, no in-memory timer) that could implement a "5 minutes" threshold. `grep` for `notReadySince`/`degradedSince`/timeout patterns returns nothing.
+- The only `Degraded`-with-component-name path that exists today is migration-Job failure (`runMigrationStep` → `"%s exhausted retries"`), which is a different failure mode (Job `backoffLimit` exhaustion, not Deployment un-readiness).
+- Un-ready Deployments simply cause a bare `Result{RequeueAfter: requeueSlow}` (30s) or `requeueFast` (10s) forever — no backoff growth, no cap, and no visible identification of *which* Deployment is stuck once past the two gated ones.
+- Consequence for G3 below: because most Deployments aren't gated at all, the CR can reach `Available`/`Ready` while, e.g., Masu or RBAC API pods are crash-looping.
+
+**Fix:** Add an `isDeploymentReady` check (or a shared "wait for all Deployments in this stage" helper) for every Deployment introduced by this ticket, track first-seen-not-ready time (e.g. via the existing condition's `LastTransitionTime`, since `apimeta.SetStatusCondition` already preserves it across reconciles when the status is unchanged), and once that duration exceeds 5 minutes, set `Degraded` with the specific component name and switch to an exponential-backoff `RequeueAfter` (this overlaps with the pre-existing [COST-7680 G2](COST-7680.md) backoff gap).
+
+### G3. Platform/Ready phase is not actually gated on "all service pods ready"
+
+Given G2, `cfg.Status.Phase = PhaseReady` / `ConditionAvailable = True` at the end of `reconcile()` fires as soon as the *pipeline* completes without error — not when Masu, Listener, ROS, Kruize, or RBAC pods are individually confirmed `Ready`. This is the same underlying issue as [COST-7689 G2](COST-7689.md) ("RBAC Deployments applied but never gated") and the `BETA-PRIORITY.md` T1 theme ("`UIReady` / Ingress / workers not truly readiness-gated"), but scoped here to the literal COST-7686 acceptance criterion "on all service pods ready, ungate the Platform phase." Fixing G2 (readiness checks for every Deployment this ticket owns) is the direct fix for this criterion; it is listed separately because the ticket calls it out as its own bullet.
+
+### G4. Profile-based sizing — confirmed pre-existing gap, still open
+
+`spec.profile` (`Profile` type, `+kubebuilder:default:=standard`) is accepted by the API but never read by any resource builder in `internal/resources/`. This is already tracked as a cross-cutting gap in [COST-7678](COST-7678.md), [COST-7687](COST-7687.md), [COST-7689](COST-7689.md), [COST-7690](COST-7690.md), and `BETA-PRIORITY.md` T5 (ranked **P2 for beta**). No new finding here — confirming it is still unimplemented as of this audit and applies equally to every Deployment this ticket (COST-7686) owns. Use per-component `spec.*.resources` fields as the documented workaround until a shared sizing map lands.
+
+---
+
+## Related gaps (not in Jira body; same surface)
+
+- **Untested Secret/Kruize builders.** `go test ./internal/resources/... -coverprofile` shows `0%` coverage on `DjangoSecret`, `djangoSecretKey`, `DBCredentialsSecret`, `randomPassword`, `KruizeDeployment`, `KruizeService`, `KruizeClusterRoleBinding`, `KruizeConfigMap`, and `KruizeServiceAccount`. Per `CLAUDE.md`'s PR review checklist, these are core to this ticket's Django-key acceptance criterion and the Kruize deliverable; worth closing before merge even though the ticket itself doesn't mandate tests.
+- **G1 undermines several "Done" claims elsewhere.** [COST-7685](COST-7685.md) ("ROS migrate skip when `ros.enabled=false` already landed"), [COST-7687](COST-7687.md) ("ROS Processor + Recommendation Poller + Housekeeper ✅ (when `spec.ros.enabled`)"), and `BETA-PRIORITY.md`'s COST-8054 "Landed" table all describe behavior that G1 shows is currently dead code. Recommend a follow-up sweep of those docs once G1 is fixed (out of scope for this file per the skill's "no collateral doc edits" rule — flagging here only).


### PR DESCRIPTION
## Summary by Sourcery

Documentation:
- Introduce docs/gap_analysis/COST-7686.md documenting the ticket’s deliverables, confirmed behavior, and outstanding gaps for ROS, Kruize, and readiness gating.