### PR TITLE
docs: close COST-7678 — defer G4 profile sizing to COST-7686/7687

### DIFF
--- a/docs/gap_analysis/COST-7678.md
+++ b/docs/gap_analysis/COST-7678.md
@@ -7,10 +7,11 @@
 
 ## Verdict
 
-**COST-7678 is done** for the CRD/API deliverables in scope. G1–G3 merged on `main`; intentional deviations documented below. **G4 (profile sizing maps)** is **deferred** — not a blocker for closing this ticket:
+**COST-7678 is done** for the CRD/API deliverables in scope. G1–G3 merged on `main`; intentional deviations documented below. **G4 (profile sizing maps)** is **partially delivered and partially deferred** — not a blocker for closing this ticket:
 
-- `spec.profile` accepts only `standard` ([#48](https://github.com/project-koku/koku-service-operator/pull/48)); field is documented as not-yet-implemented.
-- Shared sizing maps and reconciler wiring → [COST-7686](https://redhat.atlassian.net/browse/COST-7686) / [COST-7687](https://redhat.atlassian.net/browse/COST-7687) and [BETA-PRIORITY.md](BETA-PRIORITY.md) item 21 (P2 post-beta).
+- `spec.profile` enum `standard` / `ha` with CRD default `standard` ([#65](https://github.com/project-koku/koku-service-operator/pull/65) re-added `ha`; [#28](https://github.com/project-koku/koku-service-operator/pull/28) had temporarily removed it).
+- **Partial wiring:** `spec.profile` is read by the UI builder when `spec.ui.oauthProxy.resources` / `spec.ui.app.resources` are unset — [`uiProfileResources`](../../internal/resources/ui.go) ([#65](https://github.com/project-koku/koku-service-operator/pull/65)).
+- **Deferred:** shared `profiles.go` sizing maps and reconciler wiring for Celery, Koku API, Masu, Listener, RBAC, etc. → [COST-7686](https://redhat.atlassian.net/browse/COST-7686) / [COST-7687](https://redhat.atlassian.net/browse/COST-7687) and [BETA-PRIORITY.md](BETA-PRIORITY.md) item 21 (P2 post-beta).
 - ROS/Kruize profile rows → [COST-8054](../jira/COST-8054.md).
 
 Out of scope per ticket: reconciler logic, resource builders.
@@ -23,8 +24,8 @@ Out of scope per ticket: reconciler logic, resource builders.
 | [#51](https://github.com/project-koku/koku-service-operator/pull/51) | G2-b | CEL: BYOI `deploy=false` → host/secret; Keycloak `issuerURL` https + non-empty `audiences` |
 | [#52](https://github.com/project-koku/koku-service-operator/pull/52) | G1 + G2-c | Admission webhooks; `requests ≤ limits` validating webhook |
 | [#59](https://github.com/project-koku/koku-service-operator/pull/59) | G3 | `dataRetentionMonths` → `RETAIN_NUM_MONTHS` + zero-value guard |
-| [#48](https://github.com/project-koku/koku-service-operator/pull/48) | G4 (doc) | `spec.profile` documented as not-yet-implemented |
-| [#28](https://github.com/project-koku/koku-service-operator/pull/28) | G4 | Removed `ha` from enum until sizing maps exist |
+| [#65](https://github.com/project-koku/koku-service-operator/pull/65) | G4 (partial) | `ha` re-added; UI CPU/memory defaults from `spec.profile` when `spec.ui.*.resources` unset |
+| [#48](https://github.com/project-koku/koku-service-operator/pull/48) | G4 (doc) | Earlier doc pass on `spec.profile` scope (superseded for UI by #65) |
 
 [#16](https://github.com/project-koku/koku-service-operator/pull/16) (G3 field-only) was superseded by #59 and closed without merge.
 
@@ -47,7 +48,7 @@ Out of scope per ticket: reconciler logic, resource builders.
 | App types + `dataRetentionMonths` | Done — default 4, range 1–60, wired to `RETAIN_NUM_MONTHS` |
 | Status: phase, conditions, DiscoveredConfig | Done with intentional phase rename |
 | `ComponentStatus` | Removed (intentional; conditions instead) |
-| `profiles.go`: enum + resource sizing maps | **Deferred** — enum + `standard` only ([#48](https://github.com/project-koku/koku-service-operator/pull/48)); maps → COST-7686/7687 |
+| `profiles.go`: enum + resource sizing maps | **Partial** — enum `standard`/`ha` ✅ ([#65](https://github.com/project-koku/koku-service-operator/pull/65)); UI defaults from profile ✅ ([#65](https://github.com/project-koku/koku-service-operator/pull/65)); shared maps for other workloads → COST-7686/7687 |
 | `defaults.go` mutating webhook | Done — noop defaulter; CRD OpenAPI defaults cover profile/monitoring/dataRetentionMonths |
 | `validation.go` webhook + CEL | Done — [#50](https://github.com/project-koku/koku-service-operator/pull/50)/[#51](https://github.com/project-koku/koku-service-operator/pull/51) CEL + [#52](https://github.com/project-koku/koku-service-operator/pull/52) validating webhook |
 | External-only infra (no type field) | Deviated — `deploy *bool` for DB/cache (dev/CI only) |
@@ -61,7 +62,8 @@ Implemented in [`api/v1alpha1/costmanagementserviceconfig_types.go`](../../api/v
 - Full Spec surface: `profile`, `global`, `database`, `cache`, `kafka`, `objectStorage`, `auth`, `rbac`, `costManagement`, `ros`, `kruize`, `ingress`, `ui`, `gatewayRoute`, `monitoring`
 - Status: `phase`, `conditions []metav1.Condition`, `discoveredConfig`, `observedGeneration`
 - Condition constants: `Available`, `Progressing`, `Degraded`, plus component conditions and extras `UIReady` / `ROSEnabled`
-- Profile enum `standard` only (`+kubebuilder:validation:Enum=standard`); `ha` removed until sizing maps ([#28](https://github.com/project-koku/koku-service-operator/pull/28))
+- Profile enum `standard` / `ha` with CRD default `standard` ([#65](https://github.com/project-koku/koku-service-operator/pull/65))
+- `spec.profile` applies UI oauth-proxy and app CPU/memory defaults when per-component `spec.ui.*.resources` are empty ([#65](https://github.com/project-koku/koku-service-operator/pull/65))
 - Exactly **13** `*bool` defaulted fields with `BoolVal` helper
 - `ComponentStatuses` removed — status uses `[]metav1.Condition` only
 - Phase enum: `Pending` / `Progressing` / `Ready` / `Degraded`
@@ -88,8 +90,7 @@ Documented in [design-vs-jira.md](../design/design-vs-jira.md) §1–3:
 | `credentialsSecretRef` | `secretName` / Kafka `sasl.existingSecret` | Simpler string refs |
 | `authentication.issuerUrl` required | `auth.keycloak.issuerURL` optional | JWKS `url` can be in-cluster HTTP |
 | External-only infra | `database.deploy` / `cache.deploy` default true | Dev/CI only; production is BYOI |
-| `profiles.go` sizing maps | Deferred to COST-7686/7687 | Beta ships `profile: standard` only ([BETA-PRIORITY.md](BETA-PRIORITY.md) T5) |
-| `profile` enum `ha` | Removed until maps exist ([#28](https://github.com/project-koku/koku-service-operator/pull/28)) | Avoid no-op API value |
+| `profiles.go` sizing maps | Partial UI wiring ([#65](https://github.com/project-koku/koku-service-operator/pull/65)); Celery/core maps deferred to COST-7686/7687 | JIRA names a single maps file; beta ships `profile: standard` for most workloads ([BETA-PRIORITY.md](BETA-PRIORITY.md) T5) |
 
 ---
 
@@ -117,9 +118,16 @@ Mutating + validating webhooks registered. Mutating `Default()` is intentionally
 
 Field, CRD default/range, reconciler `RETAIN_NUM_MONTHS` wiring, and zero-value guard.
 
-### G4. Profile resource sizing maps — deferred (not blocking 7678 closure)
+### G4. Profile resource sizing maps — partial; remainder deferred (not blocking 7678 closure)
 
-JIRA names `profiles.go` with sizing maps. **Deferred** to workload tickets:
+JIRA names `profiles.go` with sizing maps. **Delivered on `main`:**
+
+| Scope | Status | PR |
+|-------|--------|-----|
+| Enum `standard` / `ha` | Done | [#65](https://github.com/project-koku/koku-service-operator/pull/65) |
+| UI oauth-proxy + app resources from `spec.profile` when `spec.ui.*.resources` unset | Done | [#65](https://github.com/project-koku/koku-service-operator/pull/65) — [`uiProfileResources`](../../internal/resources/ui.go) |
+
+**Deferred** to workload tickets (shared maps + wiring beyond UI):
 
 | Follow-up | Owns |
 |-----------|------|
@@ -127,7 +135,7 @@ JIRA names `profiles.go` with sizing maps. **Deferred** to workload tickets:
 | [COST-7687](https://redhat.atlassian.net/browse/COST-7687) | Celery workers — sizing maps |
 | [COST-8054](https://redhat.atlassian.net/browse/COST-8054) | ROS/Kruize profile rows |
 
-Until then: use per-component `spec.*.resources`; `spec.profile` is accepted but not read by the reconciler ([#48](https://github.com/project-koku/koku-service-operator/pull/48)).
+Until full maps land: use per-component `spec.*.resources` for non-UI workloads; explicit UI `resources` still override profile defaults ([#65](https://github.com/project-koku/koku-service-operator/pull/65)).
 
 ---
 

--- a/docs/gap_analysis/COST-7678.md
+++ b/docs/gap_analysis/COST-7678.md
@@ -1,23 +1,32 @@
 # COST-7678 Gap Analysis: Define CostManagement CRD types
 
 **Jira:** [COST-7678](https://redhat.atlassian.net/browse/COST-7678)
-**Audited:** 2026-08-10
-**Purpose:** Handoff audit of CRD type surface vs ticket acceptance criteria. This document does not update `docs/tasks.md` or other trackers.
+**Audited:** 2026-08-10 · **Closed (docs):** 2026-08-16
+**Purpose:** Handoff audit of CRD type surface vs ticket acceptance criteria.
 **Beta scope:** ROS and Kruize are **out of beta** ([BETA-PRIORITY.md](BETA-PRIORITY.md)). Keeping `ros` / `kruize` Spec types and defaulted partition flags is fine; optional enablement and ROS/Kruize profile sizing → [COST-8054](../jira/COST-8054.md).
 
 ## Verdict
 
-Types are largely implemented and richer than the JIRA description, but COST-7678 is **not done**. Open ticket gaps: admission webhooks (G1), remaining CEL/OpenAPI validation (G2), and profile sizing maps (G4). `dataRetentionMonths` is on Spec with CRD default/Min/Max and wired to `RETAIN_NUM_MONTHS` (G3 closed). Related API security gaps (`RealmUser.Password`, raw `Env` maps) also remain in the type surface.
+**COST-7678 is done** for the CRD/API deliverables in scope. G1–G3 merged on `main`; intentional deviations documented below. **G4 (profile sizing maps)** is **deferred** — not a blocker for closing this ticket:
 
-**In-flight PRs (2026-08-13):**
+- `spec.profile` accepts only `standard` ([#48](https://github.com/project-koku/koku-service-operator/pull/48)); field is documented as not-yet-implemented.
+- Shared sizing maps and reconciler wiring → [COST-7686](https://redhat.atlassian.net/browse/COST-7686) / [COST-7687](https://redhat.atlassian.net/browse/COST-7687) and [BETA-PRIORITY.md](BETA-PRIORITY.md) item 21 (P2 post-beta).
+- ROS/Kruize profile rows → [COST-8054](../jira/COST-8054.md).
 
-| PR | Gap | Closes |
-|----|-----|--------|
-| [#50](https://github.com/project-koku/koku-service-operator/pull/50) | G2-a | Port min/max (database, cache, objectStorage); `database.sslMode` enum |
+Out of scope per ticket: reconciler logic, resource builders.
+
+**Merged PR series:**
+
+| PR | Gap | Delivered |
+|----|-----|-----------|
+| [#50](https://github.com/project-koku/koku-service-operator/pull/50) | G2-a | Port min/max; `database.sslMode` enum |
 | [#51](https://github.com/project-koku/koku-service-operator/pull/51) | G2-b | CEL: BYOI `deploy=false` → host/secret; Keycloak `issuerURL` https + non-empty `audiences` |
-| [#52](https://github.com/project-koku/koku-service-operator/pull/52) | G1 + G2-c | Admission webhooks scaffold; `requests ≤ limits` via validating webhook |
+| [#52](https://github.com/project-koku/koku-service-operator/pull/52) | G1 + G2-c | Admission webhooks; `requests ≤ limits` validating webhook |
+| [#59](https://github.com/project-koku/koku-service-operator/pull/59) | G3 | `dataRetentionMonths` → `RETAIN_NUM_MONTHS` + zero-value guard |
+| [#48](https://github.com/project-koku/koku-service-operator/pull/48) | G4 (doc) | `spec.profile` documented as not-yet-implemented |
+| [#28](https://github.com/project-koku/koku-service-operator/pull/28) | G4 | Removed `ha` from enum until sizing maps exist |
 
-G2-a in #50 does **not** close all of G2 — conditional BYOI rules (#51) and `requests ≤ limits` (#52 webhook) remain open until those PRs merge.
+[#16](https://github.com/project-koku/koku-service-operator/pull/16) (G3 field-only) was superseded by #59 and closed without merge.
 
 ## Sources
 
@@ -27,23 +36,21 @@ G2-a in #50 does **not** close all of G2 — conditional BYOI rules (#51) and `r
 - [config/crd/bases/service.costmanagement.openshift.io_costmanagementserviceconfigs.yaml](../../config/crd/bases/service.costmanagement.openshift.io_costmanagementserviceconfigs.yaml)
 - [docs/design/design-vs-jira.md](../design/design-vs-jira.md)
 
-Out of scope per ticket: reconciler logic, resource builders.
-
 ---
 
 ## Ticket acceptance criteria
 
 | Deliverable | Status |
 |-------------|--------|
-| Top-level Spec/Status types | Done (different kind/file name) |
+| Top-level Spec/Status types | Done (kind `CostManagementServiceConfig`) |
 | Infra types (DB, cache, Kafka, auth, object storage, monitoring) | Done (flat spec, not `spec.infra`) |
-| App types + `dataRetentionMonths` | Done — `spec.costManagement.dataRetentionMonths` (default 4, range 1–60) |
+| App types + `dataRetentionMonths` | Done — default 4, range 1–60, wired to `RETAIN_NUM_MONTHS` |
 | Status: phase, conditions, DiscoveredConfig | Done with intentional phase rename |
 | `ComponentStatus` | Removed (intentional; conditions instead) |
-| `profiles.go`: enum + resource sizing maps | Partial — enum only; **no sizing maps** |
-| `defaults.go` mutating webhook | **In progress** — [#52](https://github.com/project-koku/koku-service-operator/pull/52) (scaffold; `dataRetentionMonths` default deferred until #16) |
-| `validation.go` webhook + CEL | **Partial** — G2-a [#50](https://github.com/project-koku/koku-service-operator/pull/50), G2-b [#51](https://github.com/project-koku/koku-service-operator/pull/51), G2-c + G1 [#52](https://github.com/project-koku/koku-service-operator/pull/52) |
-| External-only infra (no type field) | Deviated — `deploy *bool` for DB/cache |
+| `profiles.go`: enum + resource sizing maps | **Deferred** — enum + `standard` only ([#48](https://github.com/project-koku/koku-service-operator/pull/48)); maps → COST-7686/7687 |
+| `defaults.go` mutating webhook | Done — noop defaulter; CRD OpenAPI defaults cover profile/monitoring/dataRetentionMonths |
+| `validation.go` webhook + CEL | Done — [#50](https://github.com/project-koku/koku-service-operator/pull/50)/[#51](https://github.com/project-koku/koku-service-operator/pull/51) CEL + [#52](https://github.com/project-koku/koku-service-operator/pull/52) validating webhook |
+| External-only infra (no type field) | Deviated — `deploy *bool` for DB/cache (dev/CI only) |
 
 ---
 
@@ -53,29 +60,18 @@ Implemented in [`api/v1alpha1/costmanagementserviceconfig_types.go`](../../api/v
 
 - Full Spec surface: `profile`, `global`, `database`, `cache`, `kafka`, `objectStorage`, `auth`, `rbac`, `costManagement`, `ros`, `kruize`, `ingress`, `ui`, `gatewayRoute`, `monitoring`
 - Status: `phase`, `conditions []metav1.Condition`, `discoveredConfig`, `observedGeneration`
-- Condition constants: `Available`, `Progressing`, `Degraded`, plus `DiscoveryComplete`, `DatabaseReady`, `CacheReady`, `StorageReady`, `KafkaReady`, `AuthenticationReady`, `SchemaUpToDate`, and extras `UIReady` / `ROSEnabled` (not in JIRA)
-- Profile enum `standard` / `ha` with CRD default `standard`
-- Exactly **13** `*bool` defaulted fields (`+kubebuilder:default:=true`) with `BoolVal` helper:
-  1. `ServiceAccountSpec.Create`
-  2. `DatabaseConfig.Deploy`
-  3. `CacheConfig.Deploy`
-  4. `ObjectStorageConfig.UseSSL`
-  5. `KruizePartitionsSpec.CreateEnabled`
-  6. `KruizePartitionsSpec.DeleteEnabled`
-  7. `ROSConfig.Enabled`
-  8. `ROSPartitionCleanerSpec.Enabled`
-  9. `CostManagementConfig.ScheduleReportChecks`
-  10. `KokuAPISpec.Enabled`
-  11. `MasuSpec.Enabled`
-  12. `ListenerSpec.Enabled`
-  13. `MonitoringConfig.Enabled`
+- Condition constants: `Available`, `Progressing`, `Degraded`, plus component conditions and extras `UIReady` / `ROSEnabled`
+- Profile enum `standard` only (`+kubebuilder:validation:Enum=standard`); `ha` removed until sizing maps ([#28](https://github.com/project-koku/koku-service-operator/pull/28))
+- Exactly **13** `*bool` defaulted fields with `BoolVal` helper
 - `ComponentStatuses` removed — status uses `[]metav1.Condition` only
 - Phase enum: `Pending` / `Progressing` / `Ready` / `Degraded`
-- Deep-copy + CRD generated under `config/crd/bases/service.costmanagement.openshift.io_costmanagementserviceconfigs.yaml`
-- Django secret-key charset fixed in [`internal/resources/secrets.go`](../../internal/resources/secrets.go) (not a CRD field; adjacent to ticket notes)
-- `spec.costManagement.dataRetentionMonths` (`int32`) with CRD OpenAPI `default: 4`, `minimum: 1`, `maximum: 60` — JIRA `spec.app.dataRetentionMonths` maps to the flat `costManagement` block; default aligned with Koku `RETAIN_NUM_MONTHS` (JIRA said 3)
+- Deep-copy + CRD generated under `config/crd/bases/`
+- `spec.costManagement.dataRetentionMonths` with CRD default/range + reconciler env wiring ([#59](https://github.com/project-koku/koku-service-operator/pull/59))
+- Admission webhooks in [`costmanagementserviceconfig_webhook.go`](../../api/v1alpha1/costmanagementserviceconfig_webhook.go) — mutating noop + validating `requests ≤ limits` ([#52](https://github.com/project-koku/koku-service-operator/pull/52))
+- CEL `XValidation` for BYOI and Keycloak ([#51](https://github.com/project-koku/koku-service-operator/pull/51)); port/sslMode OpenAPI ([#50](https://github.com/project-koku/koku-service-operator/pull/50))
+- `RealmUser.Password` removed from Spec — replaced by `rbac.bootstrapAdmin` + SecretRef (COST-7694 tracks rotation)
 
-Partial defaulting already exists via CRD OpenAPI defaults (`+kubebuilder:default`) for `spec.profile` → `standard`, `spec.monitoring.enabled` → `true`, and `spec.costManagement.dataRetentionMonths` → `4`.
+Defaulting via CRD OpenAPI: `spec.profile` → `standard`, `spec.monitoring.enabled` → `true`, `spec.costManagement.dataRetentionMonths` → `4`.
 
 ---
 
@@ -86,66 +82,62 @@ Documented in [design-vs-jira.md](../design/design-vs-jira.md) §1–3:
 | JIRA | Implementation | Rationale |
 |------|----------------|-----------|
 | Kind `CostManagement` | `CostManagementServiceConfig` (`cmsc`) | Naming settled for OLM/product |
-| 6-file split | Single `costmanagementserviceconfig_types.go` | Semantically identical; file not large enough |
-| Linear phases (`Discovering`…`Deploying`) | `Pending`/`Progressing`/`Ready`/`Degraded` + conditions | Conditions are the machine API |
+| 6-file split (`profiles.go`, `defaults.go`, …) | Single `costmanagementserviceconfig_types.go` + `costmanagementserviceconfig_webhook.go` | Semantically identical; file not large enough |
+| Linear phases | `Pending`/`Progressing`/`Ready`/`Degraded` + conditions | Conditions are the machine API |
 | `spec.infra.*` / `spec.app.*` | Flat top-level fields | Current API shape |
 | `credentialsSecretRef` | `secretName` / Kafka `sasl.existingSecret` | Simpler string refs |
-| `authentication.issuerUrl` | `auth.keycloak.issuerURL` (+ `url`) | Keycloak-nested auth model |
+| `authentication.issuerUrl` required | `auth.keycloak.issuerURL` optional | JWKS `url` can be in-cluster HTTP |
 | External-only infra | `database.deploy` / `cache.deploy` default true | Dev/CI only; production is BYOI |
-| `ComponentStatus` | `metav1.Condition` | Kubernetes convention |
+| `profiles.go` sizing maps | Deferred to COST-7686/7687 | Beta ships `profile: standard` only ([BETA-PRIORITY.md](BETA-PRIORITY.md) T5) |
+| `profile` enum `ha` | Removed until maps exist ([#28](https://github.com/project-koku/koku-service-operator/pull/28)) | Avoid no-op API value |
 
 ---
 
-## Remaining gaps (ticket-scoped)
+## Gap closure summary
 
-### G1. Admission webhooks — in progress ([#52](https://github.com/project-koku/koku-service-operator/pull/52))
+### G1. Admission webhooks — closed ([#52](https://github.com/project-koku/koku-service-operator/pull/52))
 
-[#52](https://github.com/project-koku/koku-service-operator/pull/52) adds `costmanagementserviceconfig_webhook.go`, `SetupWebhookWithManager` in `cmd/main.go`, and `config/webhook/` + cert-manager kustomize overlays. Mutating webhook is a scaffold (noop default) until G3 ([#16](https://github.com/project-koku/koku-service-operator/pull/16)) adds `dataRetentionMonths`.
+Mutating + validating webhooks registered. Mutating `Default()` is intentionally noop — CRD OpenAPI defaults cover `profile`, `monitoring.enabled`, and `dataRetentionMonths`. Validating webhook enforces `requests ≤ limits` across all component resource blocks.
 
-`internal/controller/validation.go` is **reconciler** connectivity/secret probing (COST-7684), not admission.
+`internal/controller/validation.go` is **reconciler** connectivity probing (COST-7684), not admission.
 
-| Default | CRD OpenAPI today | Webhook still needed? |
-|---------|-------------------|------------------------|
-| `spec.profile` → `standard` | Yes | No for this value |
-| `monitoring.enabled` → `true` | Yes (`spec.monitoring`, not `spec.infra.monitoring`) | No for this value |
-| `dataRetentionMonths` → `4` | Yes (`spec.costManagement.dataRetentionMonths`) | No for this value |
-
-### G2. CEL / OpenAPI validation — partial (G2-a [#50](https://github.com/project-koku/koku-service-operator/pull/50), G2-b [#51](https://github.com/project-koku/koku-service-operator/pull/51))
+### G2. CEL / OpenAPI validation — closed ([#50](https://github.com/project-koku/koku-service-operator/pull/50), [#51](https://github.com/project-koku/koku-service-operator/pull/51), [#52](https://github.com/project-koku/koku-service-operator/pull/52))
 
 | JIRA rule | Status |
 |-----------|--------|
-| Required: `database.host`, `database.credentialsSecretRef`, `cache.host`, `cache.credentialsSecretRef` | **G2-b [#51](https://github.com/project-koku/koku-service-operator/pull/51)** — CEL when `deploy=false` (`secretName` not `credentialsSecretRef`) |
-| Required: `kafka.bootstrapServers` | CRD-required today |
-| Required: `authentication.issuerUrl` | Not required; field is `auth.keycloak.issuerURL` optional |
-| `database.port` 1–65535 | **Done in [#50](https://github.com/project-koku/koku-service-operator/pull/50)** (cache + objectStorage ports too) |
-| `sslMode` ∈ disable/require/verify-ca/verify-full | **Done in [#50](https://github.com/project-koku/koku-service-operator/pull/50)** |
-| issuerUrl must be HTTPS | **G2-b [#51](https://github.com/project-koku/koku-service-operator/pull/51)** |
-| audiences non-empty | **G2-b [#51](https://github.com/project-koku/koku-service-operator/pull/51)** |
-| profile ∈ standard/ha | Done (Enum) |
-| `dataRetentionMonths` 1–60 | Done (OpenAPI Minimum/Maximum on `spec.costManagement.dataRetentionMonths`) |
-| requests ≤ limits | **G2-c [#52](https://github.com/project-koku/koku-service-operator/pull/52)** — validating webhook |
+| BYOI host + secret when `deploy=false` | Done — CEL [#51](https://github.com/project-koku/koku-service-operator/pull/51) |
+| `kafka.bootstrapServers` required | Done — CRD required |
+| `authentication.issuerUrl` required | Not required (deviation) |
+| Port 1–65535, `sslMode` enum | Done [#50](https://github.com/project-koku/koku-service-operator/pull/50) |
+| issuerURL HTTPS, audiences non-empty | Done [#51](https://github.com/project-koku/koku-service-operator/pull/51) |
+| `dataRetentionMonths` 1–60 | Done — OpenAPI + webhook path |
+| requests ≤ limits | Done [#52](https://github.com/project-koku/koku-service-operator/pull/52) |
 
-**Implication for BYOI:** validation must be conditional (`deploy == false` ⇒ host + secret required). That is webhook and/or CEL `XValidation`, not simple `required:`.
+### G3. `dataRetentionMonths` — closed ([#59](https://github.com/project-koku/koku-service-operator/pull/59))
 
-### G3. `dataRetentionMonths` — closed
+Field, CRD default/range, reconciler `RETAIN_NUM_MONTHS` wiring, and zero-value guard.
 
-Field added on `CostManagementConfig` as `spec.costManagement.dataRetentionMonths` with CRD default `4` (aligned with Koku `RETAIN_NUM_MONTHS`; JIRA said 3) and range 1–60. Reconciler wiring done: `KokuCommonEnv` emits `RETAIN_NUM_MONTHS` with a Go-level fallback to `4` when the CRD default has not been applied (e.g. CRD upgrade before CR re-save).
+### G4. Profile resource sizing maps — deferred (not blocking 7678 closure)
 
-### G4. Profile resource sizing maps — missing
+JIRA names `profiles.go` with sizing maps. **Deferred** to workload tickets:
 
-`Profile` enum exists; **no** sizing maps in `api/` or `internal/` keyed by profile. No Go code reads `cfg.Spec.Profile`. `docs/tasks.md` attributes profile-based sizing to COST-7686/7693, but COST-7678 explicitly asks for maps in `profiles.go`. Treat as an API-package deliverable still open for 7678, even if reconciler consumption is later.
+| Follow-up | Owns |
+|-----------|------|
+| [COST-7686](https://redhat.atlassian.net/browse/COST-7686) | Core app Deployments — profile sizing when wired |
+| [COST-7687](https://redhat.atlassian.net/browse/COST-7687) | Celery workers — sizing maps |
+| [COST-8054](https://redhat.atlassian.net/browse/COST-8054) | ROS/Kruize profile rows |
+
+Until then: use per-component `spec.*.resources`; `spec.profile` is accepted but not read by the reconciler ([#48](https://github.com/project-koku/koku-service-operator/pull/48)).
 
 ---
 
-## Related gaps (not in Jira body; same surface)
+## Related gaps (outside 7678 closure)
 
-### R1. API security gaps in types (design §4a/§4b; block beta/GA)
+### R1. API security — partial
 
-Not listed in the JIRA body, but they are part of the CRD type surface audited with this ticket:
-
-- `RealmUser.Password string` still in Spec (`api/v1alpha1/costmanagementserviceconfig_types.go`) — **P0** for beta ([BETA-PRIORITY.md](BETA-PRIORITY.md) T2); type comment points at COST-7694
-- `Env map[string]string` on Koku API / Masu / Listener — **P1** (tighten before GA; warn in beta docs)
+- `RealmUser.Password` in Spec — **resolved** (replaced by `bootstrapAdmin` + SecretRef)
+- `Env map[string]string` on Koku API / Masu / Listener — **P1** before GA; warn in beta docs
 
 ### R2. Stale wrong-group CRD YAML — resolved
 
-Deleted the leftover `costmanagement-service-cfg.openshift.io` CRD YAML. Canonical CRD remains `service.costmanagement.openshift.io_costmanagementserviceconfigs.yaml`.
+Canonical CRD: `service.costmanagement.openshift.io_costmanagementserviceconfigs.yaml`.

--- a/docs/tasks.md
+++ b/docs/tasks.md
@@ -14,7 +14,7 @@ Last audited: 2026-08-15.
 
 | Ticket | Summary | Status | Notes |
 |--------|---------|--------|-------|
-| [COST-7678](https://redhat.atlassian.net/browse/COST-7678) | Define CostManagement CRD types | 🔄 | `*bool` for 12 defaulted fields ✅, `metav1.Condition` replacing `ComponentStatuses` ✅, `DiscoveredConfig` in status ✅, `Profile` enum (standard only; `ha` removed until sizing maps are implemented) ✅, phase names fixed (Pending/Progressing/Ready/Degraded) ✅, Django key charset ✅. File split skipped intentionally (see design doc §3). Missing: webhooks (`defaults.go`, `validation.go`), **profile-based sizing** (`spec.profile` is accepted but not read by the reconciler — the Helm chart's 4 sizing overlays need operator equivalents; use per-component `resources` fields until then). |
+| [COST-7678](https://redhat.atlassian.net/browse/COST-7678) | Define CostManagement CRD types | ✅ | CRD types ✅, CEL + admission webhooks ([#50](https://github.com/project-koku/koku-service-operator/pull/50)/[#51](https://github.com/project-koku/koku-service-operator/pull/51)/[#52](https://github.com/project-koku/koku-service-operator/pull/52)) ✅, `dataRetentionMonths` wired ([#59](https://github.com/project-koku/koku-service-operator/pull/59)) ✅. **Profile sizing maps deferred** to COST-7686/7687 — `spec.profile` is `standard` only and not read by the reconciler until then ([#48](https://github.com/project-koku/koku-service-operator/pull/48)). See [gap analysis](gap_analysis/COST-7678.md). |
 | [COST-7679](https://redhat.atlassian.net/browse/COST-7679) | Create sample CRs and generate manifests | 🔄 | Bundled CR ✅, BYOI CR ✅, BYOI kustomize fixture ✅, CRD installs on CRC ✅. Missing: HA profile sample, CEL validation verified. |
 
 ## Reconciler Core
@@ -97,4 +97,3 @@ Short version: bundled infra is dev-only (intentional), profile-based sizing is 
 1. **[COST-7695](https://redhat.atlassian.net/browse/COST-7695)** — OLM bundle generation and validation
 2. **[COST-7694](https://redhat.atlassian.net/browse/COST-7694)** — Secret rotation trigger + `SecretRotated` Event
 3. **[COST-7696](https://redhat.atlassian.net/browse/COST-7696)** — CI bundle pipeline (needs COST-7695 first)
-4. **[COST-7678](https://redhat.atlassian.net/browse/COST-7678)** — Admission webhooks (defaults + validation)

--- a/docs/tasks.md
+++ b/docs/tasks.md
@@ -14,7 +14,7 @@ Last audited: 2026-08-15.
 
 | Ticket | Summary | Status | Notes |
 |--------|---------|--------|-------|
-| [COST-7678](https://redhat.atlassian.net/browse/COST-7678) | Define CostManagement CRD types | ✅ | CRD types ✅, CEL + admission webhooks ([#50](https://github.com/project-koku/koku-service-operator/pull/50)/[#51](https://github.com/project-koku/koku-service-operator/pull/51)/[#52](https://github.com/project-koku/koku-service-operator/pull/52)) ✅, `dataRetentionMonths` wired ([#59](https://github.com/project-koku/koku-service-operator/pull/59)) ✅. **Profile sizing maps deferred** to COST-7686/7687 — `spec.profile` is `standard` only and not read by the reconciler until then ([#48](https://github.com/project-koku/koku-service-operator/pull/48)). See [gap analysis](gap_analysis/COST-7678.md). |
+| [COST-7678](https://redhat.atlassian.net/browse/COST-7678) | Define CostManagement CRD types | ✅ | CRD types ✅, CEL + admission webhooks ([#50](https://github.com/project-koku/koku-service-operator/pull/50)/[#51](https://github.com/project-koku/koku-service-operator/pull/51)/[#52](https://github.com/project-koku/koku-service-operator/pull/52)) ✅, `dataRetentionMonths` wired ([#59](https://github.com/project-koku/koku-service-operator/pull/59)) ✅. **G4 partial:** enum `standard`/`ha` + UI profile defaults ([#65](https://github.com/project-koku/koku-service-operator/pull/65)) ✅; shared sizing maps for Celery/core workloads deferred to COST-7686/7687. See [gap analysis](gap_analysis/COST-7678.md). |
 | [COST-7679](https://redhat.atlassian.net/browse/COST-7679) | Create sample CRs and generate manifests | 🔄 | Bundled CR ✅, BYOI CR ✅, BYOI kustomize fixture ✅, CRD installs on CRC ✅. Missing: HA profile sample, CEL validation verified. |
 
 ## Reconciler Core


### PR DESCRIPTION
## Summary

- Update `docs/gap_analysis/COST-7678.md` — verdict **done**; G1–G3 closed via merged PRs (#50, #51, #52, #59, #48, #28); **G4 (profile sizing maps) explicitly deferred** to COST-7686/7687 and BETA-PRIORITY P2
- Update `docs/tasks.md` — COST-7678 → ✅; remove from Next Priority list

## Rationale (option B)

JIRA names `profiles.go` sizing maps, but the team already documents `spec.profile` as not-yet-implemented (#48) and beta ships `profile: standard` only. Reconciler wiring belongs in workload tickets, not the CRD-type ticket.

**Does not** change Jira — documentation closure only.

## Test plan

- [x] Doc-only change
- [ ] Reviewer agrees G4 deferral is acceptable for COST-7678 closure


Made with [Cursor](https://cursor.com)

## Summary by Sourcery

Close COST-7678 from a documentation perspective by marking CRD type work as complete, noting intentional deviations, and explicitly deferring profile sizing maps to follow-up tickets.

Documentation:
- Update the COST-7678 gap analysis to reflect merged webhook and validation work, `dataRetentionMonths` wiring, security changes, and the deferral of profile sizing maps to COST-7686/7687.
- Update the tasks overview to mark COST-7678 as complete, point to the gap analysis for details, and describe profile sizing as deferred rather than an open item.