### PR TITLE
COST-7690: apply profile-based UI resource sizing

### DIFF
--- a/api/v1alpha1/costmanagementserviceconfig_types.go
+++ b/api/v1alpha1/costmanagementserviceconfig_types.go
@@ -37,22 +37,17 @@ const (
 // Profile
 // -----------------------------------------------------------------------------
 
-// Profile selects a pre-defined resource sizing tier for all components.
-//
-// NOT YET IMPLEMENTED — the field is accepted but not read by the reconciler.
-// Profile-based sizing (mapping profile values to per-component resource
-// defaults) is tracked in COST-7678. The Helm chart ships four sizing
-// overlays (small/medium/large/xlarge in values-*.yaml); the operator
-// equivalent will apply similar defaults when this field is wired.
-//
-// Until then, use per-component spec.*.resources fields directly.
-// Only "standard" is accepted; "ha" was removed to avoid a no-op API.
-// +kubebuilder:validation:Enum=standard
+// Profile selects a pre-defined resource sizing tier.
+// UI applies these defaults when spec.ui.*.resources are unset; other
+// workloads still use per-component spec.*.resources (COST-7678).
+// +kubebuilder:validation:Enum=standard;ha
 type Profile string
 
 const (
-	// ProfileStandard is the default sizing tier. No sizing map is applied yet.
+	// ProfileStandard is the default sizing tier (chart-equivalent UI footprint).
 	ProfileStandard Profile = "standard"
+	// ProfileHA raises UI CPU/memory defaults for a redundant footprint.
+	ProfileHA Profile = "ha"
 )
 
 // -----------------------------------------------------------------------------
@@ -593,8 +588,6 @@ type MonitoringConfig struct {
 
 type CostManagementServiceConfigSpec struct {
 	// Profile selects pre-defined resource sizing. Defaults to standard.
-	// NOT YET IMPLEMENTED — accepted but not read by the reconciler (COST-7678).
-	// Use per-component resources fields until profile sizing is wired.
 	// +kubebuilder:default:=standard
 	Profile        Profile              `json:"profile,omitempty"`
 	Global         GlobalConfig         `json:"global,omitempty"`

--- a/api/v1alpha1/costmanagementserviceconfig_types.go
+++ b/api/v1alpha1/costmanagementserviceconfig_types.go
@@ -38,8 +38,7 @@ const (
 // -----------------------------------------------------------------------------
 
 // Profile selects a pre-defined resource sizing tier.
-// UI applies these defaults when spec.ui.*.resources are unset; other
-// workloads still use per-component spec.*.resources (COST-7678).
+// Currently applies to UI containers only; other workloads use per-component spec.*.resources fields.
 // +kubebuilder:validation:Enum=standard;ha
 type Profile string
 
@@ -587,7 +586,8 @@ type MonitoringConfig struct {
 // -----------------------------------------------------------------------------
 
 type CostManagementServiceConfigSpec struct {
-	// Profile selects pre-defined resource sizing. Defaults to standard.
+	// Profile selects a pre-defined resource sizing tier.
+	// Currently applies to UI containers only; other workloads use per-component spec.*.resources fields.
 	// +kubebuilder:default:=standard
 	Profile        Profile              `json:"profile,omitempty"`
 	Global         GlobalConfig         `json:"global,omitempty"`

--- a/config/crd/bases/service.costmanagement.openshift.io_costmanagementserviceconfigs.yaml
+++ b/config/crd/bases/service.costmanagement.openshift.io_costmanagementserviceconfigs.yaml
@@ -1863,12 +1863,11 @@ spec:
                 type: object
               profile:
                 default: standard
-                description: |-
-                  Profile selects pre-defined resource sizing. Defaults to standard.
-                  NOT YET IMPLEMENTED — accepted but not read by the reconciler (COST-7678).
-                  Use per-component resources fields until profile sizing is wired.
+                description: Profile selects pre-defined resource sizing. Defaults
+                  to standard.
                 enum:
                 - standard
+                - ha
                 type: string
               rbac:
                 properties:

--- a/config/crd/bases/service.costmanagement.openshift.io_costmanagementserviceconfigs.yaml
+++ b/config/crd/bases/service.costmanagement.openshift.io_costmanagementserviceconfigs.yaml
@@ -1863,8 +1863,9 @@ spec:
                 type: object
               profile:
                 default: standard
-                description: Profile selects pre-defined resource sizing. Defaults
-                  to standard.
+                description: |-
+                  Profile selects a pre-defined resource sizing tier.
+                  Currently applies to UI containers only; other workloads use per-component spec.*.resources fields.
                 enum:
                 - standard
                 - ha

--- a/docs/gap_analysis/COST-7690.md
+++ b/docs/gap_analysis/COST-7690.md
@@ -1,13 +1,13 @@
 # COST-7690 Gap Analysis: Implement UI and ConsoleLink
 
 **Jira:** [COST-7690](https://redhat.atlassian.net/browse/COST-7690)
-**Audited:** 2026-08-10
+**Audited:** 2026-08-16
 **Purpose:** Handoff audit vs ticket acceptance criteria. Does not update `docs/tasks.md` or other trackers.
 **Beta scope:** ROS and Kruize are **out of beta** ([BETA-PRIORITY.md](BETA-PRIORITY.md)); optional install → [COST-8054](../jira/COST-8054.md). `reconcileDelete` ordering that cleans Kruize cluster RBAC after ConsoleLink is incidental ownership hygiene, not a Cost beta deliverable for Kruize. Nginx aliases under `/costManagementRos/` in `UINginxConfigMap` are UI static paths only.
 
 ## Verdict
 
-UI Deployment (oauth2-proxy sidecar + nginx), ClusterIP Service with service-CA TLS, operator-managed cookie Secret / nginx ConfigMap, and cluster-scoped ConsoleLink with finalizer cleanup are implemented under Edge (`reconcileUI`). COST-7690 is **not fully done**: the ticket’s **profile-based resource sizing** acceptance criterion is missing — `spec.profile` is unused and UI resources use hardcoded defaults (or per-component CR overrides only).
+UI Deployment (oauth2-proxy sidecar + nginx), ClusterIP Service with service-CA TLS, operator-managed cookie Secret / nginx ConfigMap, and cluster-scoped ConsoleLink with finalizer cleanup are implemented under Edge (`reconcileUI`). COST-7690 ticket AC is **done**, including profile-based UI resource sizing (`spec.profile` `standard` / `ha`). Other workloads still ignore `spec.profile` (COST-7678 G4).
 
 ## Sources
 
@@ -31,7 +31,7 @@ Out of scope per ticket: Routes (separate story — COST-7691).
 | UI Deployment with OAuth2 Proxy sidecar | Done |
 | ClusterIP Service for the UI | Done (Type implicit ClusterIP; service-CA annotation present) |
 | Cluster-scoped ConsoleLink with finalizer cleanup on CR deletion | Done |
-| Profile-based resource sizing | **Missing** |
+| Profile-based resource sizing | Done (UI only) |
 | Routes | Out of scope — note: `UIRoute` already applied in `reconcileUI` when domain is known |
 
 ---
@@ -88,20 +88,9 @@ Built in [`UIDeployment`](../../internal/resources/ui.go) (~L145–303), applied
 
 ## Remaining gaps (ticket-scoped)
 
-### G1. Profile-based resource sizing — missing
+### G1. Profile-based resource sizing — closed
 
-Ticket AC requires profile-based sizing. `Profile` enum (`standard` / `ha`) exists on the CR ([`types.go`](../../api/v1alpha1/costmanagementserviceconfig_types.go) ~L38–48, `spec.profile` ~L580–582), but **no Go code reads `cfg.Spec.Profile`** for UI (or any workload).
-
-UI fallbacks when `Resources.Limits == nil` are fixed constants in [`UIDeployment`](../../internal/resources/ui.go) (~L164–177):
-
-| Container | Requests | Limits |
-|-----------|----------|--------|
-| oauth-proxy | 50m / 64Mi | 100m / 128Mi |
-| app (nginx) | 50m / 64Mi | 100m / 128Mi |
-
-`replicaCount` defaults to `1` when unset (~L150–153). Per-component overrides (`spec.ui.oauthProxy.resources`, `spec.ui.app.resources`, `spec.ui.replicaCount`) exist, but nothing keys replicas/resources off `standard` vs `ha`. Cross-ticket: same gap tracked under COST-7678 (sizing maps G4) and attributed to COST-7686/7693 in `docs/tasks.md`.
-
-**Impact:** HA profile does not change UI footprint; ticket AC unmet.
+[`UIDeployment`](../../internal/resources/ui.go) reads `cfg.Spec.Profile` via `uiProfileResources`. `standard`/unset keep 50m/64Mi request and 100m/128Mi limit; `ha` uses 100m/128Mi and 200m/256Mi. Per-component `spec.ui.*.resources` win when set. Other workloads still ignore `spec.profile` (COST-7678 G4 / COST-7686 / COST-7693).
 
 ---
 

--- a/internal/resources/ui.go
+++ b/internal/resources/ui.go
@@ -142,6 +142,25 @@ location = /logout {
 	}
 }
 
+func uiProfileResources(profile costv1alpha1.Profile) corev1.ResourceRequirements {
+	if profile == costv1alpha1.ProfileHA {
+		return corev1.ResourceRequirements{
+			Requests: corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("100m"), corev1.ResourceMemory: resource.MustParse("128Mi")},
+			Limits:   corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("200m"), corev1.ResourceMemory: resource.MustParse("256Mi")},
+		}
+	}
+	if profile == costv1alpha1.ProfileStandard {
+		return corev1.ResourceRequirements{
+			Requests: corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("50m"), corev1.ResourceMemory: resource.MustParse("64Mi")},
+			Limits:   corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("100m"), corev1.ResourceMemory: resource.MustParse("128Mi")},
+		}
+	}
+	return corev1.ResourceRequirements{
+		Requests: corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("50m"), corev1.ResourceMemory: resource.MustParse("64Mi")},
+		Limits:   corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("100m"), corev1.ResourceMemory: resource.MustParse("128Mi")},
+	}
+}
+
 // UIDeployment builds the UI Deployment with the oauth2-proxy sidecar and nginx app.
 func UIDeployment(cfg *costv1alpha1.CostManagementServiceConfig) *appsv1.Deployment {
 	spec := cfg.Spec.UI
@@ -163,17 +182,11 @@ func UIDeployment(cfg *costv1alpha1.CostManagementServiceConfig) *appsv1.Deploym
 
 	proxyResources := spec.OAuthProxy.Resources
 	if proxyResources.Limits == nil {
-		proxyResources = corev1.ResourceRequirements{
-			Requests: corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("50m"), corev1.ResourceMemory: resource.MustParse("64Mi")},
-			Limits:   corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("100m"), corev1.ResourceMemory: resource.MustParse("128Mi")},
-		}
+		proxyResources = uiProfileResources(cfg.Spec.Profile)
 	}
 	appResources := spec.App.Resources
 	if appResources.Limits == nil {
-		appResources = corev1.ResourceRequirements{
-			Requests: corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("50m"), corev1.ResourceMemory: resource.MustParse("64Mi")},
-			Limits:   corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("100m"), corev1.ResourceMemory: resource.MustParse("128Mi")},
-		}
+		appResources = uiProfileResources(cfg.Spec.Profile)
 	}
 
 	proxyArgs := []string{

--- a/internal/resources/ui.go
+++ b/internal/resources/ui.go
@@ -143,21 +143,19 @@ location = /logout {
 }
 
 func uiProfileResources(profile costv1alpha1.Profile) corev1.ResourceRequirements {
-	if profile == costv1alpha1.ProfileHA {
+	switch profile {
+	case costv1alpha1.ProfileHA:
 		return corev1.ResourceRequirements{
 			Requests: corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("100m"), corev1.ResourceMemory: resource.MustParse("128Mi")},
 			Limits:   corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("200m"), corev1.ResourceMemory: resource.MustParse("256Mi")},
 		}
-	}
-	if profile == costv1alpha1.ProfileStandard {
+	case costv1alpha1.ProfileStandard:
+		fallthrough
+	default: // unset
 		return corev1.ResourceRequirements{
 			Requests: corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("50m"), corev1.ResourceMemory: resource.MustParse("64Mi")},
 			Limits:   corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("100m"), corev1.ResourceMemory: resource.MustParse("128Mi")},
 		}
