### PR TITLE
fix: default ros.enabled to false for Cost-only beta

### DIFF
--- a/api/v1alpha1/costmanagementserviceconfig_types.go
+++ b/api/v1alpha1/costmanagementserviceconfig_types.go
@@ -385,10 +385,12 @@ type KruizePartitionsSpec struct {
 // -----------------------------------------------------------------------------
 
 type ROSConfig struct {
-	// When false, the operator skips ROS and Kruize (ROS-only dependency):
-	// migrations, Deployments/Services, CronJobs, NetworkPolicies, Envoy routes,
-	// and cluster-scoped Kruize RBAC. Defaults to true.
-	// +kubebuilder:default:=true
+	// When false (the default), the operator skips ROS and Kruize (ROS-only
+	// dependency): migrations, Deployments/Services, CronJobs, NetworkPolicies,
+	// Envoy routes, and cluster-scoped Kruize RBAC.
+	// Beta ships Cost Management without ROS/Kruize — set enabled: true only when
+	// you intentionally opt in (and provide ROS/Kruize images).
+	// +kubebuilder:default:=false
 	Enabled *bool `json:"enabled,omitempty"`
 
 	Image                ImageSpec          `json:"image,omitempty"`
@@ -400,8 +402,9 @@ type ROSConfig struct {
 }
 
 // ROSEnabled reports whether ROS (and Kruize) should be deployed for this CR.
+// Omitted / nil defaults to false (beta: Cost-only).
 func ROSEnabled(cfg *CostManagementServiceConfig) bool {
-	return BoolVal(cfg.Spec.ROS.Enabled, true)
+	return BoolVal(cfg.Spec.ROS.Enabled, false)
 }
 
 type ROSAPISpec struct {

--- a/api/v1alpha1/ros_enabled_test.go
+++ b/api/v1alpha1/ros_enabled_test.go
@@ -4,8 +4,8 @@ import "testing"
 
 func TestROSEnabled(t *testing.T) {
 	cfg := &CostManagementServiceConfig{}
-	if !ROSEnabled(cfg) {
-		t.Fatal("nil Enabled should default to true")
+	if ROSEnabled(cfg) {
+		t.Fatal("nil Enabled should default to false (beta: Cost-only)")
 	}
 	enabled := true
 	cfg.Spec.ROS.Enabled = &enabled

--- a/bundle/manifests/service.costmanagement.openshift.io_costmanagementserviceconfigs.yaml
+++ b/bundle/manifests/service.costmanagement.openshift.io_costmanagementserviceconfigs.yaml
@@ -1,9 +1,9 @@
+---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.18.0
-  creationTimestamp: null
   name: costmanagementserviceconfigs.service.costmanagement.openshift.io
 spec:
   group: service.costmanagement.openshift.io
@@ -140,6 +140,7 @@ spec:
                         - cost-management-ui
                         description: JWT audiences accepted by the gateway.
                         items:
+                          pattern: ^[^\x00-\x1f\x7f]*$
                           type: string
                         type: array
                       issuerURL:
@@ -149,12 +150,14 @@ spec:
                           as iss even when clients obtain them via the in-cluster Service — set
                           this to that frontend base URL (or the full .../realms/<realm> issuer).
                           When empty, issuer is derived from url + realm.
+                        pattern: ^[^\x00-\x1f\x7f]*$
                         type: string
                       namespace:
                         description: Keycloak namespace. Defaults to "keycloak".
                         type: string
                       realm:
                         default: kubernetes
+                        pattern: ^[^\x00-\x1f\x7f]*$
                         type: string
                       tls:
                         properties:
@@ -177,37 +180,15 @@ spec:
                           issuerURL is unset). Prefer an in-cluster http(s) Service URL so Envoy
                           can reach JWKS without depending on the OpenShift router.
                           Example: http://keycloak-service.keycloak.svc.cluster.local:8080
+                        pattern: ^[^\x00-\x1f\x7f]*$
                         type: string
                     type: object
-                  realmUsers:
-                    items:
-                      description: |-
-                        RealmUser defines an initial Keycloak user created by the operator.
-                        NOTE: do not put production credentials here — the Password field is stored
-                        in etcd. Use a Secret reference instead once secret-backed user provisioning
-                        is implemented (COST-7694).
-                      properties:
-                        accountNumber:
-                          type: string
-                        email:
-                          type: string
-                        firstName:
-                          type: string
-                        lastName:
-                          type: string
-                        orgAdmin:
-                          type: boolean
-                        orgId:
-                          type: string
-                        password:
-                          type: string
-                        username:
-                          type: string
-                      required:
-                      - password
-                      - username
-                      type: object
-                    type: array
+                    x-kubernetes-validations:
+                    - message: issuerURL must use https when set
+                      rule: '!has(self.issuerURL) || size(self.issuerURL) == 0 ||
+                        self.issuerURL.startsWith(''https://'')'
+                    - message: audiences must not be empty when set
+                      rule: '!has(self.audiences) || size(self.audiences) > 0'
                 type: object
               cache:
                 properties:
@@ -258,6 +239,8 @@ spec:
                   port:
                     default: 6379
                     format: int32
+                    maximum: 65535
+                    minimum: 1
                     type: integer
                   resources:
                     description: ResourceRequirements describes the compute resource
@@ -329,6 +312,11 @@ spec:
                         type: boolean
                     type: object
                 type: object
+                x-kubernetes-validations:
+                - message: host and auth.secretName are required when cache.deploy
+                    is false
+                  rule: self.deploy != false || (size(self.host) > 0 && has(self.auth.secretName)
+                    && size(self.auth.secretName) > 0)
               costManagement:
                 properties:
                   api:
@@ -1151,6 +1139,14 @@ spec:
                             type: object
                         type: object
                     type: object
+                  dataRetentionMonths:
+                    default: 4
+                    description: DataRetentionMonths is how many months of cost report
+                      data to retain.
+                    format: int32
+                    maximum: 60
+                    minimum: 1
+                    type: integer
                   listener:
                     properties:
                       enabled:
@@ -1325,8 +1321,15 @@ spec:
                     properties:
                       create:
                         default: true
+                        description: |-
+                          Create controls whether the operator creates and owns the ServiceAccount.
+                          When false, the operator references Name (or the default name) without
+                          applying or adopting the object — the SA must already exist.
                         type: boolean
                       name:
+                        description: |-
+                          Name is the ServiceAccount name used by pods. When empty, a default
+                          name derived from the CR is used.
                         type: string
                     type: object
                   storage:
@@ -1369,6 +1372,8 @@ spec:
                   port:
                     default: 5432
                     format: int32
+                    maximum: 65535
+                    minimum: 1
                     type: integer
                   resources:
                     description: ResourceRequirements describes the compute resource
@@ -1439,6 +1444,11 @@ spec:
                     type: string
                   sslMode:
                     default: disable
+                    enum:
+                    - disable
+                    - require
+                    - verify-ca
+                    - verify-full
                     type: string
                   storage:
                     properties:
@@ -1451,32 +1461,21 @@ spec:
                         x-kubernetes-int-or-string: true
                     type: object
                 type: object
+                x-kubernetes-validations:
+                - message: host and secretName are required when database.deploy is
+                    false
+                  rule: self.deploy != false || (size(self.host) > 0 && size(self.secretName)
+                    > 0)
               gatewayRoute:
                 properties:
                   annotations:
                     additionalProperties:
                       type: string
                     type: object
-                  hosts:
-                    items:
-                      properties:
-                        host:
-                          description: Empty host uses the cluster's default ingress
-                            domain.
-                          type: string
-                        paths:
-                          items:
-                            properties:
-                              path:
-                                default: /
-                                type: string
-                              pathType:
-                                default: Prefix
-                                type: string
-                            type: object
-                          type: array
-                      type: object
-                    type: array
+                  host:
+                    description: Custom hostname for the OpenShift Route. Leave empty
+                      to derive from clusterDomain.
+                    type: string
                   tls:
                     properties:
                       insecureEdgeTerminationPolicy:
@@ -1504,6 +1503,9 @@ spec:
                       Auto-detected by the Discovery phase when empty.
                     type: string
                   imagePullSecrets:
+                    description: |-
+                      ImagePullSecrets are applied to every Pod the operator creates (Deployments,
+                      StatefulSets, Jobs, CronJobs) so workloads can pull from private registries.
                     items:
                       description: |-
                         LocalObjectReference contains enough information to let you locate the
@@ -1834,6 +1836,8 @@ spec:
                   port:
                     default: 443
                     format: int32
+                    maximum: 65535
+                    minimum: 1
                     type: integer
                   s3:
                     properties:
@@ -1859,11 +1863,12 @@ spec:
                 type: object
               profile:
                 default: standard
-                description: Profile selects pre-defined resource sizing. Defaults
-                  to standard.
+                description: |-
+                  Profile selects pre-defined resource sizing. Defaults to standard.
+                  NOT YET IMPLEMENTED — accepted but not read by the reconciler (COST-7678).
+                  Use per-component resources fields until profile sizing is wired.
                 enum:
                 - standard
-                - ha
                 type: string
               rbac:
                 properties:
@@ -1938,6 +1943,22 @@ spec:
                     properties:
                       enabled:
                         type: boolean
+                      secretRef:
+                        description: |-
+                          SecretRef references a Secret containing the bootstrap admin identity.
+                          Required keys: org-id, account-number, username.
+                        properties:
+                          name:
+                            default: ""
+                            description: |-
+                              Name of the referent.
+                              This field is effectively required, but due to backwards compatibility is
+                              allowed to be empty. Instances of this type with an empty value here are
+                              almost certainly wrong.
+                              More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                            type: string
+                        type: object
+                        x-kubernetes-map-type: atomic
                     type: object
                   image:
                     properties:
@@ -2178,11 +2199,13 @@ spec:
                         type: object
                     type: object
                   enabled:
-                    default: true
+                    default: false
                     description: |-
-                      When false, the operator skips ROS and Kruize (ROS-only dependency):
-                      migrations, Deployments/Services, CronJobs, NetworkPolicies, Envoy routes,
-                      and cluster-scoped Kruize RBAC. Defaults to true.
+                      When false (the default), the operator skips ROS and Kruize (ROS-only
+                      dependency): migrations, Deployments/Services, CronJobs, NetworkPolicies,
+                      Envoy routes, and cluster-scoped Kruize RBAC.
+                      Beta ships Cost Management without ROS/Kruize — set enabled: true only when
+                      you intentionally opt in (and provide ROS/Kruize images).
                     type: boolean
                   housekeeper:
                     properties:
@@ -2472,8 +2495,15 @@ spec:
                     properties:
                       create:
                         default: true
+                        description: |-
+                          Create controls whether the operator creates and owns the ServiceAccount.
+                          When false, the operator references Name (or the default name) without
+                          applying or adopting the object — the SA must already exist.
                         type: boolean
                       name:
+                        description: |-
+                          Name is the ServiceAccount name used by pods. When empty, a default
+                          name derived from the CR is used.
                         type: string
                     type: object
                 type: object
@@ -2775,9 +2805,3 @@ spec:
     storage: true
     subresources:
       status: {}
-status:
-  acceptedNames:
-    kind: ""
-    plural: ""
-  conditions: null
-  storedVersions: null

--- a/config/crd/bases/service.costmanagement.openshift.io_costmanagementserviceconfigs.yaml
+++ b/config/crd/bases/service.costmanagement.openshift.io_costmanagementserviceconfigs.yaml
@@ -2199,11 +2199,13 @@ spec:
                         type: object
                     type: object
                   enabled:
-                    default: true
+                    default: false
                     description: |-
-                      When false, the operator skips ROS and Kruize (ROS-only dependency):
-                      migrations, Deployments/Services, CronJobs, NetworkPolicies, Envoy routes,
-                      and cluster-scoped Kruize RBAC. Defaults to true.
+                      When false (the default), the operator skips ROS and Kruize (ROS-only
+                      dependency): migrations, Deployments/Services, CronJobs, NetworkPolicies,
+                      Envoy routes, and cluster-scoped Kruize RBAC.
+                      Beta ships Cost Management without ROS/Kruize — set enabled: true only when
+                      you intentionally opt in (and provide ROS/Kruize images).
                     type: boolean
                   housekeeper:
                     properties:

--- a/config/samples/byoi/README.md
+++ b/config/samples/byoi/README.md
@@ -127,8 +127,9 @@ Override the Secret name with `spec.ui.oauthClientSecretRef.name` if needed.
 Cookie session Secret (`{cr}-ui-cookie-secret`) is still created by the operator.
 
 Set `spec.ui.app.image` and `spec.ui.oauthProxy.image` (repository and tag).
-Empty values yield `InvalidImageName`. With `ros.enabled: false` (sample default),
-ROS/Kruize are skipped — suitable for UI smoke without ROS images.
+Empty values yield `InvalidImageName`. **`ros.enabled` defaults to `false`**
+(beta: Cost-only); samples keep it false so ROS/Kruize are skipped — suitable
+for UI smoke without ROS images. Set `enabled: true` only when opting in.
 
 ## Apply
 

--- a/config/samples/byoi/app/costmanagementserviceconfig-smoke.yaml
+++ b/config/samples/byoi/app/costmanagementserviceconfig-smoke.yaml
@@ -79,6 +79,7 @@ spec:
         costModel:
           replicas: 1
 
+  # Beta: ROS/Kruize out of scope — CRD default is false.
   ros:
     enabled: false
 

--- a/config/samples/byoi/app/costmanagementserviceconfig.yaml
+++ b/config/samples/byoi/app/costmanagementserviceconfig.yaml
@@ -71,8 +71,8 @@ spec:
         costModel:
           replicas: 1
 
-  # Beta: ROS (and Kruize) are optional. Set enabled: true to deploy them
-  # (requires ROS/Kruize images + DB roles). Leave false for UI smoke.
+  # Beta: ROS and Kruize are out of scope. Keep enabled: false (also the CRD
+  # default). Set enabled: true and fill ros.image / kruize.image only when opting in.
   ros:
     enabled: false
 

--- a/config/samples/service.costmanagement_v1alpha1_costmanagementserviceconfig.yaml
+++ b/config/samples/service.costmanagement_v1alpha1_costmanagementserviceconfig.yaml
@@ -63,7 +63,10 @@ spec:
         costModel:
           replicas: 1
 
+  # Beta: ROS and Kruize are out of scope — omit or keep enabled: false (CRD default).
+  # Set enabled: true and fill ros.image / kruize.image only when opting in.
   ros:
+    enabled: false
     image:
       repository: quay.io/redhat-services-prod/insights-management-tenant/insights-ocp-resource-optimization/ros-ocp-backend
       tag: "ae8c990"
@@ -79,6 +82,7 @@ spec:
     worker:
       replicas: 1
 
+  # Only applied when ros.enabled: true
   kruize:
     replicas: 1
     image:

--- a/config/samples/service.costmanagement_v1alpha1_costmanagementserviceconfig_byoi.yaml
+++ b/config/samples/service.costmanagement_v1alpha1_costmanagementserviceconfig_byoi.yaml
@@ -119,7 +119,8 @@ spec:
         costModel:
           replicas: 1
 
-  # Beta: ROS (and Kruize) are optional. Omit or set enabled: true to deploy.
+  # Beta: ROS and Kruize are out of scope. Keep enabled: false (CRD default).
+  # Set enabled: true and fill images only when opting in.
   ros:
     enabled: false
     image:

--- a/docs/development/clusterbot.md
+++ b/docs/development/clusterbot.md
@@ -4,6 +4,9 @@ Short path to get a `CostManagementServiceConfig` reconciling on a **Cluster Bot
 (or any remote OpenShift) lab cluster. OwnNamespace: operator install namespace
 **equals** CR namespace.
 
+**Beta:** ROS/Kruize are off by default (`spec.ros.enabled` defaults to `false`).
+Day-one success does not require ROS images or migrate Jobs.
+
 For a fuller BYOI → UI walkthrough (AMQ Streams + Keycloak), see
 [pre-prod-install.md](pre-prod-install.md). For laptop **CRC** with bundled DB,
 see [crc-testing.md](crc-testing.md).
@@ -98,7 +101,7 @@ If you already have AMQ Streams Kafka, point
 | **Schema** | `SchemaUpToDate` True | Must become True for app Deployments |
 | **Available (day-one goal)** | `Available=True` (`KokuAvailable`) + core Deployments Ready | Goal without Keycloak |
 | **Auth / UI** | `AuthenticationReady`, `UIReady` | **Yes** False without Keycloak + OAuth mirror — needed for `Phase=Ready` / UI login |
-| **ROS** | `ROSEnabled=False` when `ros.enabled: false` | Expected — no ROS/Kruize objects |
+| **ROS** | `ROSEnabled=False` (CRD default / sample `ros.enabled: false`) | Expected for beta — no ROS/Kruize objects |
 
 Reading conditions:
 

--- a/docs/development/pre-prod-install.md
+++ b/docs/development/pre-prod-install.md
@@ -223,10 +223,13 @@ Required image fields (empty `repository`/`tag` → `InvalidImageName` / image `
 | `ui.app.image` | UI |
 | `ui.oauthProxy.image` | oauth2-proxy sidecar |
 
-The sample CR sets `ros.enabled: false`. That skips ROS schema migrate, Kruize,
-and ROS workers so a UI smoke does not need ROS/Kruize images or ClusterRole
-escalation rights beyond what `manager-cluster-role` already grants for cleanup.
-Set `ros.enabled: true` (and fill ROS/Kruize images) only when you need ROS.
+**CRD default and samples:** `spec.ros.enabled` defaults to **`false`** (beta is
+Cost-only — no ROS/Kruize). Samples set `enabled: false` explicitly. That skips
+ROS schema migrate, Kruize, and ROS workers so install paths do not need
+ROS/Kruize images or ClusterRole escalation rights beyond what
+`manager-cluster-role` already grants for cleanup.
+Set `ros.enabled: true` (and fill ROS/Kruize images) only when you intentionally
+opt in.
 
 ### B4. Wait for reconcile
 

--- a/docs/gap_analysis/BETA-PRIORITY.md
+++ b/docs/gap_analysis/BETA-PRIORITY.md
@@ -6,7 +6,7 @@
 
 **Scope note (2026-08-10):** ROS and Kruize are **out of beta**. Name them separately in gaps (different secrets, migrate, readiness). Optional install, independent Kruize enablement, and day-2 enablement are owned by **[COST-8054](../jira/COST-8054.md)** — not by COST-7678–7692 closure.
 
-**Code progress since first draft:** `spec.ros.enabled` (`*bool`, default `true`) + `ROSEnabled()` gate Deployments/CronJobs/migrate/Envoy ROS routes/NPs/SMs; `reconcileROSFeature` sets condition `ROSEnabled` and cleans up when flipped off. BYOI samples set `ros.enabled: false`. **Still open for Cost-only honesty:** Validation **always** requires `ros-user` / `ros-password` (not conditional; not Kruize keys); Kruize is not independently toggleable (tied to ROS today); default remains enabled unless the CR sets `false`. “Out of beta scope” means *do not treat ROS or Kruize readiness/hardening as Cost beta blockers*.
+**Code progress since first draft:** `spec.ros.enabled` (`*bool`, **default `false`** for Cost-only beta) + `ROSEnabled()` gate Deployments/CronJobs/migrate/Envoy ROS routes/NPs/SMs; `reconcileROSFeature` sets condition `ROSEnabled` and cleans up when flipped off. Samples keep `ros.enabled: false`. **Still open for Cost-only honesty:** Validation **always** requires `ros-user` / `ros-password` (not conditional; not Kruize keys); Kruize is not independently toggleable (tied to ROS today). Opt in with `ros.enabled: true` + images. “Out of beta scope” means *do not treat ROS or Kruize readiness/hardening as Cost beta blockers*.
 
 Per-ticket detail stays in the linked audits. This doc is the cross-cut ranking.
 
@@ -208,7 +208,7 @@ Track separately; do not conflate the two components. **Partial progress already
 | Skip `ROSMigrationJob` when `ros.enabled=false` | Done (`reconcileMigration` + `ROSEnabled()`) |
 | Skip ROS/Kruize Deployments, CronJobs, Envoy ROS routes, Kruize NP/SM | Done (gated apply + `reconcileROSFeature` cleanup) |
 | `ROSEnabled` condition | Done |
-| BYOI samples default `ros.enabled: false` | Done |
+| BYOI samples + CRD default `ros.enabled: false` | Done |
 | Default when unset | Still **enabled** (`+kubebuilder:default:=true`) |
 
 **Still owned by [COST-8054](../jira/COST-8054.md):**
@@ -220,7 +220,7 @@ Track separately; do not conflate the two components. **Partial progress already
 | Day-2 enable polish / docs | Full AC of 8054 |
 | Hardening (SA, NP, SM, profile rows, bucket discovery) | Post-beta ROS/Kruize quality |
 
-**Beta posture today:** document and sample `ros.enabled: false`; do not gate Available on ROS/Kruize; treat unused `ros-*` secret keys as a known COST-8054 footgun until Validation is conditional.
+**Beta posture today:** CRD and samples default `ros.enabled: false`; do not gate Available on ROS/Kruize; treat unused `ros-*` secret keys as a known COST-8054 footgun until Validation is conditional.
 
 S3/OBC items stay relevant either way — Ingress/uploads still need object storage; only the default OBC name `ros-data-ceph` is ROS-flavored.
 

--- a/docs/gap_analysis/BETA-PRIORITY.md
+++ b/docs/gap_analysis/BETA-PRIORITY.md
@@ -208,8 +208,8 @@ Track separately; do not conflate the two components. **Partial progress already
 | Skip `ROSMigrationJob` when `ros.enabled=false` | Done (`reconcileMigration` + `ROSEnabled()`) |
 | Skip ROS/Kruize Deployments, CronJobs, Envoy ROS routes, Kruize NP/SM | Done (gated apply + `reconcileROSFeature` cleanup) |
 | `ROSEnabled` condition | Done |
-| BYOI samples + CRD default `ros.enabled: false` | Done |
-| Default when unset | Still **enabled** (`+kubebuilder:default:=true`) |
+| BYOI samples + CRD / `ROSEnabled()` default `ros.enabled: false` | Done |
+| Default when unset | **Disabled** (`+kubebuilder:default:=false`, `BoolVal(..., false)`) |
 
 **Still owned by [COST-8054](../jira/COST-8054.md):**
 

--- a/docs/gap_analysis/COST-7685.md
+++ b/docs/gap_analysis/COST-7685.md
@@ -3,7 +3,7 @@
 **Jira:** [COST-7685](https://redhat.atlassian.net/browse/COST-7685)
 **Audited:** 2026-08-10
 **Purpose:** Handoff audit of migration Job lifecycle vs ticket acceptance criteria. This document does not update `docs/tasks.md` or other trackers.
-**Beta scope:** ROS and Kruize are **out of beta** ([BETA-PRIORITY.md](BETA-PRIORITY.md)). Ticket AC for the ROS migration Job is still **Done** in code. `reconcileMigration` already skips `ROSMigrationJob` when `spec.ros.enabled=false` (`ROSEnabled`); default remains enabled. Broader Cost-only install (Validation secrets, Deployments, day-2 enablement) stays under [COST-8054](../jira/COST-8054.md).
+**Beta scope:** ROS and Kruize are **out of beta** ([BETA-PRIORITY.md](BETA-PRIORITY.md)). Ticket AC for the ROS migration Job is still **Done** in code. `reconcileMigration` already skips `ROSMigrationJob` when `spec.ros.enabled=false` (`ROSEnabled`); **default is false** (Cost-only). Broader Cost-only install (Validation secrets, Deployments, day-2 enablement) stays under [COST-8054](../jira/COST-8054.md).
 
 ## Verdict
 
@@ -27,7 +27,7 @@ Out of scope per ticket: Application Deployment creation.
 
 | Deliverable | Status |
 |-------------|--------|
-| Migration Jobs for Koku, ROS, RBAC schemas + RBAC seeding | Done (RBAC migrate+seed combined; optional admin-bootstrap). ROS Job implemented; gated by `spec.ros.enabled` (default true) |
+| Migration Jobs for Koku, ROS, RBAC schemas + RBAC seeding | Done (RBAC migrate+seed combined; optional admin-bootstrap). ROS Job implemented; gated by `spec.ros.enabled` (default **false**) |
 | Sequential order: Koku → ROS → RBAC migrate → RBAC seed | Deviated — Koku → (ROS if enabled) → RBAC migrate+seed → (optional) admin-bootstrap |
 | `activeDeadlineSeconds: 600`, `backoffLimit: 3` | Done |
 | On failure: retries; then `SchemaUpToDate=False` + failed Job name; block progression | Done (retries via Job `backoffLimit`, not operator recreate) |
@@ -117,7 +117,7 @@ On failure also sets `Degraded=True`, `PhaseDegraded`, `Result{Stop: true}` (no 
 | Four Jobs: … RBAC migrate, then RBAC seed | One `RBACMigrationJob` script: `migrate` → `seeds` → cost-management role seed → tenants | Chart parity; documented in tasks.md as “RBAC migrate+seed”; design summary marks migration scope Done |
 | “Operator retries up to 3 times” | Kubernetes Job `backoffLimit: 3` + `RestartPolicy: OnFailure` inside one Job object | Matches the ticket’s own Job field requirements; operator does not delete/recreate failed Jobs for extra attempts |
 | Optional 4th step | `AdminBootstrapJob` when `spec.rbac.bootstrapAdmin.enabled` + orgAdmin present | Superset of ticket; org-admin bootstrap, not generic RBAC seeding |
-| ROS always in the sequence | ROS step only when `ROSEnabled` (`spec.ros.enabled`, default true) | Superset / product optionality; ticket assumed always-on ROS |
+| ROS always in the sequence | ROS step only when `ROSEnabled` (`spec.ros.enabled`, default **false**) | Superset / product optionality; ticket assumed always-on ROS |
 
 ---
 

--- a/docs/gap_analysis/COST-7687.md
+++ b/docs/gap_analysis/COST-7687.md
@@ -51,7 +51,7 @@ Reconciled in [`reconcileWorkers`](../../internal/controller/costmanagementservi
 - Extra default `celery` queue worker (spec `workers.default`) — useful for beat-scheduled default-queue tasks; supersedes ticket’s six-queue list
 - Queue names keep underscores in `WORKER_QUEUES`; Deployment names use `DNS1123Label` ([`names.go`](../../internal/resources/names.go)); covered by [`names_test.go`](../../internal/resources/names_test.go)
 
-### ROS (gated by `ROSEnabled` / `spec.ros.enabled`, default true)
+### ROS (gated by `ROSEnabled` / `spec.ros.enabled`, default **false**)
 
 - [`ROSPollerDeployment`](../../internal/resources/ros.go) — `recommendation-poller`
 - [`ROSHousekeeperDeployment`](../../internal/resources/ros.go) — `housekeeper --sources`

--- a/docs/tasks.md
+++ b/docs/tasks.md
@@ -67,11 +67,11 @@ Last audited: 2026-08-09 against implementation in `internal/controller/` and `i
 
 ## Beta scope
 
-**ROS is not required for Beta.** `spec.ros.enabled` (default `true`) can be set to
-`false` to skip ROS and its Kruize dependency (migrations, Deployments, CronJobs,
-Envoy recommendation routes, NetworkPolicies, ServiceMonitors, cluster-scoped
-Kruize RBAC). BYOI samples default this to `false`. Full ROS/Kruize delivery
-remains tracked under COST-7686 / COST-7687 for post-Beta.
+**ROS is not required for Beta.** `spec.ros.enabled` defaults to **`false`**
+(Cost-only). Set it to `true` only to opt in to ROS and its Kruize dependency
+(migrations, Deployments, CronJobs, Envoy recommendation routes, NetworkPolicies,
+ServiceMonitors, cluster-scoped Kruize RBAC). Samples keep `enabled: false`
+explicitly. Full ROS/Kruize delivery remains tracked under COST-8054 / post-Beta.
 
 ## Intentional Deviations and Known Gaps
 

--- a/internal/controller/cronjob_disable_test.go
+++ b/internal/controller/cronjob_disable_test.go
@@ -36,10 +36,13 @@ func cronJobScheme(t *testing.T) *runtime.Scheme {
 func TestKruizeCronJobDeletedWhenDisabled(t *testing.T) {
 	const ns = "test"
 	falseVal := false
+	rosOn := true
 
 	cfg := &costv1alpha1.CostManagementServiceConfig{
 		ObjectMeta: metav1.ObjectMeta{Name: testCRName, Namespace: ns},
 		Spec: costv1alpha1.CostManagementServiceConfigSpec{
+			// Kruize CronJobs only reconcile when ROS is enabled.
+			ROS: costv1alpha1.ROSConfig{Enabled: &rosOn},
 			Kruize: costv1alpha1.KruizeConfig{
 				Partitions: costv1alpha1.KruizePartitionsSpec{
 					DeleteEnabled: &falseVal, // disabled

--- a/internal/resources/envoy_test.go
+++ b/internal/resources/envoy_test.go
@@ -182,6 +182,8 @@ func TestKeycloakDefaults(t *testing.T) {
 
 func TestEnvoyYAMLContainsIssuerAudiencesAndKokuCluster(t *testing.T) {
 	cfg := testCfg()
+	enabled := true
+	cfg.Spec.ROS.Enabled = &enabled
 	yaml := EnvoyYAML(cfg)
 
 	checks := []string{
@@ -242,6 +244,7 @@ func TestEnvoyYAMLHTTPKeycloakOmitsTLS(t *testing.T) {
 
 func TestEnvoyYAMLOmitsROSWhenDisabled(t *testing.T) {
 	cfg := testCfg()
+	// nil / omitted Enabled also means off (beta default); exercise explicit false.
 	disabled := false
 	cfg.Spec.ROS.Enabled = &disabled
 	yaml := EnvoyYAML(cfg)
@@ -258,6 +261,12 @@ func TestEnvoyYAMLOmitsROSWhenDisabled(t *testing.T) {
 		if strings.Contains(yaml, tok) {
 			t.Errorf("EnvoyYAML left unsubstituted token %q", tok)
 		}
+	}
+
+	cfgNil := testCfg()
+	yamlNil := EnvoyYAML(cfgNil)
+	if strings.Contains(yamlNil, "ros-api-backend") {
+		t.Error("EnvoyYAML should omit ros-api-backend when ros.enabled is omitted (default false)")
 	}
 }
 

--- a/internal/resources/envoy_test.go
+++ b/internal/resources/envoy_test.go
@@ -180,6 +180,18 @@ func TestKeycloakDefaults(t *testing.T) {
 	}
 }
 
+// envoyROSMarkers are Envoy YAML fragments present only when ROS is enabled.
+// Keep the omit-ROS tests in sync with these so Cost-only configs cannot leak
+// partial ROS routes/clusters.
+var envoyROSMarkers = []string{
+	"name: ros-api-backend",
+	"cluster: ros-api-backend",
+	"cluster_name: ros-api-backend",
+	"/api/cost-management/v1/recommendations/openshift",
+	"__ROS_ROUTE__",
+	"__ROS_CLUSTER__",
+}
+
 func TestEnvoyYAMLContainsIssuerAudiencesAndKokuCluster(t *testing.T) {
 	cfg := testCfg()
 	enabled := true
@@ -204,6 +216,14 @@ func TestEnvoyYAMLContainsIssuerAudiencesAndKokuCluster(t *testing.T) {
 			t.Errorf("EnvoyYAML missing %q", want)
 		}
 	}
+	for _, marker := range envoyROSMarkers {
+		if strings.HasPrefix(marker, "__") {
+			continue // unsubstituted tokens must not appear when ROS is on
+		}
+		if !strings.Contains(yaml, marker) {
+			t.Errorf("EnvoyYAML (ROS enabled) missing ROS marker %q", marker)
+		}
+	}
 	// Backend ports must match ROS Service (8000) and RBAC Service (8080).
 	rosIdx := strings.Index(yaml, "name: ros-api-backend")
 	rbacIdx := strings.Index(yaml, "name: rbac-api-backend")
@@ -223,7 +243,7 @@ func TestEnvoyYAMLContainsIssuerAudiencesAndKokuCluster(t *testing.T) {
 	if !strings.Contains(rbacBlock, "port_value: 8080") {
 		t.Error("rbac-api-backend should use port 8080")
 	}
-	for _, tok := range []string{"__HTTP_PORT__", "__ISSUER__", "__LUA__", "__KOKU_HOST__", "__KC_TLS__"} {
+	for _, tok := range []string{"__HTTP_PORT__", "__ISSUER__", "__LUA__", "__KOKU_HOST__", "__KC_TLS__", "__ROS_ROUTE__", "__ROS_CLUSTER__"} {
 		if strings.Contains(yaml, tok) {
 			t.Errorf("EnvoyYAML left unsubstituted token %q", tok)
 		}
@@ -242,32 +262,27 @@ func TestEnvoyYAMLHTTPKeycloakOmitsTLS(t *testing.T) {
 	}
 }
 
+func assertEnvoyYAMLOmitsROS(t *testing.T, yaml string, path string) {
+	t.Helper()
+	for _, marker := range envoyROSMarkers {
+		if strings.Contains(yaml, marker) {
+			t.Errorf("EnvoyYAML should omit ROS marker %q when ros.enabled is %s", marker, path)
+		}
+	}
+	if !strings.Contains(yaml, "name: koku-api-backend") {
+		t.Errorf("koku-api-backend must still be present when ros.enabled is %s", path)
+	}
+}
+
 func TestEnvoyYAMLOmitsROSWhenDisabled(t *testing.T) {
 	cfg := testCfg()
 	// nil / omitted Enabled also means off (beta default); exercise explicit false.
 	disabled := false
 	cfg.Spec.ROS.Enabled = &disabled
-	yaml := EnvoyYAML(cfg)
-	if strings.Contains(yaml, "ros-api-backend") {
-		t.Error("EnvoyYAML should omit ros-api-backend when ros.enabled=false")
-	}
-	if strings.Contains(yaml, "/api/cost-management/v1/recommendations/openshift") {
-		t.Error("EnvoyYAML should omit ROS recommendations route when ros.enabled=false")
-	}
-	if !strings.Contains(yaml, "name: koku-api-backend") {
-		t.Error("koku-api-backend must still be present")
-	}
-	for _, tok := range []string{"__ROS_ROUTE__", "__ROS_CLUSTER__"} {
-		if strings.Contains(yaml, tok) {
-			t.Errorf("EnvoyYAML left unsubstituted token %q", tok)
-		}
-	}
+	assertEnvoyYAMLOmitsROS(t, EnvoyYAML(cfg), "explicitly false")
 
 	cfgNil := testCfg()
-	yamlNil := EnvoyYAML(cfgNil)
-	if strings.Contains(yamlNil, "ros-api-backend") {
-		t.Error("EnvoyYAML should omit ros-api-backend when ros.enabled is omitted (default false)")
-	}
+	assertEnvoyYAMLOmitsROS(t, EnvoyYAML(cfgNil), "omitted (default false)")
 }
 
 func TestEnvoyYAMLParsesForROSEnabledAndDisabled(t *testing.T) {


### PR DESCRIPTION
## Summary

Beta ships **without ROS/Kruize**. This flips `spec.ros.enabled` from default `true` to **`false`** so omitting the field is Cost-only.

- CRD `+kubebuilder:default:=false` + `ROSEnabled()` nil → false
- All sample CRs keep/explicit `enabled: false` with beta wording
- Guides: `clusterbot.md`, `pre-prod-install.md`, `tasks.md`, `BETA-PRIORITY`, related gap notes
- Tests updated for the new default (Envoy + Kruize CronJob path enables ROS explicitly when needed)

## Test plan

- [x] `go test ./api/v1alpha1/ ./internal/resources/ ./internal/controller/ -run 'ROS|KruizeCron|Envoy…'`
- [ ] Apply a CR with `ros` omitted → no ROS migrate / Kruize objects; `ROSEnabled=False`
- [ ] `ros.enabled: true` + images still deploys ROS/Kruize

## Summary by Sourcery

Default ROS/Kruize integration to be disabled for Cost-only beta while tightening CRD schema and refreshing related documentation and tests.

New Features:
- Add dataRetentionMonths configuration field with validated bounds for cost report retention.

Enhancements:
- Change spec.ros.enabled default from true to false and update ROSEnabled() to treat omission as disabled.
- Clarify beta posture and opt-in behavior for ROS/Kruize across installation guides, gap analyses, and sample BYOI configurations.
- Refine ServiceAccount, gateway route, imagePullSecrets, database, cache, and profile CRD fields with descriptions, validation rules, and constrained enums.
- Ensure Envoy and Kruize CronJob behaviors explicitly gate on ROS being enabled, including tests for the new default-off behavior.

Documentation:
- Document that ROS/Kruize are out of beta scope and off by default, with instructions for optional enablement and day-2 behavior in clusterbot, pre-prod install, tasks, and gap analysis docs.

Tests:
- Adjust Envoy, ROSEnabled, and Kruize CronJob tests to reflect ros.enabled defaulting to false and to cover both explicit and omitted configuration cases.