### PR TITLE
fix: use upstream operator image and revert test-cluster keycloak URL

### DIFF
--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -4,8 +4,8 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 images:
 - name: controller
-  newName: image-registry.openshift-image-registry.svc:5000/koku-service-operator-system/koku-service-operator
-  newTag: latest
+  newName: quay.io/project-koku/koku-service-operator
+  newTag: v0.0.1
 # Keep --operator-image arg in sync with the container image so init containers
 # automatically use the same registry/tag without a separate image pull.
 # args array layout: 0=--leader-elect, 1=--health-probe-bind-address, 2=--operator-image

--- a/config/samples/service.costmanagement_v1alpha1_costmanagementserviceconfig.yaml
+++ b/config/samples/service.costmanagement_v1alpha1_costmanagementserviceconfig.yaml
@@ -96,14 +96,12 @@ spec:
     keycloak:
       # JWKS fetch URL (prefer in-cluster Service). When RHBK sets a public
       # hostname, tokens use that URL as iss — set issuerURL to match.
-      url: "https://keycloak-service.keycloak.svc.cluster.local:8443"
+      url: "https://keycloak.keycloak.svc.cluster.local"
       # issuerURL: "https://keycloak-keycloak.apps.example.com"
       realm: kubernetes
       audiences:
         - "cost-management-operator"
         - "cost-management-ui"
-      tls:
-        insecureSkipVerify: true
 
   ui:
     replicaCount: 1


### PR DESCRIPTION
## Summary

- Point `config/manager/kustomization.yaml` operator image at `quay.io/project-koku/koku-service-operator` (matching koku-metrics-operator convention) instead of in-cluster registry from PR #56
- Revert keycloak URL to generic `keycloak.keycloak.svc.cluster.local` and drop `tls.insecureSkipVerify` (test-cluster-specific, shouldn't be on main)

## Test plan

- [ ] `make manifests` produces no drift
- [ ] CI green

## Summary by Sourcery

Update operator image configuration to use the upstream quay.io koku-service-operator image and align sample Keycloak configuration with the generic in-cluster URL without test-cluster-specific TLS overrides.

Enhancements:
- Adjust the sample CostManagementServiceConfig Keycloak URL to the generic in-cluster service and remove insecure TLS skip verification options.

Build:
- Point the manager kustomization to the quay.io/project-koku/koku-service-operator image with a pinned tag.