-	}
-	return corev1.ResourceRequirements{
-		Requests: corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("50m"), corev1.ResourceMemory: resource.MustParse("64Mi")},
-		Limits:   corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("100m"), corev1.ResourceMemory: resource.MustParse("128Mi")},
 	}
 }
 

--- a/internal/resources/ui.go
+++ b/internal/resources/ui.go
@@ -181,11 +181,11 @@ func UIDeployment(cfg *costv1alpha1.CostManagementServiceConfig) *appsv1.Deploym
 	appImage := spec.App.Image.Repository + ":" + spec.App.Image.Tag
 
 	proxyResources := spec.OAuthProxy.Resources
-	if proxyResources.Limits == nil {
+	if len(proxyResources.Requests) == 0 && len(proxyResources.Limits) == 0 {
 		proxyResources = uiProfileResources(cfg.Spec.Profile)
 	}
 	appResources := spec.App.Resources
-	if appResources.Limits == nil {
+	if len(appResources.Requests) == 0 && len(appResources.Limits) == 0 {
 		appResources = uiProfileResources(cfg.Spec.Profile)
 	}
 

--- a/internal/resources/ui_test.go
+++ b/internal/resources/ui_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	costv1alpha1 "github.com/project-koku/koku-service-operator/api/v1alpha1"
@@ -140,6 +141,62 @@ func TestValidateUIOAuthClientSecret(t *testing.T) {
 	}
 	if err := ValidateUIOAuthClientSecret(ok); err != nil {
 		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestUIDeploymentProfileResources(t *testing.T) {
+	tests := []struct {
+		name       string
+		profile    costv1alpha1.Profile
+		wantCPUReq string
+		wantMemReq string
+		wantCPULim string
+		wantMemLim string
+	}{
+		{"unset", "", "50m", "64Mi", "100m", "128Mi"},
+		{"standard", costv1alpha1.ProfileStandard, "50m", "64Mi", "100m", "128Mi"},
+		{"ha", costv1alpha1.ProfileHA, "100m", "128Mi", "200m", "256Mi"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := uiTestCfg()
+			cfg.Spec.Profile = tt.profile
+			dep := UIDeployment(cfg)
+			for _, name := range []string{"oauth-proxy", "app"} {
+				c := containerByName(t, dep.Spec.Template.Spec.Containers, name)
+				assertQuantity(t, name+" cpu request", c.Resources.Requests[corev1.ResourceCPU], tt.wantCPUReq)
+				assertQuantity(t, name+" memory request", c.Resources.Requests[corev1.ResourceMemory], tt.wantMemReq)
+				assertQuantity(t, name+" cpu limit", c.Resources.Limits[corev1.ResourceCPU], tt.wantCPULim)
+				assertQuantity(t, name+" memory limit", c.Resources.Limits[corev1.ResourceMemory], tt.wantMemLim)
+			}
+		})
+	}
+}
+
+func TestUIDeploymentHonorsResourceOverrides(t *testing.T) {
+	cfg := uiTestCfg()
+	cfg.Spec.Profile = costv1alpha1.ProfileHA
+	cfg.Spec.UI.OAuthProxy.Resources = corev1.ResourceRequirements{
+		Requests: corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("200m"), corev1.ResourceMemory: resource.MustParse("256Mi")},
+		Limits:   corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("300m"), corev1.ResourceMemory: resource.MustParse("512Mi")},
+	}
+	cfg.Spec.UI.App.Resources = corev1.ResourceRequirements{
+		Requests: corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("10m"), corev1.ResourceMemory: resource.MustParse("32Mi")},
+		Limits:   corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("20m"), corev1.ResourceMemory: resource.MustParse("64Mi")},
+	}
+	dep := UIDeployment(cfg)
+	proxy := containerByName(t, dep.Spec.Template.Spec.Containers, "oauth-proxy")
+	assertQuantity(t, "oauth-proxy cpu request", proxy.Resources.Requests[corev1.ResourceCPU], "200m")
+	assertQuantity(t, "oauth-proxy cpu limit", proxy.Resources.Limits[corev1.ResourceCPU], "300m")
+	app := containerByName(t, dep.Spec.Template.Spec.Containers, "app")
+	assertQuantity(t, "app cpu request", app.Resources.Requests[corev1.ResourceCPU], "10m")
+	assertQuantity(t, "app cpu limit", app.Resources.Limits[corev1.ResourceCPU], "20m")
+}
+
+func assertQuantity(t *testing.T, label string, got resource.Quantity, want string) {
+	t.Helper()
+	if got.Cmp(resource.MustParse(want)) != 0 {
+		t.Errorf("%s = %s, want %s", label, got.String(), want)
 	}
 }
 

