### PR TITLE
docs: add worktree setup instructions to CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -42,10 +42,10 @@ etcd + kube-apiserver binaries needed by the controller integration tests
 
 The `bin/` directory (controller-gen, setup-envtest, kustomize, envtest
 binaries under `bin/k8s/`) is gitignored and not present in worktrees.
-After creating a worktree, symlink it from the main checkout:
+After creating a worktree, symlink `bin/` from the main checkout:
 
 ```bash
-ln -s "$(git rev-parse --show-toplevel)/bin" <worktree>/bin
+ln -s <main-checkout>/bin <worktree>/bin
 ```
 
 ## Production design target

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -38,6 +38,16 @@ etcd + kube-apiserver binaries needed by the controller integration tests
 (envtest). Without these, `internal/controller` tests fail with
 "no such file or directory: etcd".
 
+### Worktree setup
+
+The `bin/` directory (controller-gen, setup-envtest, kustomize, envtest
+binaries under `bin/k8s/`) is gitignored and not present in worktrees.
+After creating a worktree, symlink it from the main checkout:
+
+```bash
+ln -s "$(git rev-parse --show-toplevel)/bin" <worktree>/bin
+```
+
 ## Production design target
 
 **All infrastructure is external (BYOI).** In production, PostgreSQL, Kafka,


### PR DESCRIPTION
## Summary

- Document the `bin/` symlink step needed after creating a git worktree
- Without this, `make test` fails (missing envtest binaries) and `make manifests`/`make generate` fail (missing controller-gen)

## Test plan

- [ ] Verify CLAUDE.md renders correctly on GitHub

## Summary by Sourcery

Documentation:
- Add instructions for symlinking the bin/ directory when using git worktrees so local development commands work correctly.