### PR TITLE
fix: add NetworkPolicies for bundled cache and database

### DIFF
--- a/docs/review-follow-ups.md
+++ b/docs/review-follow-ups.md
@@ -122,3 +122,41 @@ catch this at CI time.
 `rbac_manifest_test.go` that parses `role.yaml` and fails if it
 contains resources like `consolelinks`, `clusterroles`,
 `clusterrolebindings`, `ingresses`, or `storageclasses`.
+
+---
+
+## 7. Keycloak sync: mount CA bundle for private-CA Keycloak
+
+**Source:** Code review finding — pre-existing (applies when KeycloakSync is implemented).
+
+**Problem:** When the Keycloak sync CronJob is implemented, the embedded
+Python script will need to verify TLS against Keycloak. If Keycloak uses a
+private CA (common on-prem), `ssl.create_default_context()` won't trust it.
+`KEYCLOAK_TLS_VERIFY` would follow `auth.keycloak.tls.insecureSkipVerify`,
+but `auth.keycloak.tls.caCertSecretName` is never mounted into the sync Job
+and the script has no `SSL_CERT_FILE` override.
+
+The Helm chart's CronJob template has the same gap.
+
+**Impact:** Private-CA Keycloak with `insecureSkipVerify=false` (the secure
+default) → CronJob auth failures. Users would have to set
+`insecureSkipVerify=true` as a workaround, defeating TLS verification.
+
+**Suggested fix:** When implementing the sync CronJob, mount the Keycloak CA
+Secret (or the combined CA bundle from CACombineInitContainer) and set
+`SSL_CERT_FILE` in the container env. Follow the same pattern used by the
+Envoy gateway and oauth2-proxy for Keycloak CA trust.
+
+---
+
+## 8. Keycloak sync: enable/disable lifecycle test
+
+**Source:** Code review finding — pre-existing (applies when KeycloakSync is implemented).
+
+**Problem:** When the Keycloak sync CronJob is implemented, it needs a
+fake-client test covering the enable → apply → disable → delete lifecycle
+(same pattern as `TestKruizeCronJobDeletedWhenDisabled`). Without it,
+disabling the sync could leave orphaned CronJobs running.
+
+**Suggested fix:** Add a test following the Kruize CronJob disable pattern
+in `ros_cleanup_test.go`.

--- a/internal/controller/costmanagementserviceconfig_controller.go
+++ b/internal/controller/costmanagementserviceconfig_controller.go
@@ -675,19 +675,25 @@ func (r *CostManagementServiceConfigReconciler) reconcileEdge(ctx context.Contex
 	}
 
 	// NetworkPolicies — restrict traffic to expected flows per component.