--- a/internal/resources/ui_test.go
+++ b/internal/resources/ui_test.go
@@ -193,6 +193,21 @@ func TestUIDeploymentHonorsResourceOverrides(t *testing.T) {
 	assertQuantity(t, "app cpu limit", app.Resources.Limits[corev1.ResourceCPU], "20m")
 }
 
+func TestUIDeploymentHonorsRequestsOnlyOverride(t *testing.T) {
+	cfg := uiTestCfg()
+	cfg.Spec.Profile = costv1alpha1.ProfileHA
+	cfg.Spec.UI.OAuthProxy.Resources = corev1.ResourceRequirements{
+		Requests: corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("200m"), corev1.ResourceMemory: resource.MustParse("256Mi")},
+	}
+	dep := UIDeployment(cfg)
+	proxy := containerByName(t, dep.Spec.Template.Spec.Containers, "oauth-proxy")
+	assertQuantity(t, "oauth-proxy cpu request", proxy.Resources.Requests[corev1.ResourceCPU], "200m")
+	assertQuantity(t, "oauth-proxy memory request", proxy.Resources.Requests[corev1.ResourceMemory], "256Mi")
+	if len(proxy.Resources.Limits) != 0 {
+		t.Errorf("oauth-proxy limits = %v, want empty (do not fill profile limits)", proxy.Resources.Limits)
+	}
+}
+
 func assertQuantity(t *testing.T, label string, got resource.Quantity, want string) {
 	t.Helper()
 	if got.Cmp(resource.MustParse(want)) != 0 {


### PR DESCRIPTION
## Summary
- Re-add `ha` to `spec.profile` and apply it to UI CPU/memory defaults when `spec.ui.*.resources` are unset.
- Per-component resource overrides still win.

## Test plan
- [x] `go test ./internal/resources/`
- [ ] Confirm `profile: ha` raises UI oauth-proxy and app requests/limits vs `standard`


Made with [Cursor](https://cursor.com)

## Summary by Sourcery

Apply profile-based resource sizing to UI deployments and reintroduce the `ha` profile option.

New Features:
- Enable profile-based default CPU and memory sizing for UI oauth-proxy and app containers based on the CostManagementServiceConfig profile.
- Reintroduce the `ha` profile option to provide a higher-resource UI footprint alongside the existing `standard` profile.

Enhancements:
- Refactor UI deployment resource selection into a shared helper to centralize profile defaults.

Documentation:
- Update API type and CRD documentation to describe active profile-based sizing and the available `standard` and `ha` profiles.

Tests:
- Add tests to verify UI resource defaults for each profile and ensure explicit per-component resource overrides take precedence over profile defaults.