### PR TITLE
test: cover core/edge/UI stages and gate internal coverage at 85%

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -102,12 +102,22 @@ jobs:
       - name: Run tests (unit + envtest integration)
         run: make test
 
+      - name: Coverage gate (internal packages)
+        run: make coverage-gate
+
       - name: Coverage summary
         run: |
           echo '### Test Coverage' >> $GITHUB_STEP_SUMMARY
           echo '```' >> $GITHUB_STEP_SUMMARY
           go tool cover -func=cover.out | grep -E 'total:|\.go:' >> $GITHUB_STEP_SUMMARY
           echo '```' >> $GITHUB_STEP_SUMMARY
+          if [ -f cover.internal.out ]; then
+            echo '' >> $GITHUB_STEP_SUMMARY
+            echo '### Internal coverage (gate)' >> $GITHUB_STEP_SUMMARY
+            echo '```' >> $GITHUB_STEP_SUMMARY
+            go tool cover -func=cover.internal.out | grep '^total:' >> $GITHUB_STEP_SUMMARY
+            echo '```' >> $GITHUB_STEP_SUMMARY
+          fi
 
   check-generated:
     name: Check Generated Code

--- a/Makefile
+++ b/Makefile
@@ -114,6 +114,23 @@ vet: ## Run go vet against code.
 test: manifests generate fmt vet setup-envtest ## Run tests.
 	KUBEBUILDER_ASSETS="$(shell $(ENVTEST) use $(ENVTEST_K8S_VERSION) --bin-dir $(LOCALBIN) -p path)" go test $$(go list ./... | grep -v /e2e) -coverprofile cover.out
 
+# Statement coverage across internal/controller + internal/resources (coverpkg),
+# not make test's per-package cover.out. Override: make coverage-gate COVERAGE_MIN=84.0
+COVERAGE_PKG ?= ./internal/...
+COVERAGE_MIN ?= 85.0
+
+.PHONY: coverage-gate
+coverage-gate: setup-envtest ## Fail if ./internal/... statement coverage is below COVERAGE_MIN.
+	KUBEBUILDER_ASSETS="$(shell $(ENVTEST) use $(ENVTEST_K8S_VERSION) --bin-dir $(LOCALBIN) -p path)" go test $(COVERAGE_PKG) -coverprofile cover.internal.out -coverpkg=$(COVERAGE_PKG)
+	@go tool cover -func=cover.internal.out | awk -v min="$(COVERAGE_MIN)" '\
+	  /^total:/ {\
+	    found=1;\
+	    pct=$$NF; gsub(/%/,"",pct);\
+	    if (pct+0 < min+0) { printf "FAIL: internal coverage %.1f%% is below minimum %.1f%%\n", pct, min; exit 1 }\
+	    printf "OK: internal coverage %.1f%% (minimum %.1f%%)\n", pct, min\
+	  }\
+	  END { if (!found) { print "FAIL: no total coverage line in cover.internal.out"; exit 1 } }'
+
 # TODO(user): To use a different vendor for e2e tests, modify the setup under 'tests/e2e'.
 # The default setup assumes Kind is pre-installed and builds/loads the Manager Docker image locally.
 # CertManager is installed by default; skip with:

--- a/internal/controller/apply_statefulset_test.go
+++ b/internal/controller/apply_statefulset_test.go
@@ -1,0 +1,92 @@
+package controller
+
+import (
+	"context"
+	"testing"
+
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+
+	costv1alpha1 "github.com/project-koku/koku-service-operator/api/v1alpha1"
+	"github.com/project-koku/koku-service-operator/internal/resources"
+)
+
+func TestReconcileInfrastructure_ApplyStatefulSetCreate(t *testing.T) {
+	scheme := ownershipScheme(t)
+	cfg := minimalCR(testCRName, testNamespace)
+	cfg.Spec.Cache.Deploy = boolPtr(false)
+	// Database.Deploy defaults true → applyStatefulSet create path.
+
+	r := &CostManagementServiceConfigReconciler{
+		Client:   fakeClientWithApplySupport(scheme),
+		Scheme:   scheme,
+		Recorder: &noopRecorder{},
+	}
+
+	result, err := r.reconcileInfrastructure(context.Background(), cfg)
+	if err != nil {
+		t.Fatalf("reconcileInfrastructure: %v", err)
+	}
+	if result.RequeueAfter == 0 {
+		t.Fatal("expected requeue while StatefulSet is not ready")
+	}
+
+	mustExist(t, r.Client, testNamespace, resources.NameDatabase(cfg), &corev1.Service{})
+	sts := &appsv1.StatefulSet{}
+	mustExist(t, r.Client, testNamespace, resources.NameDatabase(cfg), sts)
+
+	cond := findCondition(cfg.Status.Conditions, costv1alpha1.ConditionDatabaseReady)
+	if cond == nil || cond.Status != metav1.ConditionFalse || cond.Reason != "WaitingForDatabase" {
+		t.Fatalf("expected DatabaseReady=False WaitingForDatabase, got %+v", cond)
+	}
+}
+
+func TestApplyStatefulSet_UpdatePreservesVolumeClaimTemplates(t *testing.T) {
+	scheme := ownershipScheme(t)
+	cfg := minimalCR(testCRName, testNamespace)
+
+	existing := resources.DatabaseStatefulSet(cfg)
+	existing.Spec.Template.Spec.Containers[0].Image = "postgres:old"
+	existing.Spec.VolumeClaimTemplates[0].Spec.Resources.Requests[corev1.ResourceStorage] = resource.MustParse("10Gi")
+	replicas := int32(1)
+	existing.Spec.Replicas = &replicas
+
+	r := &CostManagementServiceConfigReconciler{
+		Client:   fakeClientWithApplySupport(scheme, existing),
+		Scheme:   scheme,
+		Recorder: &noopRecorder{},
+	}
+
+	desired := resources.DatabaseStatefulSet(cfg)
+	desired.Spec.Template.Spec.Containers[0].Image = "postgres:new"
+	wantReplicas := int32(2)
+	desired.Spec.Replicas = &wantReplicas
+	// Attempt to change VCT size — applyStatefulSet must ignore this.
+	desired.Spec.VolumeClaimTemplates[0].Spec.Resources.Requests[corev1.ResourceStorage] = resource.MustParse("99Gi")
+
+	if err := r.applyStatefulSet(context.Background(), cfg, desired); err != nil {
+		t.Fatalf("applyStatefulSet: %v", err)
+	}
+
+	got := &appsv1.StatefulSet{}
+	if err := r.Get(context.Background(), types.NamespacedName{
+		Namespace: testNamespace,
+		Name:      resources.NameDatabase(cfg),
+	}, got); err != nil {
+		t.Fatalf("Get StatefulSet: %v", err)
+	}
+
+	if got.Spec.Template.Spec.Containers[0].Image != "postgres:new" {
+		t.Errorf("image not updated: got %q", got.Spec.Template.Spec.Containers[0].Image)
+	}
+	if got.Spec.Replicas == nil || *got.Spec.Replicas != 2 {
+		t.Errorf("replicas not updated: got %v", got.Spec.Replicas)
+	}
+	size := got.Spec.VolumeClaimTemplates[0].Spec.Resources.Requests[corev1.ResourceStorage]
+	if !size.Equal(resource.MustParse("10Gi")) {
+		t.Errorf("VolumeClaimTemplates must be immutable; got size %s want 10Gi", size.String())
+	}
+}