-	nps := []client.Object{
+	netpols := []client.Object{
 		resources.GatewayNetworkPolicy(cfg),
 		resources.IngressNetworkPolicy(cfg),
 		resources.RBACAPINetworkPolicy(cfg),
 		resources.KokuAPINetworkPolicy(cfg),
 	}
 	if costv1alpha1.ROSEnabled(cfg) {
-		nps = append(nps,
+		netpols = append(netpols,
 			resources.KruizeNetworkPolicy(cfg),
 			resources.ROSAPINetworkPolicy(cfg),
 		)
 	}
-	for _, np := range nps {
+	if costv1alpha1.BoolVal(cfg.Spec.Cache.Deploy, true) {
+		netpols = append(netpols, resources.CacheNetworkPolicy(cfg))
+	}
+	if costv1alpha1.BoolVal(cfg.Spec.Database.Deploy, true) {
+		netpols = append(netpols, resources.DatabaseNetworkPolicy(cfg))
+	}
+	for _, np := range netpols {
 		if err := r.apply(ctx, cfg, np); err != nil {
 			return Result{}, fmt.Errorf("networkpolicy %s: %w", np.GetName(), err)
 		}

--- a/internal/resources/cache.go
+++ b/internal/resources/cache.go
@@ -9,7 +9,14 @@ import (
 	costv1alpha1 "github.com/project-koku/koku-service-operator/api/v1alpha1"
 )
 
-// CacheDeployment builds the Valkey Deployment.
+// CacheDeployment builds the bundled Valkey Deployment (dev/CI only).
+//
+// The server runs with --protected-mode no and no --requirepass / TLS flags.
+// This is intentional: the bundled cache is not for production (BYOI model).
+// spec.cache.auth and spec.cache.tls configure *client-side* env vars on
+// Koku/RBAC containers for connecting to an *external* Redis/Valkey; they
+// do not affect this bundled server. A CacheNetworkPolicy restricts ingress
+// to operator-managed pods as defense in depth.
 func CacheDeployment(cfg *costv1alpha1.CostManagementServiceConfig) *appsv1.Deployment {
 	name := NameValkey(cfg)
 	selLabels := SelectorLabels(cfg, "cache")

--- a/internal/resources/networkpolicies.go
+++ b/internal/resources/networkpolicies.go
@@ -46,6 +46,15 @@ func podFrom(cfg *costv1alpha1.CostManagementServiceConfig, component string, po
 	}
 }
 
+// ingressFromPods builds one ingress rule per pod component on the given port.
+func ingressFromPods(cfg *costv1alpha1.CostManagementServiceConfig, port int32, pods []string) []networkingv1.NetworkPolicyIngressRule {
+	rules := make([]networkingv1.NetworkPolicyIngressRule, 0, len(pods))
+	for _, name := range pods {
+		rules = append(rules, podFrom(cfg, name, port))
+	}
+	return rules
+}
+
 // -----------------------------------------------------------------------------
 // Gateway (Envoy JWT proxy)
 // -----------------------------------------------------------------------------
@@ -138,6 +147,64 @@ func ROSAPINetworkPolicy(cfg *costv1alpha1.CostManagementServiceConfig) *network
 	return netpol(cfg, cfg.Name+"-ros-api", "ros-api", []networkingv1.NetworkPolicyIngressRule{
 		podFrom(cfg, "gateway", rosAPIPort),
 	})
+}
+
+// -----------------------------------------------------------------------------
+// Bundled Valkey (cache)
+// -----------------------------------------------------------------------------
+
+// CacheNetworkPolicy restricts ingress to the bundled Valkey instance.
+// Only Koku workloads (API, Masu, Listener, Celery, RBAC) need cache access.
+// The bundled Valkey runs with --protected-mode no (dev-only, no auth); this
+// NetworkPolicy is defense-in-depth to prevent arbitrary namespace pods from
+// reading/writing the cache.
+func CacheNetworkPolicy(cfg *costv1alpha1.CostManagementServiceConfig) *networkingv1.NetworkPolicy {
+	cachePort := cfg.Spec.Cache.Port
+	if cachePort == 0 {
+		cachePort = 6379
+	}
+	return netpol(cfg, cfg.Name+"-cache", "cache", ingressFromPods(cfg, cachePort, []string{
+		"cost-management-api",
+		"cost-processor",
+		"listener",
+		"cost-scheduler",
+		"cost-worker-celery",
+		"cost-worker-priority",
+		"cost-worker-summary",
+		"cost-worker-ocp",
+		"cost-worker-cost-model",
+		"cost-worker-refresh",
+		"cost-worker-hcs",
+		"cost-worker-download",
+		"cost-worker-subs-extraction",
+		"cost-worker-subs-transmission",
+		"rbac-api",
+		"rbac-worker",
+	}))
+}
+
+// -----------------------------------------------------------------------------
+// Bundled Database (PostgreSQL)
+// -----------------------------------------------------------------------------
+
+// DatabaseNetworkPolicy restricts ingress to the bundled PostgreSQL instance.
+// Only services that connect to the database need access.
+func DatabaseNetworkPolicy(cfg *costv1alpha1.CostManagementServiceConfig) *networkingv1.NetworkPolicy {
+	dbPort := cfg.Spec.Database.Port
+	if dbPort == 0 {
+		dbPort = 5432
+	}
+	return netpol(cfg, cfg.Name+"-database", "database", ingressFromPods(cfg, dbPort, []string{
+		"cost-management-api",
+		"cost-processor",
+		"rbac-api",
+		"rbac-worker",
+		"ros-api",
+		"ros-processor",
+		"ros-recommendation-poller",
+		"ros-housekeeper",
+		"ros-optimization",
+	}))
 }
 
 // -----------------------------------------------------------------------------

--- a/internal/resources/networkpolicies.go
+++ b/internal/resources/networkpolicies.go
@@ -197,13 +197,17 @@ func DatabaseNetworkPolicy(cfg *costv1alpha1.CostManagementServiceConfig) *netwo
 	return netpol(cfg, cfg.Name+"-database", "database", ingressFromPods(cfg, dbPort, []string{
 		"cost-management-api",
 		"cost-processor",
+		"cost-management-migration",
 		"rbac-api",
 		"rbac-worker",
+		"rbac-migration",
+		"rbac-admin-bootstrap",
 		"ros-api",
 		"ros-processor",
 		"ros-recommendation-poller",
 		"ros-housekeeper",
 		"ros-optimization",
+		"ros-migration",
 	}))
 }
 

--- a/internal/resources/networkpolicies.go
+++ b/internal/resources/networkpolicies.go
@@ -202,6 +202,7 @@ func DatabaseNetworkPolicy(cfg *costv1alpha1.CostManagementServiceConfig) *netwo
 		"rbac-worker",
 		"rbac-migration",
 		"rbac-admin-bootstrap",
+		"rbac-keycloak-sync",
 		"ros-api",
 		"ros-processor",
 		"ros-recommendation-poller",

--- a/internal/resources/networkpolicies_test.go
+++ b/internal/resources/networkpolicies_test.go
@@ -120,6 +120,68 @@ func TestROSAPINetworkPolicy_GatewayOnly(t *testing.T) {
 	}
 }
 
+func TestCacheNetworkPolicy(t *testing.T) {
+	cfg := testCfg()
+	np := CacheNetworkPolicy(cfg)
+	assertIngressOnly(t, np)
+	if got := np.Spec.PodSelector.MatchLabels[labelComponent]; got != "cache" {
+		t.Errorf("podSelector component = %q, want cache", got)
+	}
+	wantFrom := []string{
+		"cost-management-api", "cost-processor", "listener", "cost-scheduler",
+		"cost-worker-celery", "cost-worker-priority", "cost-worker-summary",
+		"cost-worker-ocp", "cost-worker-cost-model", "cost-worker-refresh",
+		"cost-worker-hcs", "cost-worker-download",
+		"cost-worker-subs-extraction", "cost-worker-subs-transmission",
+		"rbac-api", "rbac-worker",
+	}
+	for _, comp := range wantFrom {
+		found := false
+		for _, rule := range np.Spec.Ingress {
+			if peerHasComponent(rule, comp) {
+				found = true
+				break
+			}
+		}
+		if !found {
+			t.Errorf("missing peer component %q", comp)
+		}
+	}
+	if !ruleAllowsPort(np.Spec.Ingress, 6379) {
+		t.Error("missing default cache port 6379")
+	}
+}
+
+func TestDatabaseNetworkPolicy(t *testing.T) {
+	cfg := testCfg()
+	np := DatabaseNetworkPolicy(cfg)
+	assertIngressOnly(t, np)
+	if got := np.Spec.PodSelector.MatchLabels[labelComponent]; got != "database" {
+		t.Errorf("podSelector component = %q, want database", got)
+	}
+	wantFrom := []string{
+		"cost-management-api", "cost-processor", "cost-management-migration",
+		"rbac-api", "rbac-worker", "rbac-migration", "rbac-admin-bootstrap",
+		"ros-api", "ros-processor", "ros-recommendation-poller",
+		"ros-housekeeper", "ros-optimization", "ros-migration",
+	}
+	for _, comp := range wantFrom {
+		found := false
+		for _, rule := range np.Spec.Ingress {
+			if peerHasComponent(rule, comp) {
+				found = true
+				break
+			}
+		}
+		if !found {
+			t.Errorf("missing peer component %q", comp)
+		}
+	}
+	if !ruleAllowsPort(np.Spec.Ingress, 5432) {
+		t.Error("missing default database port 5432")
+	}
+}
+
 func assertIngressOnly(t *testing.T, np *networkingv1.NetworkPolicy) {
 	t.Helper()
 	if len(np.Spec.PolicyTypes) != 1 || np.Spec.PolicyTypes[0] != networkingv1.PolicyTypeIngress {

--- a/internal/resources/networkpolicies_test.go
+++ b/internal/resources/networkpolicies_test.go
@@ -161,7 +161,7 @@ func TestDatabaseNetworkPolicy(t *testing.T) {
 	}
 	wantFrom := []string{
 		"cost-management-api", "cost-processor", "cost-management-migration",
-		"rbac-api", "rbac-worker", "rbac-migration", "rbac-admin-bootstrap",
+		"rbac-api", "rbac-worker", "rbac-migration", "rbac-admin-bootstrap", "rbac-keycloak-sync",
 		"ros-api", "ros-processor", "ros-recommendation-poller",
 		"ros-housekeeper", "ros-optimization", "ros-migration",
 	}


### PR DESCRIPTION
## Summary

- Add `CacheNetworkPolicy` restricting bundled Valkey ingress to Koku/RBAC/Celery pods only
- Add `DatabaseNetworkPolicy` restricting bundled PostgreSQL ingress to Koku/RBAC/ROS/Kruize pods only
- Only created when `deploy=true` (bundled mode); BYOI deployments unaffected
- Document in `cache.go` that `spec.cache.auth/tls` are client-side only and intentionally do not affect the bundled server

Addresses review finding #5 (Valkey `--protected-mode no` with no NetworkPolicy).

The bundled Valkey intentionally runs without `--requirepass` or TLS — it is dev/CI only per the BYOI production model. The NetworkPolicy is defense in depth.

## Test plan

- [x] `go build ./...` — clean
- [x] `go test ./internal/...` — all pass
- [x] `golangci-lint run ./...` — 0 issues
- [x] LSP: `CacheNetworkPolicy` and `DatabaseNetworkPolicy` wired from `reconcileEdge`
- [ ] Deploy with `deploy=true` and verify NetworkPolicies created
- [ ] Deploy with `deploy=false` (BYOI) and verify no infra NetworkPolicies

## Summary by Sourcery

Add NetworkPolicies to restrict ingress to bundled cache and database services when they are deployed, and clarify bundled cache documentation.

New Features:
- Introduce CacheNetworkPolicy to restrict access to the bundled Valkey cache to specific operator-managed pods.
- Introduce DatabaseNetworkPolicy to restrict access to the bundled PostgreSQL database to specific operator-managed pods.

Enhancements:
- Conditionally apply cache and database NetworkPolicies only when the bundled services are deployed, leaving BYOI deployments unchanged.
- Add documentation to the bundled cache deployment clarifying its dev/CI-only role and client-side nature of cache auth/TLS settings.