### PR TITLE
fix: S3 validation follow-ups — deduplicate Secret fetch, add TLS options

### DIFF
--- a/api/v1alpha1/costmanagementserviceconfig_types.go
+++ b/api/v1alpha1/costmanagementserviceconfig_types.go
@@ -229,6 +229,7 @@ type ObjectStorageConfig struct {
 	// InsecureSkipVerify disables TLS certificate verification for the S3
 	// endpoint. Use for dev/CRC setups with self-signed certs.
 	// Prefer CACertSecretName for production.
+	// +kubebuilder:default:=false
 	InsecureSkipVerify bool `json:"insecureSkipVerify,omitempty"`
 	// CACertSecretName names a Secret with key ca.crt containing the CA
 	// certificate used to verify the S3 endpoint TLS. Required for on-prem

--- a/api/v1alpha1/costmanagementserviceconfig_types.go
+++ b/api/v1alpha1/costmanagementserviceconfig_types.go
@@ -228,7 +228,12 @@ type ObjectStorageConfig struct {
 	UseSSL *bool `json:"useSSL,omitempty"`
 	// InsecureSkipVerify disables TLS certificate verification for the S3
 	// endpoint. Use for dev/CRC setups with self-signed certs.
+	// Prefer CACertSecretName for production.
 	InsecureSkipVerify bool `json:"insecureSkipVerify,omitempty"`
+	// CACertSecretName names a Secret with key ca.crt containing the CA
+	// certificate used to verify the S3 endpoint TLS. Required for on-prem
+	// S3 endpoints (MinIO, Ceph RGW, NooBaa HTTPS) using private CAs.
+	CACertSecretName string `json:"caCertSecretName,omitempty"`
 	// Name of an existing Secret with keys: access-key, secret-key.
 	// When empty the operator creates or detects the secret via ODF/NooBaa.
 	SecretName string    `json:"secretName,omitempty"`

--- a/api/v1alpha1/costmanagementserviceconfig_types.go
+++ b/api/v1alpha1/costmanagementserviceconfig_types.go
@@ -226,6 +226,9 @@ type ObjectStorageConfig struct {
 	Port int32 `json:"port,omitempty"`
 	// +kubebuilder:default:=true
 	UseSSL *bool `json:"useSSL,omitempty"`
+	// InsecureSkipVerify disables TLS certificate verification for the S3
+	// endpoint. Use for dev/CRC setups with self-signed certs.
+	InsecureSkipVerify bool `json:"insecureSkipVerify,omitempty"`
 	// Name of an existing Secret with keys: access-key, secret-key.
 	// When empty the operator creates or detects the secret via ODF/NooBaa.
 	SecretName string    `json:"secretName,omitempty"`

--- a/config/crd/bases/service.costmanagement.openshift.io_costmanagementserviceconfigs.yaml
+++ b/config/crd/bases/service.costmanagement.openshift.io_costmanagementserviceconfigs.yaml
@@ -1827,6 +1827,12 @@ spec:
                 type: object
               objectStorage:
                 properties:
+                  caCertSecretName:
+                    description: |-
+                      CACertSecretName names a Secret with key ca.crt containing the CA
+                      certificate used to verify the S3 endpoint TLS. Required for on-prem
+                      S3 endpoints (MinIO, Ceph RGW, NooBaa HTTPS) using private CAs.
+                    type: string
                   endpoint:
                     default: s3.openshift-storage.svc.cluster.local
                     description: |-
@@ -1837,6 +1843,7 @@ spec:
                     description: |-
                       InsecureSkipVerify disables TLS certificate verification for the S3
                       endpoint. Use for dev/CRC setups with self-signed certs.
+                      Prefer CACertSecretName for production.
                     type: boolean
                   port:
                     default: 443

--- a/config/crd/bases/service.costmanagement.openshift.io_costmanagementserviceconfigs.yaml
+++ b/config/crd/bases/service.costmanagement.openshift.io_costmanagementserviceconfigs.yaml
@@ -1840,6 +1840,7 @@ spec:
                       Auto-detected by the Discovery phase (OBC → NooBaa → user-provided).
                     type: string
                   insecureSkipVerify:
+                    default: false
                     description: |-
                       InsecureSkipVerify disables TLS certificate verification for the S3
                       endpoint. Use for dev/CRC setups with self-signed certs.

--- a/config/crd/bases/service.costmanagement.openshift.io_costmanagementserviceconfigs.yaml
+++ b/config/crd/bases/service.costmanagement.openshift.io_costmanagementserviceconfigs.yaml
@@ -1833,6 +1833,11 @@ spec:
                       S3 endpoint hostname (without protocol or port).
                       Auto-detected by the Discovery phase (OBC → NooBaa → user-provided).
                     type: string
+                  insecureSkipVerify:
+                    description: |-
+                      InsecureSkipVerify disables TLS certificate verification for the S3
+                      endpoint. Use for dev/CRC setups with self-signed certs.
+                    type: boolean
                   port:
                     default: 443
                     format: int32

--- a/docs/review-follow-ups.md
+++ b/docs/review-follow-ups.md
@@ -160,3 +160,30 @@ disabling the sync could leave orphaned CronJobs running.
 
 **Suggested fix:** Add a test following the Kruize CronJob disable pattern
 in `ros_cleanup_test.go`.
+
+---
+
+## 9. S3 TLS fields are probe-only — not wired to app pods
+
+**Source:** Code review of PR #71 (validation follow-ups).
+
+**Problem:** `spec.objectStorage.insecureSkipVerify` and
+`spec.objectStorage.caCertSecretName` configure the operator's own
+`ListBuckets` validation probe, but are not wired to application pod
+env vars (`AWS_CA_BUNDLE`) or volume mounts. App pods that need to
+reach the same S3 endpoint with a private CA rely on the combined CA
+bundle from `CACombineInitContainer`, which does not read the
+objectStorage TLS fields.
+
+The Keycloak and Cache TLS equivalents (`auth.keycloak.tls`,
+`cache.tls`) are wired to both the operator probe and the app
+containers. S3 should follow the same pattern.
+
+**Impact:** A user sets `caCertSecretName` expecting it to fix S3
+connectivity for both the operator condition and the running workloads.
+The `StorageReady` condition turns green, but uploads still fail if
+the app pods don't have the CA in their trust store via another path.
+
+**Suggested fix:** Wire `objectStorage.caCertSecretName` into the
+`CACombineInitContainer` inputs (or set `AWS_CA_BUNDLE` env var on
+Koku/Masu containers) so app pods trust the same CA.

--- a/internal/controller/validation.go
+++ b/internal/controller/validation.go
@@ -67,7 +67,7 @@ func (r *CostManagementServiceConfigReconciler) reconcileValidation(ctx context.
 			// Validate secret keys when the user provided their own secret.
 			if cfg.Spec.Database.SecretName != "" {
 				required := dbSecretKeys
-				if _, err := r.checkSecretKeys(ctx, cfg.Namespace, cfg.Spec.Database.SecretName, required); err != nil {
+				if _, err := r.getSecret(ctx, cfg.Namespace, cfg.Spec.Database.SecretName, required); err != nil {
 					r.setCondition(cfg, costv1alpha1.ConditionDatabaseReady, metav1.ConditionFalse,
 						"DatabaseSecretInvalid", err.Error())
 					allReady = false
@@ -96,7 +96,7 @@ func (r *CostManagementServiceConfigReconciler) reconcileValidation(ctx context.
 			allReady = false
 		} else {
 			if cfg.Spec.Cache.Auth.SecretName != "" {
-				if _, err := r.checkSecretKeys(ctx, cfg.Namespace, cfg.Spec.Cache.Auth.SecretName, []string{"redis-password"}); err != nil {
+				if _, err := r.getSecret(ctx, cfg.Namespace, cfg.Spec.Cache.Auth.SecretName, []string{"redis-password"}); err != nil {
 					r.setCondition(cfg, costv1alpha1.ConditionCacheReady, metav1.ConditionFalse,
 						"CacheSecretInvalid", err.Error())
 					allReady = false
@@ -118,7 +118,7 @@ func (r *CostManagementServiceConfigReconciler) reconcileValidation(ctx context.
 				"KafkaUnreachable", err.Error())
 		} else {
 			if cfg.Spec.Kafka.SASL.ExistingSecret != "" {
-				if _, err := r.checkSecretKeys(ctx, cfg.Namespace, cfg.Spec.Kafka.SASL.ExistingSecret, []string{"username", "password"}); err != nil { //nolint:goconst // Secret key names are clearer as literals
+				if _, err := r.getSecret(ctx, cfg.Namespace, cfg.Spec.Kafka.SASL.ExistingSecret, []string{"username", "password"}); err != nil { //nolint:goconst // Secret key names are clearer as literals
 					r.setCondition(cfg, costv1alpha1.ConditionKafkaReady, metav1.ConditionFalse,
 						"KafkaSASLSecretInvalid", err.Error())
 				} else {
@@ -242,10 +242,10 @@ func jwksProbe(ctx context.Context, rawURL string, insecureSkipVerify bool, time
 	return nil
 }
 
-// checkSecretKeys verifies that a named Secret exists and contains all required keys
+// getSecret verifies that a named Secret exists and contains all required keys
 // with non-empty values. Returns the fetched Secret on success so callers can
 // read credential data without a second API server round-trip.
-func (r *CostManagementServiceConfigReconciler) checkSecretKeys(ctx context.Context, namespace, name string, required []string) (*corev1.Secret, error) {
+func (r *CostManagementServiceConfigReconciler) getSecret(ctx context.Context, namespace, name string, required []string) (*corev1.Secret, error) {
 	secret := &corev1.Secret{}
 	if err := r.Get(ctx, types.NamespacedName{Namespace: namespace, Name: name}, secret); err != nil {
 		if errors.IsNotFound(err) {

--- a/internal/controller/validation.go
+++ b/internal/controller/validation.go
@@ -67,7 +67,7 @@ func (r *CostManagementServiceConfigReconciler) reconcileValidation(ctx context.
 			// Validate secret keys when the user provided their own secret.
 			if cfg.Spec.Database.SecretName != "" {
 				required := dbSecretKeys
-				if err := r.checkSecretKeys(ctx, cfg.Namespace, cfg.Spec.Database.SecretName, required); err != nil {
+				if _, err := r.checkSecretKeys(ctx, cfg.Namespace, cfg.Spec.Database.SecretName, required); err != nil {
 					r.setCondition(cfg, costv1alpha1.ConditionDatabaseReady, metav1.ConditionFalse,
 						"DatabaseSecretInvalid", err.Error())
 					allReady = false
@@ -96,7 +96,7 @@ func (r *CostManagementServiceConfigReconciler) reconcileValidation(ctx context.
 			allReady = false
 		} else {
 			if cfg.Spec.Cache.Auth.SecretName != "" {
-				if err := r.checkSecretKeys(ctx, cfg.Namespace, cfg.Spec.Cache.Auth.SecretName, []string{"redis-password"}); err != nil {
+				if _, err := r.checkSecretKeys(ctx, cfg.Namespace, cfg.Spec.Cache.Auth.SecretName, []string{"redis-password"}); err != nil {
 					r.setCondition(cfg, costv1alpha1.ConditionCacheReady, metav1.ConditionFalse,
 						"CacheSecretInvalid", err.Error())
 					allReady = false
@@ -118,7 +118,7 @@ func (r *CostManagementServiceConfigReconciler) reconcileValidation(ctx context.
 				"KafkaUnreachable", err.Error())
 		} else {
 			if cfg.Spec.Kafka.SASL.ExistingSecret != "" {
-				if err := r.checkSecretKeys(ctx, cfg.Namespace, cfg.Spec.Kafka.SASL.ExistingSecret, []string{"username", "password"}); err != nil { //nolint:goconst // Secret key names are clearer as literals
+				if _, err := r.checkSecretKeys(ctx, cfg.Namespace, cfg.Spec.Kafka.SASL.ExistingSecret, []string{"username", "password"}); err != nil { //nolint:goconst // Secret key names are clearer as literals
 					r.setCondition(cfg, costv1alpha1.ConditionKafkaReady, metav1.ConditionFalse,
 						"KafkaSASLSecretInvalid", err.Error())
 				} else {
@@ -243,14 +243,15 @@ func jwksProbe(ctx context.Context, rawURL string, insecureSkipVerify bool, time
 }
 
 // checkSecretKeys verifies that a named Secret exists and contains all required keys
-// with non-empty values.
-func (r *CostManagementServiceConfigReconciler) checkSecretKeys(ctx context.Context, namespace, name string, required []string) error {
+// with non-empty values. Returns the fetched Secret on success so callers can
+// read credential data without a second API server round-trip.
+func (r *CostManagementServiceConfigReconciler) checkSecretKeys(ctx context.Context, namespace, name string, required []string) (*corev1.Secret, error) {
 	secret := &corev1.Secret{}
 	if err := r.Get(ctx, types.NamespacedName{Namespace: namespace, Name: name}, secret); err != nil {
 		if errors.IsNotFound(err) {
-			return fmt.Errorf("secret %q not found", name)
+			return nil, fmt.Errorf("secret %q not found", name)
 		}
-		return fmt.Errorf("get secret %q: %w", name, err)
+		return nil, fmt.Errorf("get secret %q: %w", name, err)
 	}
 	var missing []string
 	for _, key := range required {
@@ -259,7 +260,7 @@ func (r *CostManagementServiceConfigReconciler) checkSecretKeys(ctx context.Cont
 		}
 	}
 	if len(missing) > 0 {
-		return fmt.Errorf("secret %q missing keys: %s", name, strings.Join(missing, ", "))
+		return nil, fmt.Errorf("secret %q missing keys: %s", name, strings.Join(missing, ", "))
 	}
-	return nil
+	return secret, nil
 }

--- a/internal/controller/validation_s3.go
+++ b/internal/controller/validation_s3.go
@@ -36,7 +36,7 @@ func (r *CostManagementServiceConfigReconciler) validateObjectStorage(ctx contex
 		return
 	}
 
-	secret, err := r.checkSecretKeys(ctx, cfg.Namespace, secretName, s3SecretKeys)
+	secret, err := r.getSecret(ctx, cfg.Namespace, secretName, s3SecretKeys)
 	if err != nil {
 		r.setCondition(cfg, costv1alpha1.ConditionStorageReady, metav1.ConditionFalse,
 			"StorageSecretInvalid", err.Error())
@@ -45,7 +45,7 @@ func (r *CostManagementServiceConfigReconciler) validateObjectStorage(ctx contex
 
 	var caCertPool *x509.CertPool
 	if caName := cfg.Spec.ObjectStorage.CACertSecretName; caName != "" && !cfg.Spec.ObjectStorage.InsecureSkipVerify {
-		caSecret, err := r.checkSecretKeys(ctx, cfg.Namespace, caName, []string{caCertKey})
+		caSecret, err := r.getSecret(ctx, cfg.Namespace, caName, []string{caCertKey})
 		if err != nil {
 			r.setCondition(cfg, costv1alpha1.ConditionStorageReady, metav1.ConditionFalse,
 				"StorageCACertInvalid", err.Error())

--- a/internal/controller/validation_s3.go
+++ b/internal/controller/validation_s3.go
@@ -10,9 +10,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/credentials"
 	"github.com/aws/aws-sdk-go-v2/service/s3"
-	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/types"
 
 	costv1alpha1 "github.com/project-koku/koku-service-operator/api/v1alpha1"
 	"github.com/project-koku/koku-service-operator/internal/resources"
@@ -34,16 +32,10 @@ func (r *CostManagementServiceConfigReconciler) validateObjectStorage(ctx contex
 		return
 	}
 
-	if err := r.checkSecretKeys(ctx, cfg.Namespace, secretName, s3SecretKeys); err != nil {
+	secret, err := r.checkSecretKeys(ctx, cfg.Namespace, secretName, s3SecretKeys)
+	if err != nil {
 		r.setCondition(cfg, costv1alpha1.ConditionStorageReady, metav1.ConditionFalse,
 			"StorageSecretInvalid", err.Error())
-		return
-	}
-
-	secret := &corev1.Secret{}
-	if err := r.Get(ctx, types.NamespacedName{Namespace: cfg.Namespace, Name: secretName}, secret); err != nil {
-		r.setCondition(cfg, costv1alpha1.ConditionStorageReady, metav1.ConditionFalse,
-			"StorageSecretInvalid", fmt.Sprintf("get secret %q: %v", secretName, err))
 		return
 	}
 

--- a/internal/controller/validation_s3.go
+++ b/internal/controller/validation_s3.go
@@ -42,7 +42,7 @@ func (r *CostManagementServiceConfigReconciler) validateObjectStorage(ctx contex
 	}
 
 	var caCertPool *x509.CertPool
-	if caName := cfg.Spec.ObjectStorage.CACertSecretName; caName != "" {
+	if caName := cfg.Spec.ObjectStorage.CACertSecretName; caName != "" && !cfg.Spec.ObjectStorage.InsecureSkipVerify {
 		caSecret, err := r.checkSecretKeys(ctx, cfg.Namespace, caName, []string{"ca.crt"})
 		if err != nil {
 			r.setCondition(cfg, costv1alpha1.ConditionStorageReady, metav1.ConditionFalse,
@@ -87,15 +87,17 @@ func s3ListBucketsProbe(ctx context.Context, endpoint, region, accessKey, secret
 	ctx, cancel := context.WithTimeout(ctx, timeout)
 	defer cancel()
 
-	httpClient := &http.Client{
-		Timeout: timeout,
-		Transport: &http.Transport{
-			TLSClientConfig: &tls.Config{
-				InsecureSkipVerify: insecureSkipVerify, //nolint:gosec // user-controlled via CR spec
-				RootCAs:            caCertPool,
-			},
-		},
+	base, ok := http.DefaultTransport.(*http.Transport)
+	if !ok {
+		base = &http.Transport{}
 	}
+	transport := base.Clone()
+	if transport.TLSClientConfig == nil {
+		transport.TLSClientConfig = &tls.Config{}
+	}
+	transport.TLSClientConfig.InsecureSkipVerify = insecureSkipVerify //nolint:gosec // user-controlled via CR spec
+	transport.TLSClientConfig.RootCAs = caCertPool
+	httpClient := &http.Client{Timeout: timeout, Transport: transport}
 	client := s3.New(s3.Options{
 		Region:       region,
 		Credentials:  aws.NewCredentialsCache(credentials.NewStaticCredentialsProvider(accessKey, secretKey, "")),

--- a/internal/controller/validation_s3.go
+++ b/internal/controller/validation_s3.go
@@ -18,6 +18,8 @@ import (
 	"github.com/project-koku/koku-service-operator/internal/resources"
 )
 
+const caCertKey = "ca.crt"
+
 // validateObjectStorage checks S3 credentials then probes the object store.
 // Non-blocking: failures set StorageReady=False but do not gate Migration.
 //
@@ -43,14 +45,14 @@ func (r *CostManagementServiceConfigReconciler) validateObjectStorage(ctx contex
 
 	var caCertPool *x509.CertPool
 	if caName := cfg.Spec.ObjectStorage.CACertSecretName; caName != "" && !cfg.Spec.ObjectStorage.InsecureSkipVerify {
-		caSecret, err := r.checkSecretKeys(ctx, cfg.Namespace, caName, []string{"ca.crt"})
+		caSecret, err := r.checkSecretKeys(ctx, cfg.Namespace, caName, []string{caCertKey})
 		if err != nil {
 			r.setCondition(cfg, costv1alpha1.ConditionStorageReady, metav1.ConditionFalse,
 				"StorageCACertInvalid", err.Error())
 			return
 		}
 		caCertPool = x509.NewCertPool()
-		if !caCertPool.AppendCertsFromPEM(caSecret.Data["ca.crt"]) {
+		if !caCertPool.AppendCertsFromPEM(caSecret.Data[caCertKey]) {
 			r.setCondition(cfg, costv1alpha1.ConditionStorageReady, metav1.ConditionFalse,
 				"StorageCACertInvalid", fmt.Sprintf("secret %q key ca.crt contains no valid PEM certificates", caName))
 			return

--- a/internal/controller/validation_s3.go
+++ b/internal/controller/validation_s3.go
@@ -3,6 +3,7 @@ package controller
 import (
 	"context"
 	"crypto/tls"
+	"crypto/x509"
 	"fmt"
 	"net/http"
 	"net/url"
@@ -40,11 +41,27 @@ func (r *CostManagementServiceConfigReconciler) validateObjectStorage(ctx contex
 		return
 	}
 
+	var caCertPool *x509.CertPool
+	if caName := cfg.Spec.ObjectStorage.CACertSecretName; caName != "" {
+		caSecret, err := r.checkSecretKeys(ctx, cfg.Namespace, caName, []string{"ca.crt"})
+		if err != nil {
+			r.setCondition(cfg, costv1alpha1.ConditionStorageReady, metav1.ConditionFalse,
+				"StorageCACertInvalid", err.Error())
+			return
+		}
+		caCertPool = x509.NewCertPool()
+		if !caCertPool.AppendCertsFromPEM(caSecret.Data["ca.crt"]) {
+			r.setCondition(cfg, costv1alpha1.ConditionStorageReady, metav1.ConditionFalse,
+				"StorageCACertInvalid", fmt.Sprintf("secret %q key ca.crt contains no valid PEM certificates", caName))
+			return
+		}
+	}
+
 	endpoint := resources.S3Endpoint(cfg)
 	region := s3Region(cfg)
 	accessKey := string(secret.Data[s3SecretKeys[0]])
 	secretKey := string(secret.Data[s3SecretKeys[1]])
-	if err := s3ListBucketsProbe(ctx, endpoint, region, accessKey, secretKey, validationTimeout, cfg.Spec.ObjectStorage.InsecureSkipVerify); err != nil {
+	if err := s3ListBucketsProbe(ctx, endpoint, region, accessKey, secretKey, validationTimeout, cfg.Spec.ObjectStorage.InsecureSkipVerify, caCertPool); err != nil {
 		r.setCondition(cfg, costv1alpha1.ConditionStorageReady, metav1.ConditionFalse,
 			"StorageUnreachable", err.Error())
 		return
@@ -55,7 +72,7 @@ func (r *CostManagementServiceConfigReconciler) validateObjectStorage(ctx contex
 
 // s3ListBucketsProbe calls S3 ListBuckets against endpoint using path-style
 // addressing (required for MinIO / NooBaa / Ceph RGW).
-func s3ListBucketsProbe(ctx context.Context, endpoint, region, accessKey, secretKey string, timeout time.Duration, insecureSkipVerify bool) error {
+func s3ListBucketsProbe(ctx context.Context, endpoint, region, accessKey, secretKey string, timeout time.Duration, insecureSkipVerify bool, caCertPool *x509.CertPool) error {
 	if region == "" {
 		region = defaultS3Region
 	}
@@ -73,7 +90,10 @@ func s3ListBucketsProbe(ctx context.Context, endpoint, region, accessKey, secret
 	httpClient := &http.Client{
 		Timeout: timeout,
 		Transport: &http.Transport{
-			TLSClientConfig: &tls.Config{InsecureSkipVerify: insecureSkipVerify}, //nolint:gosec // user-controlled via CR spec
+			TLSClientConfig: &tls.Config{
+				InsecureSkipVerify: insecureSkipVerify, //nolint:gosec // user-controlled via CR spec
+				RootCAs:            caCertPool,
+			},
 		},
 	}
 	client := s3.New(s3.Options{

--- a/internal/controller/validation_s3.go
+++ b/internal/controller/validation_s3.go
@@ -2,6 +2,7 @@ package controller
 
 import (
 	"context"
+	"crypto/tls"
 	"fmt"
 	"net/http"
 	"net/url"
@@ -43,7 +44,7 @@ func (r *CostManagementServiceConfigReconciler) validateObjectStorage(ctx contex
 	region := s3Region(cfg)
 	accessKey := string(secret.Data[s3SecretKeys[0]])
 	secretKey := string(secret.Data[s3SecretKeys[1]])
-	if err := s3ListBucketsProbe(ctx, endpoint, region, accessKey, secretKey, validationTimeout); err != nil {
+	if err := s3ListBucketsProbe(ctx, endpoint, region, accessKey, secretKey, validationTimeout, cfg.Spec.ObjectStorage.InsecureSkipVerify); err != nil {
 		r.setCondition(cfg, costv1alpha1.ConditionStorageReady, metav1.ConditionFalse,
 			"StorageUnreachable", err.Error())
 		return
@@ -54,7 +55,7 @@ func (r *CostManagementServiceConfigReconciler) validateObjectStorage(ctx contex
 
 // s3ListBucketsProbe calls S3 ListBuckets against endpoint using path-style
 // addressing (required for MinIO / NooBaa / Ceph RGW).
-func s3ListBucketsProbe(ctx context.Context, endpoint, region, accessKey, secretKey string, timeout time.Duration) error {
+func s3ListBucketsProbe(ctx context.Context, endpoint, region, accessKey, secretKey string, timeout time.Duration, insecureSkipVerify bool) error {
 	if region == "" {
 		region = defaultS3Region
 	}
@@ -69,12 +70,18 @@ func s3ListBucketsProbe(ctx context.Context, endpoint, region, accessKey, secret
 	ctx, cancel := context.WithTimeout(ctx, timeout)
 	defer cancel()
 
+	httpClient := &http.Client{
+		Timeout: timeout,
+		Transport: &http.Transport{
+			TLSClientConfig: &tls.Config{InsecureSkipVerify: insecureSkipVerify}, //nolint:gosec // user-controlled via CR spec
+		},
+	}
 	client := s3.New(s3.Options{
 		Region:       region,
 		Credentials:  aws.NewCredentialsCache(credentials.NewStaticCredentialsProvider(accessKey, secretKey, "")),
 		BaseEndpoint: aws.String(endpoint),
 		UsePathStyle: true,
-		HTTPClient:   &http.Client{Timeout: timeout},
+		HTTPClient:   httpClient,
 		EndpointOptions: s3.EndpointResolverOptions{
 			DisableHTTPS: u.Scheme == "http",
 		},

--- a/internal/controller/validation_s3_test.go
+++ b/internal/controller/validation_s3_test.go
@@ -3,6 +3,7 @@ package controller
 import (
 	"context"
 	"crypto/x509"
+	"encoding/pem"
 	"io"
 	"net"
 	"net/http"
@@ -324,6 +325,39 @@ func TestReconcileValidation_S3InsecureSkipVerifyBypassesCACert(t *testing.T) {
 	found := findCondition(cfg.Status.Conditions, costv1alpha1.ConditionStorageReady)
 	if found == nil || found.Status != metav1.ConditionTrue {
 		t.Fatalf("expected StorageReady=True (insecureSkipVerify bypasses CA), got %+v", found)
+	}
+	if found.Reason != "StorageReachable" {
+		t.Errorf("reason = %q, want StorageReachable", found.Reason)
+	}
+}
+
+func TestReconcileValidation_S3CACertValid(t *testing.T) {
+	srv := httptest.NewTLSServer(fakeS3ListBuckets(http.StatusOK, listBucketsXML))
+	t.Cleanup(srv.Close)
+
+	caPEM := pem.EncodeToMemory(&pem.Block{
+		Type:  "CERTIFICATE",
+		Bytes: srv.Certificate().Raw,
+	})
+
+	cfg := &costv1alpha1.CostManagementServiceConfig{
+		ObjectMeta: metav1.ObjectMeta{Name: testCRName, Namespace: testNamespace},
+		Spec:       bundledNoKafkaSpec(),
+	}
+	cfg.Spec.ObjectStorage = objectStorageForServer(t, srv, s3TestSecret)
+	cfg.Spec.ObjectStorage.CACertSecretName = "s3-ca"
+
+	caSecret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{Name: "s3-ca", Namespace: testNamespace},
+		Data:       map[string][]byte{"ca.crt": caPEM},
+	}
+
+	r := newValidationReconciler(t, s3CredsSecret(s3TestSecret), caSecret)
+	_, _ = r.reconcileValidation(context.Background(), cfg)
+
+	found := findCondition(cfg.Status.Conditions, costv1alpha1.ConditionStorageReady)
+	if found == nil || found.Status != metav1.ConditionTrue {
+		t.Fatalf("expected StorageReady=True with valid CA cert, got %+v", found)
 	}
 	if found.Reason != "StorageReachable" {
 		t.Errorf("reason = %q, want StorageReachable", found.Reason)

--- a/internal/controller/validation_s3_test.go
+++ b/internal/controller/validation_s3_test.go
@@ -2,6 +2,7 @@ package controller
 
 import (
 	"context"
+	"crypto/x509"
 	"io"
 	"net"
 	"net/http"
@@ -87,7 +88,7 @@ func TestS3ListBucketsProbe(t *testing.T) {
 	t.Run("reachable", func(t *testing.T) {
 		srv := httptest.NewServer(fakeS3ListBuckets(http.StatusOK, listBucketsXML))
 		t.Cleanup(srv.Close)
-		if err := s3ListBucketsProbe(ctx, srv.URL, "us-east-1", s3TestAccessKey, s3TestSecretKey, time.Second, false); err != nil {
+		if err := s3ListBucketsProbe(ctx, srv.URL, "us-east-1", s3TestAccessKey, s3TestSecretKey, time.Second, false, nil); err != nil {
 			t.Fatalf("expected success, got %v", err)
 		}
 	})
@@ -95,13 +96,13 @@ func TestS3ListBucketsProbe(t *testing.T) {
 	t.Run("403 AccessDenied", func(t *testing.T) {
 		srv := httptest.NewServer(fakeS3ListBuckets(http.StatusForbidden, `<Error><Code>AccessDenied</Code><Message>denied</Message></Error>`))
 		t.Cleanup(srv.Close)
-		if err := s3ListBucketsProbe(ctx, srv.URL, "us-east-1", s3TestAccessKey, s3TestSecretKey, time.Second, false); err == nil {
+		if err := s3ListBucketsProbe(ctx, srv.URL, "us-east-1", s3TestAccessKey, s3TestSecretKey, time.Second, false, nil); err == nil {
 			t.Fatal("expected error for HTTP 403")
 		}
 	})
 
 	t.Run("unreachable", func(t *testing.T) {
-		if err := s3ListBucketsProbe(ctx, "http://"+localHost+":1", "us-east-1", s3TestAccessKey, s3TestSecretKey, 200*time.Millisecond, false); err == nil {
+		if err := s3ListBucketsProbe(ctx, "http://"+localHost+":1", "us-east-1", s3TestAccessKey, s3TestSecretKey, 200*time.Millisecond, false, nil); err == nil {
 			t.Fatal("expected error for unreachable endpoint")
 		}
 	})
@@ -109,7 +110,7 @@ func TestS3ListBucketsProbe(t *testing.T) {
 	t.Run("tls verify failure", func(t *testing.T) {
 		srv := httptest.NewTLSServer(fakeS3ListBuckets(http.StatusOK, listBucketsXML))
 		t.Cleanup(srv.Close)
-		if err := s3ListBucketsProbe(ctx, srv.URL, "us-east-1", s3TestAccessKey, s3TestSecretKey, time.Second, false); err == nil {
+		if err := s3ListBucketsProbe(ctx, srv.URL, "us-east-1", s3TestAccessKey, s3TestSecretKey, time.Second, false, nil); err == nil {
 			t.Fatal("expected TLS error")
 		}
 	})
@@ -117,13 +118,23 @@ func TestS3ListBucketsProbe(t *testing.T) {
 	t.Run("tls insecure skip verify", func(t *testing.T) {
 		srv := httptest.NewTLSServer(fakeS3ListBuckets(http.StatusOK, listBucketsXML))
 		t.Cleanup(srv.Close)
-		if err := s3ListBucketsProbe(ctx, srv.URL, "us-east-1", s3TestAccessKey, s3TestSecretKey, time.Second, true); err != nil {
+		if err := s3ListBucketsProbe(ctx, srv.URL, "us-east-1", s3TestAccessKey, s3TestSecretKey, time.Second, true, nil); err != nil {
 			t.Fatalf("expected success with insecureSkipVerify, got %v", err)
 		}
 	})
 
+	t.Run("tls custom CA cert", func(t *testing.T) {
+		srv := httptest.NewTLSServer(fakeS3ListBuckets(http.StatusOK, listBucketsXML))
+		t.Cleanup(srv.Close)
+		pool := x509.NewCertPool()
+		pool.AddCert(srv.Certificate())
+		if err := s3ListBucketsProbe(ctx, srv.URL, "us-east-1", s3TestAccessKey, s3TestSecretKey, time.Second, false, pool); err != nil {
+			t.Fatalf("expected success with custom CA, got %v", err)
+		}
+	})
+
 	t.Run("endpoint missing scheme", func(t *testing.T) {
-		if err := s3ListBucketsProbe(ctx, "s3.example.svc:443", "us-east-1", s3TestAccessKey, s3TestSecretKey, time.Second, false); err == nil {
+		if err := s3ListBucketsProbe(ctx, "s3.example.svc:443", "us-east-1", s3TestAccessKey, s3TestSecretKey, time.Second, false, nil); err == nil {
 			t.Fatal("expected error for endpoint without scheme")
 		}
 	})

--- a/internal/controller/validation_s3_test.go
+++ b/internal/controller/validation_s3_test.go
@@ -87,7 +87,7 @@ func TestS3ListBucketsProbe(t *testing.T) {
 	t.Run("reachable", func(t *testing.T) {
 		srv := httptest.NewServer(fakeS3ListBuckets(http.StatusOK, listBucketsXML))
 		t.Cleanup(srv.Close)
-		if err := s3ListBucketsProbe(ctx, srv.URL, "us-east-1", s3TestAccessKey, s3TestSecretKey, time.Second); err != nil {
+		if err := s3ListBucketsProbe(ctx, srv.URL, "us-east-1", s3TestAccessKey, s3TestSecretKey, time.Second, false); err != nil {
 			t.Fatalf("expected success, got %v", err)
 		}
 	})
@@ -95,13 +95,13 @@ func TestS3ListBucketsProbe(t *testing.T) {
 	t.Run("403 AccessDenied", func(t *testing.T) {
 		srv := httptest.NewServer(fakeS3ListBuckets(http.StatusForbidden, `<Error><Code>AccessDenied</Code><Message>denied</Message></Error>`))
 		t.Cleanup(srv.Close)
-		if err := s3ListBucketsProbe(ctx, srv.URL, "us-east-1", s3TestAccessKey, s3TestSecretKey, time.Second); err == nil {
+		if err := s3ListBucketsProbe(ctx, srv.URL, "us-east-1", s3TestAccessKey, s3TestSecretKey, time.Second, false); err == nil {
 			t.Fatal("expected error for HTTP 403")
 		}
 	})
 
 	t.Run("unreachable", func(t *testing.T) {
-		if err := s3ListBucketsProbe(ctx, "http://"+localHost+":1", "us-east-1", s3TestAccessKey, s3TestSecretKey, 200*time.Millisecond); err == nil {
+		if err := s3ListBucketsProbe(ctx, "http://"+localHost+":1", "us-east-1", s3TestAccessKey, s3TestSecretKey, 200*time.Millisecond, false); err == nil {
 			t.Fatal("expected error for unreachable endpoint")
 		}
 	})
@@ -109,13 +109,21 @@ func TestS3ListBucketsProbe(t *testing.T) {
 	t.Run("tls verify failure", func(t *testing.T) {
 		srv := httptest.NewTLSServer(fakeS3ListBuckets(http.StatusOK, listBucketsXML))
 		t.Cleanup(srv.Close)
-		if err := s3ListBucketsProbe(ctx, srv.URL, "us-east-1", s3TestAccessKey, s3TestSecretKey, time.Second); err == nil {
+		if err := s3ListBucketsProbe(ctx, srv.URL, "us-east-1", s3TestAccessKey, s3TestSecretKey, time.Second, false); err == nil {
 			t.Fatal("expected TLS error")
 		}
 	})
 
+	t.Run("tls insecure skip verify", func(t *testing.T) {
+		srv := httptest.NewTLSServer(fakeS3ListBuckets(http.StatusOK, listBucketsXML))
+		t.Cleanup(srv.Close)
+		if err := s3ListBucketsProbe(ctx, srv.URL, "us-east-1", s3TestAccessKey, s3TestSecretKey, time.Second, true); err != nil {
+			t.Fatalf("expected success with insecureSkipVerify, got %v", err)
+		}
+	})
+
 	t.Run("endpoint missing scheme", func(t *testing.T) {
-		if err := s3ListBucketsProbe(ctx, "s3.example.svc:443", "us-east-1", s3TestAccessKey, s3TestSecretKey, time.Second); err == nil {
+		if err := s3ListBucketsProbe(ctx, "s3.example.svc:443", "us-east-1", s3TestAccessKey, s3TestSecretKey, time.Second, false); err == nil {
 			t.Fatal("expected error for endpoint without scheme")
 		}
 	})

--- a/internal/controller/validation_s3_test.go
+++ b/internal/controller/validation_s3_test.go
@@ -246,3 +246,86 @@ func TestReconcileValidation_S3ListBucketsDiscovered(t *testing.T) {
 		t.Fatalf("expected StorageReady=True StorageReachable for discovered S3, got %+v", found)
 	}
 }
+
+func TestReconcileValidation_S3CACertSecretMissing(t *testing.T) {
+	cfg := &costv1alpha1.CostManagementServiceConfig{
+		ObjectMeta: metav1.ObjectMeta{Name: testCRName, Namespace: testNamespace},
+		Spec:       bundledNoKafkaSpec(),
+	}
+	useSSL := true
+	cfg.Spec.ObjectStorage = costv1alpha1.ObjectStorageConfig{
+		Endpoint:         localHost,
+		Port:             443,
+		UseSSL:           &useSSL,
+		SecretName:       s3TestSecret,
+		CACertSecretName: "no-such-ca",
+		S3:               costv1alpha1.S3Options{Region: "us-east-1"},
+	}
+
+	r := newValidationReconciler(t, s3CredsSecret(s3TestSecret))
+	_, _ = r.reconcileValidation(context.Background(), cfg)
+
+	found := findCondition(cfg.Status.Conditions, costv1alpha1.ConditionStorageReady)
+	if found == nil || found.Status != metav1.ConditionFalse {
+		t.Fatalf("expected StorageReady=False, got %+v", found)
+	}
+	if found.Reason != "StorageCACertInvalid" {
+		t.Errorf("reason = %q, want StorageCACertInvalid", found.Reason)
+	}
+}
+
+func TestReconcileValidation_S3CACertInvalidPEM(t *testing.T) {
+	cfg := &costv1alpha1.CostManagementServiceConfig{
+		ObjectMeta: metav1.ObjectMeta{Name: testCRName, Namespace: testNamespace},
+		Spec:       bundledNoKafkaSpec(),
+	}
+	useSSL := true
+	cfg.Spec.ObjectStorage = costv1alpha1.ObjectStorageConfig{
+		Endpoint:         localHost,
+		Port:             443,
+		UseSSL:           &useSSL,
+		SecretName:       s3TestSecret,
+		CACertSecretName: "bad-ca",
+		S3:               costv1alpha1.S3Options{Region: "us-east-1"},
+	}
+
+	badCASecret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{Name: "bad-ca", Namespace: testNamespace},
+		Data:       map[string][]byte{"ca.crt": []byte("not-a-pem")},
+	}
+
+	r := newValidationReconciler(t, s3CredsSecret(s3TestSecret), badCASecret)
+	_, _ = r.reconcileValidation(context.Background(), cfg)
+
+	found := findCondition(cfg.Status.Conditions, costv1alpha1.ConditionStorageReady)
+	if found == nil || found.Status != metav1.ConditionFalse {
+		t.Fatalf("expected StorageReady=False, got %+v", found)
+	}
+	if found.Reason != "StorageCACertInvalid" {
+		t.Errorf("reason = %q, want StorageCACertInvalid", found.Reason)
+	}
+}
+
+func TestReconcileValidation_S3InsecureSkipVerifyBypassesCACert(t *testing.T) {
+	srv := httptest.NewTLSServer(fakeS3ListBuckets(http.StatusOK, listBucketsXML))
+	t.Cleanup(srv.Close)
+
+	cfg := &costv1alpha1.CostManagementServiceConfig{
+		ObjectMeta: metav1.ObjectMeta{Name: testCRName, Namespace: testNamespace},
+		Spec:       bundledNoKafkaSpec(),
+	}
+	cfg.Spec.ObjectStorage = objectStorageForServer(t, srv, s3TestSecret)
+	cfg.Spec.ObjectStorage.InsecureSkipVerify = true
+	cfg.Spec.ObjectStorage.CACertSecretName = "stale-ca-that-does-not-exist"
+
+	r := newValidationReconciler(t, s3CredsSecret(s3TestSecret))
+	_, _ = r.reconcileValidation(context.Background(), cfg)
+
+	found := findCondition(cfg.Status.Conditions, costv1alpha1.ConditionStorageReady)
+	if found == nil || found.Status != metav1.ConditionTrue {
+		t.Fatalf("expected StorageReady=True (insecureSkipVerify bypasses CA), got %+v", found)
+	}
+	if found.Reason != "StorageReachable" {
+		t.Errorf("reason = %q, want StorageReachable", found.Reason)
+	}
+}

--- a/internal/controller/validation_test.go
+++ b/internal/controller/validation_test.go
@@ -121,7 +121,7 @@ func TestJWKSProbe(t *testing.T) {
 }
 
 // -----------------------------------------------------------------------------
-// checkSecretKeys
+// getSecret
 // -----------------------------------------------------------------------------
 
 func TestCheckSecretKeys(t *testing.T) {
@@ -151,18 +151,18 @@ func TestCheckSecretKeys(t *testing.T) {
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			got, err := r.checkSecretKeys(context.Background(), testNamespace, tc.secret, tc.required)
+			got, err := r.getSecret(context.Background(), testNamespace, tc.secret, tc.required)
 			if (err != nil) != tc.wantErr {
-				t.Errorf("checkSecretKeys(%q): err=%v, wantErr=%v", tc.secret, err, tc.wantErr)
+				t.Errorf("getSecret(%q): err=%v, wantErr=%v", tc.secret, err, tc.wantErr)
 			}
 			if !tc.wantErr && got == nil {
-				t.Error("checkSecretKeys should return the Secret on success")
+				t.Error("getSecret should return the Secret on success")
 			}
 			if !tc.wantErr && got != nil && got.Name != tc.secret {
 				t.Errorf("returned Secret.Name = %q, want %q", got.Name, tc.secret)
 			}
 			if tc.wantErr && got != nil {
-				t.Error("checkSecretKeys should return nil Secret on error")
+				t.Error("getSecret should return nil Secret on error")
 			}
 		})
 	}
@@ -434,7 +434,7 @@ func findCondition(conditions []metav1.Condition, condType string) *metav1.Condi
 }
 
 // TestDBSecretValidationRequiresKruizeCredentials verifies that the database
-// Secret validation (checkSecretKeys) includes kruize-user and kruize-password.
+// Secret validation (getSecret) includes kruize-user and kruize-password.
 // Kruize connects to the same PostgreSQL instance; missing its credentials
 // causes Kruize pods to fail silently after migrations complete.
 func TestDBSecretValidationRequiresKruizeCredentials(t *testing.T) {
@@ -464,9 +464,9 @@ func TestDBSecretValidationRequiresKruizeCredentials(t *testing.T) {
 		"rbac-user", "rbac-password",
 		"kruize-user", "kruize-password",
 	}
-	_, err := r.checkSecretKeys(context.Background(), testNamespace, testDBSecret, requiredKeys)
+	_, err := r.getSecret(context.Background(), testNamespace, testDBSecret, requiredKeys)
 	if err == nil {
-		t.Error("checkSecretKeys should fail when kruize-user/kruize-password are absent, got nil")
+		t.Error("getSecret should fail when kruize-user/kruize-password are absent, got nil")
 	}
 }
 

--- a/internal/controller/validation_test.go
+++ b/internal/controller/validation_test.go
@@ -151,9 +151,18 @@ func TestCheckSecretKeys(t *testing.T) {
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			err := r.checkSecretKeys(context.Background(), testNamespace, tc.secret, tc.required)
+			got, err := r.checkSecretKeys(context.Background(), testNamespace, tc.secret, tc.required)
 			if (err != nil) != tc.wantErr {
 				t.Errorf("checkSecretKeys(%q): err=%v, wantErr=%v", tc.secret, err, tc.wantErr)
+			}
+			if !tc.wantErr && got == nil {
+				t.Error("checkSecretKeys should return the Secret on success")
+			}
+			if !tc.wantErr && got != nil && got.Name != tc.secret {
+				t.Errorf("returned Secret.Name = %q, want %q", got.Name, tc.secret)
+			}
+			if tc.wantErr && got != nil {
+				t.Error("checkSecretKeys should return nil Secret on error")
 			}
 		})
 	}
@@ -455,7 +464,7 @@ func TestDBSecretValidationRequiresKruizeCredentials(t *testing.T) {
 		"rbac-user", "rbac-password",
 		"kruize-user", "kruize-password",
 	}
-	err := r.checkSecretKeys(context.Background(), testNamespace, testDBSecret, requiredKeys)
+	_, err := r.checkSecretKeys(context.Background(), testNamespace, testDBSecret, requiredKeys)
 	if err == nil {
 		t.Error("checkSecretKeys should fail when kruize-user/kruize-password are absent, got nil")
 	}


### PR DESCRIPTION
## Summary

Follow-ups from PR #67 review:

- **refactor: return fetched Secret from checkSecretKeys** — eliminates a duplicate `r.Get()` in `validateObjectStorage` (two API server round-trips per reconcile for the same Secret)
- **feat: S3 probe InsecureSkipVerify** — dev/CRC setups behind self-signed certs can validate S3 connectivity via `spec.objectStorage.insecureSkipVerify`
- **feat: S3 probe CACertSecretName** — production deployments with private CAs get a green `StorageReady` condition via `spec.objectStorage.caCertSecretName`
- **fix: clone DefaultTransport** — S3 probe now clones `http.DefaultTransport` (matching the JWKS probe) to preserve proxy, dial timeout, and keep-alive settings
- **fix: skip CA check when insecureSkipVerify** — a stale `caCertSecretName` no longer blocks the probe when `insecureSkipVerify: true`
- **docs: track S3 TLS probe-only gap** — `insecureSkipVerify` and `caCertSecretName` only affect the validation probe, not app pod env/volumes (follow-up #9)

## Test plan

- [x] `go test ./internal/controller/... -count=1` — 160 tests pass
- [x] `golangci-lint run ./...` clean
- [x] Existing S3 probe tests pass after refactor
- [x] New test: `tls insecure skip verify` — self-signed TLS server succeeds with flag
- [x] New test: `tls custom CA cert` — self-signed TLS server succeeds with CA pool
- [x] New test: `StorageCACertInvalid` — missing CA Secret sets condition
- [x] New test: `StorageCACertInvalid` — invalid PEM sets condition
- [x] New test: `InsecureSkipVerify bypasses CA` — stale CA Secret ignored when insecure

## Summary by Sourcery

Introduce configurable TLS behavior for S3 object storage validation, including support for self-signed and private CA endpoints, while refactoring secret validation to return the fetched Secret and updating tests and documentation accordingly.

New Features:
- Add TLS configuration options for S3 validation, including insecureSkipVerify and a CA certificate secret reference.

Enhancements:
- Reuse fetched Secrets from validation checks to avoid duplicate API calls when validating object storage and other dependencies.
- Extend S3 ListBuckets validation probe to support custom TLS settings and improve coverage for TLS-related scenarios.
- Document that S3 TLS configuration currently affects only operator probes, not application pods, and outline wiring work needed.

Build:
- Update CRD schema to expose new S3 TLS fields on the CostManagementServiceConfig spec.

Documentation:
- Add review follow-up notes explaining limitations of S3 TLS fields and recommended integration with application trust configuration.

Tests:
- Expand S3 validation tests to cover TLS failure, insecureSkipVerify behavior, custom CA certificates, and StorageReady condition outcomes.
- Update secret validation tests to assert that checkSecretKeys returns the fetched Secret on success and nil on error.