--- a/internal/controller/core_services_test.go
+++ b/internal/controller/core_services_test.go
@@ -1,0 +1,140 @@
+package controller
+
+import (
+	"context"
+	"testing"
+
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	apimeta "k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	costv1alpha1 "github.com/project-koku/koku-service-operator/api/v1alpha1"
+	"github.com/project-koku/koku-service-operator/internal/resources"
+)
+
+func TestReconcileCoreServices_ROSOff_APINotReady(t *testing.T) {
+	scheme := ownershipScheme(t)
+	cfg := minimalCR(testCRName, testNamespace)
+	r := &CostManagementServiceConfigReconciler{
+		Client:   fakeClientWithApplySupport(scheme),
+		Scheme:   scheme,
+		Recorder: &noopRecorder{},
+	}
+
+	result, err := r.reconcileCoreServices(context.Background(), cfg)
+	if err != nil {
+		t.Fatalf("reconcileCoreServices: %v", err)
+	}
+	if result.RequeueAfter == 0 {
+		t.Fatal("expected non-zero RequeueAfter while API is not ready")
+	}
+
+	mustExist(t, r.Client, testNamespace, resources.NameRBACAPI(cfg), &appsv1.Deployment{})
+	mustExist(t, r.Client, testNamespace, resources.NameRBACAPI(cfg), &corev1.Service{})
+	mustExist(t, r.Client, testNamespace, resources.NameRBACWorker(cfg), &appsv1.Deployment{})
+	mustExist(t, r.Client, testNamespace, resources.NameKokuAPI(cfg), &appsv1.Deployment{})
+	mustExist(t, r.Client, testNamespace, resources.NameKokuAPI(cfg), &corev1.Service{})
+	mustExist(t, r.Client, testNamespace, resources.NameMasu(cfg), &appsv1.Deployment{})
+	mustExist(t, r.Client, testNamespace, resources.NameMasu(cfg), &corev1.Service{})
+	mustExist(t, r.Client, testNamespace, resources.NameListener(cfg), &appsv1.Deployment{})
+
+	mustNotExist(t, r.Client, testNamespace, resources.NameKruize(cfg), &appsv1.Deployment{})
+	mustNotExist(t, r.Client, "", resources.NameKruizeClusterRole(cfg), &rbacv1.ClusterRole{})
+
+	cond := findCondition(cfg.Status.Conditions, costv1alpha1.ConditionAvailable)
+	if cond == nil || cond.Status != metav1.ConditionFalse || cond.Reason != "WaitingForAPI" {
+		t.Fatalf("expected Available=False WaitingForAPI, got %+v", cond)
+	}
+}
+
+func TestReconcileCoreServices_ROSOn_APINotReady(t *testing.T) {
+	scheme := ownershipScheme(t)
+	cfg := minimalCR(testCRName, testNamespace)
+	cfg.Spec.ROS.Enabled = boolPtr(true)
+
+	r := &CostManagementServiceConfigReconciler{
+		Client:   fakeClientWithApplySupport(scheme),
+		Scheme:   scheme,
+		Recorder: &noopRecorder{},
+	}
+
+	result, err := r.reconcileCoreServices(context.Background(), cfg)
+	if err != nil {
+		t.Fatalf("reconcileCoreServices: %v", err)
+	}
+	if result.RequeueAfter == 0 {
+		t.Fatal("expected non-zero RequeueAfter while API is not ready")
+	}
+
+	mustExist(t, r.Client, testNamespace, resources.NameKruizeServiceAccount(cfg), &corev1.ServiceAccount{})
+	mustExist(t, r.Client, testNamespace, resources.NameKruizeConfigMap(cfg), &corev1.ConfigMap{})
+	mustExist(t, r.Client, testNamespace, resources.NameKruize(cfg), &appsv1.Deployment{})
+	mustExist(t, r.Client, testNamespace, resources.NameKruize(cfg), &corev1.Service{})
+	mustExist(t, r.Client, "", resources.NameKruizeClusterRole(cfg), &rbacv1.ClusterRole{})
+	mustExist(t, r.Client, "", resources.NameKruizeClusterRole(cfg), &rbacv1.ClusterRoleBinding{})
+
+	mustExist(t, r.Client, testNamespace, resources.NameCdappConfigMap(cfg), &corev1.ConfigMap{})
+	mustExist(t, r.Client, testNamespace, resources.NameROSServiceAccount(cfg), &corev1.ServiceAccount{})
+	mustExist(t, r.Client, testNamespace, resources.NameKokuAPI(cfg), &appsv1.Deployment{})
+
+	cond := findCondition(cfg.Status.Conditions, costv1alpha1.ConditionAvailable)
+	if cond == nil || cond.Status != metav1.ConditionFalse || cond.Reason != "WaitingForAPI" {
+		t.Fatalf("expected Available=False WaitingForAPI, got %+v", cond)
+	}
+}
+
+func TestReconcileCoreServices_ROSOff_APIReady(t *testing.T) {
+	scheme := ownershipScheme(t)
+	cfg := minimalCR(testCRName, testNamespace)
+	c := fakeClientPreservingStatus(scheme)
+	r := &CostManagementServiceConfigReconciler{
+		Client:   c,
+		Scheme:   scheme,
+		Recorder: &noopRecorder{},
+	}
+
+	result, err := r.reconcileCoreServices(context.Background(), cfg)
+	if err != nil {
+		t.Fatalf("first pass: %v", err)
+	}
+	if result.RequeueAfter == 0 {
+		t.Fatal("first pass should requeue while API is not ready")
+	}
+
+	markDeploymentReady(t, c, testNamespace, resources.NameKokuAPI(cfg))
+
+	result, err = r.reconcileCoreServices(context.Background(), cfg)
+	if err != nil {
+		t.Fatalf("second pass: %v", err)
+	}
+	if !result.IsZero() {
+		t.Fatalf("expected zero Result when API is ready, got %+v", result)
+	}
+	if !apimeta.IsStatusConditionTrue(cfg.Status.Conditions, costv1alpha1.ConditionAvailable) {
+		t.Fatal("expected Available=True")
+	}
+	cond := findCondition(cfg.Status.Conditions, costv1alpha1.ConditionAvailable)
+	if cond == nil || cond.Reason != "KokuAvailable" {
+		t.Fatalf("expected Available reason KokuAvailable, got %+v", cond)
+	}
+}
+
+func mustExist(t *testing.T, c client.Client, ns, name string, obj client.Object) {
+	t.Helper()
+	if err := c.Get(context.Background(), types.NamespacedName{Namespace: ns, Name: name}, obj); err != nil {
+		t.Fatalf("expected %s/%s to exist: %v", ns, name, err)
+	}
+}
+
+func mustNotExist(t *testing.T, c client.Client, ns, name string, obj client.Object) {
+	t.Helper()
+	err := c.Get(context.Background(), types.NamespacedName{Namespace: ns, Name: name}, obj)
+	if !apierrors.IsNotFound(err) {
+		t.Fatalf("expected %s/%s to be absent, got err=%v", ns, name, err)
+	}
+}

--- a/internal/controller/edge_test.go
+++ b/internal/controller/edge_test.go
@@ -1,0 +1,216 @@
+package controller
+
+import (
+	"context"
+	"testing"
+
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	networkingv1 "k8s.io/api/networking/v1"
+	apimeta "k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+
+	costv1alpha1 "github.com/project-koku/koku-service-operator/api/v1alpha1"
+	"github.com/project-koku/koku-service-operator/internal/resources"
+)
+
+func TestReconcileEdge_EnvoyNotReady(t *testing.T) {
+	scheme := ownershipScheme(t)
+	cfg := minimalCR(testCRName, testNamespace)
+	r := &CostManagementServiceConfigReconciler{
+		Client:   fakeClientWithApplySupport(scheme),
+		Scheme:   scheme,
+		Recorder: &noopRecorder{},
+	}
+
+	result, err := r.reconcileEdge(context.Background(), cfg)
+	if err != nil {
+		t.Fatalf("reconcileEdge: %v", err)
+	}
+	if result.RequeueAfter == 0 {
+		t.Fatal("expected non-zero RequeueAfter while Envoy is not ready")
+	}
+
+	mustExist(t, r.Client, testNamespace, resources.NameEnvoyConfigMap(cfg), &corev1.ConfigMap{})
+	mustExist(t, r.Client, testNamespace, resources.NameEnvoy(cfg), &corev1.Service{})
+	mustExist(t, r.Client, testNamespace, resources.NameEnvoy(cfg), &appsv1.Deployment{})
+
+	// UI runs only after the Envoy ready gate — cookie secret and UI Deployment must be absent.
+	mustNotExist(t, r.Client, testNamespace, resources.NameUICookieSecret(cfg), &corev1.Secret{})
+	mustNotExist(t, r.Client, testNamespace, resources.NameUI(cfg), &appsv1.Deployment{})
+
+	cond := findCondition(cfg.Status.Conditions, costv1alpha1.ConditionAuthReady)
+	if cond == nil || cond.Status != metav1.ConditionFalse || cond.Reason != "WaitingForGateway" {
+		t.Fatalf("expected AuthReady=False WaitingForGateway, got %+v", cond)
+	}
+}
+
+func TestReconcileEdge_EnvoyReady_NoClusterDomain(t *testing.T) {
+	scheme := ownershipScheme(t)
+	cfg := minimalCR(testCRName, testNamespace)
+	c := fakeClientPreservingStatus(scheme)
+	r := &CostManagementServiceConfigReconciler{
+		Client:   c,
+		Scheme:   scheme,
+		Recorder: &noopRecorder{},
+	}
+
+	if _, err := r.reconcileEdge(context.Background(), cfg); err != nil {
+		t.Fatalf("first pass: %v", err)
+	}
+	markDeploymentReady(t, c, testNamespace, resources.NameEnvoy(cfg))
+
+	result, err := r.reconcileEdge(context.Background(), cfg)
+	if err != nil {
+		t.Fatalf("second pass: %v", err)
+	}
+	if result.RequeueAfter == 0 {
+		t.Fatal("expected requeue when cluster domain is missing")
+	}
+
+	cond := findCondition(cfg.Status.Conditions, costv1alpha1.ConditionAuthReady)
+	if cond == nil || cond.Status != metav1.ConditionFalse || cond.Reason != "ClusterDomainPending" {
+		t.Fatalf("expected AuthReady=False ClusterDomainPending, got %+v", cond)
+	}
+
+	// UI is after the domain/route gate — must not run yet.
+	mustNotExist(t, r.Client, testNamespace, resources.NameUICookieSecret(cfg), &corev1.Secret{})
+	mustNotExist(t, r.Client, testNamespace, resources.NameUI(cfg), &appsv1.Deployment{})
+	mustNotExist(t, r.Client, testNamespace, cfg.Name+"-gateway", &networkingv1.NetworkPolicy{})
+}
+
+func TestReconcileEdge_EnvoyReady_WithDomain_NoOAuth(t *testing.T) {
+	scheme := ownershipScheme(t)
+	cfg := minimalCR(testCRName, testNamespace)
+	cfg.Status.DiscoveredConfig = &costv1alpha1.DiscoveredConfig{ClusterDomain: "apps.example.com"}
+	c := fakeClientPreservingStatus(scheme)
+	r := &CostManagementServiceConfigReconciler{
+		Client:   c,
+		Scheme:   scheme,
+		Recorder: &noopRecorder{},
+	}
+
+	if _, err := r.reconcileEdge(context.Background(), cfg); err != nil {
+		t.Fatalf("first pass: %v", err)
+	}
+	markDeploymentReady(t, c, testNamespace, resources.NameEnvoy(cfg))
+
+	result, err := r.reconcileEdge(context.Background(), cfg)
+	if err != nil {
+		t.Fatalf("second pass: %v", err)
+	}
+	if result.RequeueAfter == 0 {
+		t.Fatal("expected requeue while UIReady is False")
+	}
+
+	if !apimeta.IsStatusConditionTrue(cfg.Status.Conditions, costv1alpha1.ConditionAuthReady) {
+		t.Fatal("expected AuthReady=True once Envoy is ready and route exists")
+	}
+	authCond := findCondition(cfg.Status.Conditions, costv1alpha1.ConditionAuthReady)
+	if authCond == nil || authCond.Reason != "GatewayReady" {
+		t.Fatalf("expected AuthReady reason GatewayReady, got %+v", authCond)
+	}
+
+	route := &unstructured.Unstructured{}
+	route.SetGroupVersionKind(schema.GroupVersionKind{Group: "route.openshift.io", Version: "v1", Kind: "Route"})
+	mustExist(t, r.Client, testNamespace, resources.NameAPIRoute(cfg), route)
+
+	mustExist(t, r.Client, testNamespace, resources.NameUICookieSecret(cfg), &corev1.Secret{})
+	mustExist(t, r.Client, testNamespace, resources.NameUINginxConfigMap(cfg), &corev1.ConfigMap{})
+	mustNotExist(t, r.Client, testNamespace, resources.NameUI(cfg), &appsv1.Deployment{})
+
+	uiCond := findCondition(cfg.Status.Conditions, costv1alpha1.ConditionUIReady)
+	if uiCond == nil || uiCond.Status != metav1.ConditionFalse || uiCond.Reason != "OAuthClientSecretMissing" {
+		t.Fatalf("expected UIReady=False OAuthClientSecretMissing, got %+v", uiCond)
+	}
+
+	mustExist(t, r.Client, testNamespace, cfg.Name+"-gateway", &networkingv1.NetworkPolicy{})
+	mustExist(t, r.Client, testNamespace, cfg.Name+"-ingress", &networkingv1.NetworkPolicy{})
+	mustExist(t, r.Client, testNamespace, cfg.Name+"-rbac-api", &networkingv1.NetworkPolicy{})
+	mustExist(t, r.Client, testNamespace, cfg.Name+"-koku-api", &networkingv1.NetworkPolicy{})
+	// Deploy defaults true → cache/db NetworkPolicies are applied.
+	mustExist(t, r.Client, testNamespace, cfg.Name+"-cache", &networkingv1.NetworkPolicy{})
+	mustExist(t, r.Client, testNamespace, cfg.Name+"-database", &networkingv1.NetworkPolicy{})
+}
+
+func TestReconcileUI_ValidOAuthSecret(t *testing.T) {
+	scheme := ownershipScheme(t)
+	cfg := minimalCR(testCRName, testNamespace)
+	cfg.Status.DiscoveredConfig = &costv1alpha1.DiscoveredConfig{ClusterDomain: "apps.example.com"}
+
+	oauth := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      resources.NameUIOAuthClientSecret(cfg),
+			Namespace: testNamespace,
+		},
+		Data: map[string][]byte{
+			"client-id":     []byte("cost-ui"),
+			"client-secret": []byte("s3cret"),
+		},
+	}
+
+	r := &CostManagementServiceConfigReconciler{
+		Client:   fakeClientWithApplySupport(scheme, oauth),
+		Scheme:   scheme,
+		Recorder: &noopRecorder{},
+	}
+
+	if err := r.reconcileUI(context.Background(), cfg); err != nil {
+		t.Fatalf("reconcileUI: %v", err)
+	}
+
+	mustExist(t, r.Client, testNamespace, resources.NameUICookieSecret(cfg), &corev1.Secret{})
+	mustExist(t, r.Client, testNamespace, resources.NameUINginxConfigMap(cfg), &corev1.ConfigMap{})
+	mustExist(t, r.Client, testNamespace, resources.NameUI(cfg), &appsv1.Deployment{})
+	mustExist(t, r.Client, testNamespace, resources.NameUI(cfg), &corev1.Service{})
+
+	uiRoute := &unstructured.Unstructured{}
+	uiRoute.SetGroupVersionKind(schema.GroupVersionKind{Group: "route.openshift.io", Version: "v1", Kind: "Route"})
+	mustExist(t, r.Client, testNamespace, cfg.Name+"-ui", uiRoute)
+
+	cl := &unstructured.Unstructured{}
+	cl.SetGroupVersionKind(schema.GroupVersionKind{Group: "console.openshift.io", Version: "v1", Kind: "ConsoleLink"})
+	mustExist(t, r.Client, "", resources.NameConsoleLink(cfg), cl)
+
+	if !apimeta.IsStatusConditionTrue(cfg.Status.Conditions, costv1alpha1.ConditionUIReady) {
+		t.Fatal("expected UIReady=True")
+	}
+}
+
+func TestReconcileUI_InvalidOAuthSecret(t *testing.T) {
+	scheme := ownershipScheme(t)
+	cfg := minimalCR(testCRName, testNamespace)
+	cfg.Status.DiscoveredConfig = &costv1alpha1.DiscoveredConfig{ClusterDomain: "apps.example.com"}
+
+	oauth := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      resources.NameUIOAuthClientSecret(cfg),
+			Namespace: testNamespace,
+		},
+		Data: map[string][]byte{
+			"client-id": []byte("cost-ui"),
+			// client-secret missing
+		},
+	}
+
+	r := &CostManagementServiceConfigReconciler{
+		Client:   fakeClientWithApplySupport(scheme, oauth),
+		Scheme:   scheme,
+		Recorder: &noopRecorder{},
+	}
+
+	if err := r.reconcileUI(context.Background(), cfg); err != nil {
+		t.Fatalf("reconcileUI should not error on invalid secret: %v", err)
+	}
+
+	mustExist(t, r.Client, testNamespace, resources.NameUICookieSecret(cfg), &corev1.Secret{})
+	mustExist(t, r.Client, testNamespace, resources.NameUINginxConfigMap(cfg), &corev1.ConfigMap{})
+	mustNotExist(t, r.Client, testNamespace, resources.NameUI(cfg), &appsv1.Deployment{})
+
+	cond := findCondition(cfg.Status.Conditions, costv1alpha1.ConditionUIReady)
+	if cond == nil || cond.Status != metav1.ConditionFalse || cond.Reason != "OAuthClientSecretInvalid" {
+		t.Fatalf("expected UIReady=False OAuthClientSecretInvalid, got %+v", cond)
+	}
+}

--- a/internal/controller/shared_config_test.go
+++ b/internal/controller/shared_config_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"testing"
 
+	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -149,6 +150,53 @@ func fakeClientWithApplySupport(scheme *runtime.Scheme, objs ...client.Object) c
 			return c.Update(ctx, obj)
 		},
 	}).Build()
+}
+
+// fakeClientPreservingStatus is like fakeClientWithApplySupport, but enables
+// Deployment/StatefulSet status subresources. Builder objects have empty Status;
+// without the subresource, Update ignores Status writes and a second apply()
+// cannot see AvailableReplicas seeded after the first pass.
+func fakeClientPreservingStatus(scheme *runtime.Scheme, objs ...client.Object) client.Client {
+	return fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(objs...).
+		WithStatusSubresource(&appsv1.Deployment{}, &appsv1.StatefulSet{}).
+		WithInterceptorFuncs(interceptor.Funcs{
+			Patch: func(ctx context.Context, c client.WithWatch, obj client.Object, _ client.Patch, _ ...client.PatchOption) error {
+				key := client.ObjectKeyFromObject(obj)
+				existing := obj.DeepCopyObject().(client.Object)
+				err := c.Get(ctx, key, existing)
+				if apierrors.IsNotFound(err) {
+					return c.Create(ctx, obj)
+				}
+				if err != nil {
+					return err
+				}
+				obj.SetResourceVersion(existing.GetResourceVersion())
+				// With status subresource enabled, Update leaves Status intact.
+				return c.Update(ctx, obj)
+			},
+		}).Build()
+}
+
+// markDeploymentReady sets AvailableReplicas to Spec.Replicas so isDeploymentReady
+// returns true. Requires a client built with WithStatusSubresource(&appsv1.Deployment{}).
+func markDeploymentReady(t *testing.T, c client.Client, ns, name string) {
+	t.Helper()
+	d := &appsv1.Deployment{}
+	if err := c.Get(context.Background(), types.NamespacedName{Namespace: ns, Name: name}, d); err != nil {
+		t.Fatalf("get deployment %s: %v", name, err)
+	}
+	replicas := int32(1)
+	if d.Spec.Replicas != nil {
+		replicas = *d.Spec.Replicas
+	}
+	d.Status.AvailableReplicas = replicas
+	d.Status.ReadyReplicas = replicas
+	d.Status.Replicas = replicas
+	if err := c.Status().Update(context.Background(), d); err != nil {
+		t.Fatalf("mark deployment %s ready: %v", name, err)
+	}
 }
 
 func TestReconcileSharedConfig_CreatesStorageCredentialsPlaceholder(t *testing.T) {

--- a/internal/resources/database_test.go
+++ b/internal/resources/database_test.go
@@ -1,0 +1,37 @@
+package resources
+
+import (
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+)
+
+func TestDatabaseService_DefaultPort(t *testing.T) {
+	cfg := testCfg()
+	svc := DatabaseService(cfg)
+	if svc.Name != NameDatabase(cfg) {
+		t.Errorf("Name = %q", svc.Name)
+	}
+	if svc.Spec.ClusterIP != "None" {
+		t.Errorf("ClusterIP = %q, want None (headless)", svc.Spec.ClusterIP)
+	}
+	if svc.Spec.Selector[labelComponent] != "database" {
+		t.Errorf("selector component = %q", svc.Spec.Selector[labelComponent])
+	}
+	if len(svc.Spec.Ports) != 1 {
+		t.Fatalf("ports = %+v", svc.Spec.Ports)
+	}
+	port := svc.Spec.Ports[0]
+	if port.Name != "postgres" || port.Port != 5432 || port.Protocol != corev1.ProtocolTCP {
+		t.Errorf("port = %+v, want postgres/5432/TCP", port)
+	}
+}
+
+func TestDatabaseService_CustomPort(t *testing.T) {
+	cfg := testCfg()
+	cfg.Spec.Database.Port = 5433
+	svc := DatabaseService(cfg)
+	if len(svc.Spec.Ports) != 1 || svc.Spec.Ports[0].Port != 5433 {
+		t.Errorf("ports = %+v, want 5433", svc.Spec.Ports)
+	}
+}

--- a/internal/resources/koku_test.go
+++ b/internal/resources/koku_test.go
@@ -1,0 +1,49 @@
+package resources
+
+import (
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+)
+
+func TestKokuAPIService(t *testing.T) {
+	cfg := testCfg()
+	svc := KokuAPIService(cfg)
+	if svc.Name != NameKokuAPI(cfg) {
+		t.Errorf("Name = %q, want %q", svc.Name, NameKokuAPI(cfg))
+	}
+	if svc.Namespace != cfg.Namespace {
+		t.Errorf("Namespace = %q", svc.Namespace)
+	}
+	if svc.Spec.Selector[labelComponent] != "cost-management-api" {
+		t.Errorf("selector component = %q", svc.Spec.Selector[labelComponent])
+	}
+	if len(svc.Spec.Ports) != 1 {
+		t.Fatalf("ports = %+v", svc.Spec.Ports)
+	}
+	port := svc.Spec.Ports[0]
+	if port.Name != "http" || port.Port != 8000 || port.Protocol != corev1.ProtocolTCP {
+		t.Errorf("port = %+v, want http/8000/TCP", port)
+	}
+}
+
+func TestMasuService(t *testing.T) {
+	cfg := testCfg()
+	svc := MasuService(cfg)
+	if svc.Name != NameMasu(cfg) {
+		t.Errorf("Name = %q, want %q", svc.Name, NameMasu(cfg))
+	}
+	if svc.Namespace != cfg.Namespace {
+		t.Errorf("Namespace = %q", svc.Namespace)
+	}
+	if svc.Spec.Selector[labelComponent] != "cost-processor" {
+		t.Errorf("selector component = %q", svc.Spec.Selector[labelComponent])
+	}
+	if len(svc.Spec.Ports) != 1 {
+		t.Fatalf("ports = %+v", svc.Spec.Ports)
+	}
+	port := svc.Spec.Ports[0]
+	if port.Name != "http" || port.Port != 9000 || port.Protocol != corev1.ProtocolTCP {
+		t.Errorf("port = %+v, want http/9000/TCP", port)
+	}
+}

--- a/internal/resources/networkpolicies_test.go
+++ b/internal/resources/networkpolicies_test.go
@@ -104,29 +104,7 @@ func TestKokuAPINetworkPolicy(t *testing.T) {
 	}
 }
 
-func TestROSAPINetworkPolicy_GatewayOnly(t *testing.T) {
-	// Extends the smoke test in names_test.go with peer/port assertions.
-	cfg := testCfg()
-	np := ROSAPINetworkPolicy(cfg)
-	assertIngressOnly(t, np)
-	if len(np.Spec.Ingress) != 1 {
-		t.Fatalf("expected single gateway rule, got %d", len(np.Spec.Ingress))
-	}
-	if !peerHasComponent(np.Spec.Ingress[0], "gateway") {
-		t.Error("ROS API must only accept traffic from gateway")
-	}
-	if !ruleAllowsPort(np.Spec.Ingress, rosAPIPort) {
-		t.Errorf("missing ros API port %d", rosAPIPort)
-	}
-}
-
 func TestCacheNetworkPolicy(t *testing.T) {
-	cfg := testCfg()
-	np := CacheNetworkPolicy(cfg)
-	assertIngressOnly(t, np)
-	if got := np.Spec.PodSelector.MatchLabels[labelComponent]; got != "cache" {
-		t.Errorf("podSelector component = %q, want cache", got)
-	}
 	wantFrom := []string{
 		"cost-management-api", "cost-processor", "listener", "cost-scheduler",
 		"cost-worker-celery", "cost-worker-priority", "cost-worker-summary",
@@ -134,6 +112,19 @@ func TestCacheNetworkPolicy(t *testing.T) {
 		"cost-worker-hcs", "cost-worker-download",
 		"cost-worker-subs-extraction", "cost-worker-subs-transmission",
 		"rbac-api", "rbac-worker",
+	}
+
+	cfg := testCfg()
+	np := CacheNetworkPolicy(cfg)
+	if np.Name != cfg.Name+"-cache" {
+		t.Errorf("Name = %q", np.Name)
+	}
+	assertIngressOnly(t, np)
+	if got := np.Spec.PodSelector.MatchLabels[labelComponent]; got != "cache" {
+		t.Errorf("podSelector component = %q, want cache", got)
+	}
+	if len(np.Spec.Ingress) != len(wantFrom) {
+		t.Fatalf("ingress rules = %d, want %d", len(np.Spec.Ingress), len(wantFrom))
 	}
 	for _, comp := range wantFrom {
 		found := false
@@ -150,20 +141,34 @@ func TestCacheNetworkPolicy(t *testing.T) {
 	if !ruleAllowsPort(np.Spec.Ingress, 6379) {
 		t.Error("missing default cache port 6379")
 	}
+
+	cfgCustom := testCfg()
+	cfgCustom.Spec.Cache.Port = 6380
+	npCustom := CacheNetworkPolicy(cfgCustom)
+	if !ruleAllowsPort(npCustom.Spec.Ingress, 6380) {
+		t.Errorf("missing custom cache port 6380")
+	}
 }
 
 func TestDatabaseNetworkPolicy(t *testing.T) {
-	cfg := testCfg()
-	np := DatabaseNetworkPolicy(cfg)
-	assertIngressOnly(t, np)
-	if got := np.Spec.PodSelector.MatchLabels[labelComponent]; got != "database" {
-		t.Errorf("podSelector component = %q, want database", got)
-	}
 	wantFrom := []string{
 		"cost-management-api", "cost-processor", "cost-management-migration",
 		"rbac-api", "rbac-worker", "rbac-migration", "rbac-admin-bootstrap", "rbac-keycloak-sync",
 		"ros-api", "ros-processor", "ros-recommendation-poller",
 		"ros-housekeeper", "ros-optimization", "ros-migration",
+	}
+
+	cfg := testCfg()
+	np := DatabaseNetworkPolicy(cfg)
+	if np.Name != cfg.Name+"-database" {
+		t.Errorf("Name = %q", np.Name)
+	}
+	assertIngressOnly(t, np)
+	if got := np.Spec.PodSelector.MatchLabels[labelComponent]; got != "database" {
+		t.Errorf("podSelector component = %q, want database", got)
+	}
+	if len(np.Spec.Ingress) != len(wantFrom) {
+		t.Fatalf("ingress rules = %d, want %d", len(np.Spec.Ingress), len(wantFrom))
 	}
 	for _, comp := range wantFrom {
 		found := false
@@ -179,6 +184,29 @@ func TestDatabaseNetworkPolicy(t *testing.T) {
 	}
 	if !ruleAllowsPort(np.Spec.Ingress, 5432) {
 		t.Error("missing default database port 5432")
+	}
+
+	cfgCustom := testCfg()
+	cfgCustom.Spec.Database.Port = 5433
+	npCustom := DatabaseNetworkPolicy(cfgCustom)
+	if !ruleAllowsPort(npCustom.Spec.Ingress, 5433) {
+		t.Errorf("missing custom database port 5433")
+	}
+}
+
+func TestROSAPINetworkPolicy_GatewayOnly(t *testing.T) {
+	// Extends the smoke test in names_test.go with peer/port assertions.
+	cfg := testCfg()
+	np := ROSAPINetworkPolicy(cfg)
+	assertIngressOnly(t, np)
+	if len(np.Spec.Ingress) != 1 {
+		t.Fatalf("expected single gateway rule, got %d", len(np.Spec.Ingress))
+	}
+	if !peerHasComponent(np.Spec.Ingress[0], "gateway") {
+		t.Error("ROS API must only accept traffic from gateway")
+	}
+	if !ruleAllowsPort(np.Spec.Ingress, rosAPIPort) {
+		t.Errorf("missing ros API port %d", rosAPIPort)
 	}
 }
 

--- a/internal/resources/ui_test.go
+++ b/internal/resources/ui_test.go
@@ -1,12 +1,15 @@
 package resources
 
 import (
+	"fmt"
 	"slices"
+	"strings"
 	"testing"
 
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 
 	costv1alpha1 "github.com/project-koku/koku-service-operator/api/v1alpha1"
 )
@@ -212,6 +215,88 @@ func assertQuantity(t *testing.T, label string, got resource.Quantity, want stri
 	t.Helper()
 	if got.Cmp(resource.MustParse(want)) != 0 {
 		t.Errorf("%s = %s, want %s", label, got.String(), want)
+	}
+}
+
+func TestUICookieSecret(t *testing.T) {
+	cfg := uiTestCfg()
+	secret := UICookieSecret(cfg)
+	if secret.Name != NameUICookieSecret(cfg) {
+		t.Errorf("Name = %q, want %q", secret.Name, NameUICookieSecret(cfg))
+	}
+	if secret.Labels[labelComponent] != "ui" {
+		t.Errorf("component label = %q", secret.Labels[labelComponent])
+	}
+	val := secret.StringData["session-secret"]
+	if val == "" {
+		t.Error("session-secret must be non-empty")
+	}
+}
+
+func TestUINginxConfigMap(t *testing.T) {
+	cfg := uiTestCfg()
+	cm := UINginxConfigMap(cfg)
+	nginx := cm.Data["nginx.conf"]
+	wantProxy := fmt.Sprintf("proxy_pass http://%s:80", NameEnvoy(cfg))
+	if !strings.Contains(nginx, wantProxy) {
+		t.Errorf("nginx config missing %q", wantProxy)
+	}
+	if !strings.Contains(nginx, "location /api/") {
+		t.Error("nginx config missing /api/ location")
+	}
+}
+
+func TestUIService(t *testing.T) {
+	cfg := uiTestCfg()
+	svc := UIService(cfg)
+	if svc.Name != NameUI(cfg) {
+		t.Errorf("Name = %q", svc.Name)
+	}
+	if len(svc.Spec.Ports) != 1 {
+		t.Fatalf("ports = %+v", svc.Spec.Ports)
+	}
+	port := svc.Spec.Ports[0]
+	if port.Name != "https" || port.Port != uiProxyPort {
+		t.Errorf("port = %+v, want https/%d", port, uiProxyPort)
+	}
+	wantAnnot := NameUITLSSecret(cfg)
+	if got := svc.Annotations["service.beta.openshift.io/serving-cert-secret-name"]; got != wantAnnot {
+		t.Errorf("serving-cert annotation = %q, want %q", got, wantAnnot)
+	}
+}
+
+func TestUIRoute_NilWithoutClusterDomain(t *testing.T) {
+	cfg := testCfg()
+	if UIRoute(cfg) != nil {
+		t.Error("expected nil Route when cluster domain is missing")
+	}
+}
+
+func TestUIRoute_Spec(t *testing.T) {
+	cfg := uiTestCfg()
+	route := UIRoute(cfg)
+	if route == nil {
+		t.Fatal("expected Route when cluster domain is set")
+	}
+	if route.GroupVersionKind() != routeGVK {
+		t.Errorf("GVK = %v, want %v", route.GroupVersionKind(), routeGVK)
+	}
+	wantHost := fmt.Sprintf("%s-ui-%s.%s", cfg.Name, cfg.Namespace, cfg.Status.DiscoveredConfig.ClusterDomain)
+	host, _, _ := unstructured.NestedString(route.Object, "spec", "host")
+	if host != wantHost {
+		t.Errorf("spec.host = %q, want %q", host, wantHost)
+	}
+	svc, _, _ := unstructured.NestedString(route.Object, "spec", "to", "name")
+	if svc != NameUI(cfg) {
+		t.Errorf("spec.to.name = %q, want %q", svc, NameUI(cfg))
+	}
+	targetPort, _, _ := unstructured.NestedString(route.Object, "spec", "port", "targetPort")
+	if targetPort != "https" {
+		t.Errorf("spec.port.targetPort = %q, want https", targetPort)
+	}
+	term, _, _ := unstructured.NestedString(route.Object, "spec", "tls", "termination")
+	if term != "passthrough" {
+		t.Errorf("tls.termination = %q, want passthrough", term)
 	}
 }
 


### PR DESCRIPTION
## Summary
- Adds fake-client tests for `reconcileCoreServices`, `reconcileEdge`, `reconcileUI`, `applyStatefulSet`, and `applyClusterScoped` (conditions, requeue, and applied objects — not call stubs).
- Adds constructor tests for leftover 0% builders: cache/database NetworkPolicies, Koku/Masu/Database Services, UI cookie/nginx/Service/Route.
- CI: `make coverage-gate` fails the test job when `./internal/...` statement coverage (with `-coverpkg`) drops below 85%.
- Rebased onto current `main` from [fork PR #38](https://github.com/martinpovolny/koku-service-operator/pull/38) (draft against `gold`). Kept main's UI profile tests and Database NetworkPolicy peers (migration Jobs, `rbac-keycloak-sync`).
- Internal coverage on this tree: **85.3%**. Tests and CI only — no production code changes.

## Test plan
- [ ] `make coverage-gate` prints `OK: internal coverage … (minimum 85.0%)`
- [ ] `make test` passes
- [ ] `go tool cover -func=cover.internal.out` shows non-zero for `reconcileCoreServices`, `reconcileEdge`, `reconcileUI`, `applyStatefulSet`, `applyClusterScoped`
- [ ] CI test job runs `make coverage-gate` after `make test`

## Summary by Sourcery

Increase test coverage for internal controllers and resources and enforce a minimum coverage threshold for internal packages via a new Make target and CI gate.

New Features:
- Add controller tests covering core services reconciliation, edge reconciliation, UI reconciliation, and database StatefulSet apply behavior
- Add resource-level tests for UI cookie secret, nginx config map, UI service and route, Koku and Masu services, and database service ports
- Add cache and database NetworkPolicy tests asserting names, selectors, ingress peers, and support for custom ports

Enhancements:
- Extend fake client helpers to preserve Deployment and StatefulSet status and add utilities to mark deployments ready for readiness-gated reconciliation tests

Build:
- Introduce a coverage-gate make target enforcing minimum statement coverage for internal packages and supporting configurable thresholds

CI:
- Update CI workflow to run the new internal coverage gate and publish internal coverage summary alongside overall coverage

Tests:
- Reorganize and expand NetworkPolicy tests, including ROS API gateway-only coverage and stricter cache/database NetworkPolicy expectations