### PR TITLE
[COST-8095] Move profile sizing to post-beta scope

### DIFF
--- a/docs/gap_analysis/BETA-PRIORITY.md
+++ b/docs/gap_analysis/BETA-PRIORITY.md
@@ -1,7 +1,7 @@
 # Beta Gap Priority Summary
 
-**Audited inputs:** [COST-7678](COST-7678.md)–[COST-7685](COST-7685.md), [COST-7687](COST-7687.md)–[COST-7692](COST-7692.md) (2026-08-10; refreshed for `spec.ros.enabled` / `ROSEnabled`)
-**Also considered:** [docs/tasks.md](../tasks.md) (COST-7686, COST-7693–7700 — no per-ticket gap docs yet)
+**Audited inputs:** [COST-7678](COST-7678.md)–[COST-7692](COST-7692.md) (2026-08-10; refreshed for `spec.ros.enabled` / `ROSEnabled` and COST-7686)
+**Also considered:** [docs/tasks.md](../tasks.md) (COST-7693–7700 — no per-ticket gap docs yet)
 **Beta bar used here:** A beta customer can install the operator, apply a BYOI `CostManagementServiceConfig` with **`ros.enabled: false`**, reach an honest Ready/Available state for the **core Cost** stack (Koku/Masu/Listener, Celery on-prem workers, RBAC, Ingress, Gateway, UI — **not ROS, not Kruize**), and not hit silent false-success or plaintext-secret API footguns. HA polish, full monitoring parity, E2E suites, and day-2 rotation can trail.
 
 **Scope note (2026-08-10):** ROS and Kruize are **out of beta**. Name them separately in gaps (different secrets, migrate, readiness). Optional install, independent Kruize enablement, and day-2 enablement are owned by **[COST-8054](../jira/COST-8054.md)** — not by COST-7678–7692 closure.
@@ -39,7 +39,7 @@ Several paths report success while the underlying dependency is wrong or while a
 | OIDC HTTP probe accepts any status &lt; 500 | [7684 G3](COST-7684.md) | 401/404 still `AuthenticationReady=True` |
 | External DB secret validation omits `kruize-user` / `kruize-password` | [7684 R3](COST-7684.md) | **→ [COST-8054](../jira/COST-8054.md)** (Kruize); not a Cost beta blocker |
 | External DB secret validation always requires `ros-user` / `ros-password` | [7684](COST-7684.md), [8054](../jira/COST-8054.md) | **→ [COST-8054](../jira/COST-8054.md)** — blocks true Cost-only BYOI even when `ros.enabled=false` |
-| RBAC Deployments applied but never gated; no `RBACReady` | [7689 G2](COST-7689.md) | Core can go Available while RBAC is down |
+| RBAC Deployments applied but never gated; no `RBACReady` | [7689 G1](COST-7689.md) | Core can go Available while RBAC is down |
 | `UIReady` / Ingress / workers not truly readiness-gated | [7690 R2](COST-7690.md), [7688 R4](COST-7688.md), [7687](COST-7687.md) | Weaker than RBAC/S3; still erodes trust in status |
 
 **Beta minimum:** fix Auth condition collision + S3 secret-key check + tighten OIDC success + RBAC readiness gate.
@@ -73,15 +73,13 @@ Several paths report success while the underlying dependency is wrong or while a
 
 | Gap | Tickets | Rank |
 |-----|---------|------|
-| SaaS-only Celery queues (`hcs`, `subs_extraction`, `subs_transmission`) still deploy at `replicas: 1` | [7687 G2](COST-7687.md) | **P0** — wasted resources + wrong on-prem shape |
+| SaaS-only Celery queues (`hcs`, `subs_extraction`, `subs_transmission`) still deploy at `replicas: 1` | [7687 G1](COST-7687.md) | **P0** — wasted resources + wrong on-prem shape |
 
 ---
 
-### T5. Profile / HA sizing (many tickets, one deliverable) — **P2 for beta**
+### T5. Size Profiles — **out of Cost beta** → [COST-8095](https://redhat.atlassian.net/browse/COST-8095)
 
-`spec.profile` exists; **no code reads it**. Called out as G1/G4 across [7678](COST-7678.md), [7687](COST-7687.md), [7689](COST-7689.md), [7690](COST-7690.md); also [tasks.md](../tasks.md) COST-7686 / 7693.
-
-**Beta stance:** ship `profile: standard` only; document that `ha` is reserved. Implement one shared sizing map post-beta (or late beta if HA demos are required).
+Not a beta theme. Shared maps + `profile: ha` sample are P2 item 21 / [COST-8095](https://redhat.atlassian.net/browse/COST-8095). Beta ships `profile: standard` + per-component `spec.*.resources` (UI already reads profile when `spec.ui.*.resources` are unset — [#65](https://github.com/project-koku/koku-service-operator/pull/65)).
 
 ---
 
@@ -116,7 +114,8 @@ Several paths report success while the underlying dependency is wrong or while a
 | App ServiceMonitors largely non-functional (ports/Services/NP) | [7692 G2](COST-7692.md) | **P2** unless beta promises in-cluster scrape |
 | Custom operator metrics + ticket alert names | [7692 G1/G3](COST-7692.md) | **P2** |
 | Missing Event reasons (`PhaseChanged`, `DependencyFailed`, …) | [7692 G4](COST-7692.md), [7680 G3](COST-7680.md) | **P2** |
-| Minimal + HA sample CRs | [7679 G1/G2](COST-7679.md) | **P1** for beta docs/demos |
+| Minimal sample CR | [7679 G1](COST-7679.md) | **P1** for beta docs/demos |
+| Production sample (beta = BYOI Cost-only + monitoring) | [7679 G2](COST-7679.md) | **Done** — BYOI template; HA sample → [COST-8095](https://redhat.atlassian.net/browse/COST-8095) |
 | Legacy stale CRD file still in tree | [7679 R1](COST-7679.md), [7678 R2](COST-7678.md) | **Resolved** (file removed; CRC path uses `make install`) |
 | BYOI template keeps `kruize:` block while `ros.enabled: false` | [7679 R3](COST-7679.md) | **P2** (docs clarity) |
 
@@ -127,7 +126,6 @@ Several paths report success while the underlying dependency is wrong or while a
 | Ticket | Summary | Suggested beta rank |
 |--------|---------|---------------------|
 | [COST-7695](https://redhat.atlassian.net/browse/COST-7695) | OLM bundle | **P0** if beta is delivered via OLM; else P1 |
-| [COST-7686](https://redhat.atlassian.net/browse/COST-7686) | App services — profile sizing + 5m readiness → Degraded | Profile **P2**; readiness timeout **P1** |
 | [COST-7693](https://redhat.atlassian.net/browse/COST-7693) | Upgrade/scaling/rollback | **P2** (basic image-tag migrate exists) |
 | [COST-7694](https://redhat.atlassian.net/browse/COST-7694) | Secret rotation annotation | **P2** (day-2); CA merge overlaps [7691 G3](COST-7691.md) **P1** |
 | [COST-7696](https://redhat.atlassian.net/browse/COST-7696)–[7699](https://redhat.atlassian.net/browse/COST-7699) | Bundle CI / E2E / OpenShift CI | **P2** for beta; **P1** if beta needs automated install proof |
@@ -144,17 +142,17 @@ Tickets marked ✅ in `tasks.md` that gap audits found incomplete: **7683, 7684,
 1. **Auth status honesty** — Split/compose gateway vs OIDC; stop Edge clearing `OIDCUnreachable` ([7688 G1](COST-7688.md) / [7684 R1](COST-7684.md)).
 2. **S3 credential validation** — `checkSecretKeys` on `objectStorage.secretName`; fail `StorageReady` on missing keys ([7684 G2](COST-7684.md)).
 3. **Remove/replace `RealmUser.Password`** in Spec ([7678 R1](COST-7678.md)).
-4. **Exclude SaaS Celery queues** by default (`replicas: 0` or omit) ([7687 G2](COST-7687.md)).
+4. **Exclude SaaS Celery queues** by default (`replicas: 0` or omit) ([7687 G1](COST-7687.md)).
 5. **BYOI StorageClass soft-fail** when no bundled PVC consumers ([7682 R1](COST-7682.md)).
 6. **`objectbucket.io` RBAC** if OBC is in-scope for beta ([7683 G1](COST-7683.md)); otherwise document user-secret-only.
 7. **OIDC probe** — require 2xx + parse JWKS `keys` ([7684 G3](COST-7684.md)).
-8. **RBAC readiness gate + condition** before core Available ([7689 G2](COST-7689.md)).
+8. **RBAC readiness gate + condition** before core Available ([7689 G1](COST-7689.md)).
 9. **OLM bundle** ([COST-7695](../tasks.md)) if that is the beta install vehicle.
 
 ### P1 — Ship with beta if possible
 
 10. OpenAPI/CEL markers (ports, `sslMode`, conditional BYOI required fields) ([7678 G2](COST-7678.md)).
-11. Minimal sample CR + remove/stop applying legacy CRD ([7679 G1/R1](COST-7679.md) / [7678 R2](COST-7678.md)); point CRC docs at `make install` or the canonical base only.
+11. Minimal sample CR + remove/stop applying legacy CRD ([7679 G1/R1](COST-7679.md) / [7678 R2](COST-7678.md)); point CRC docs at `make install` or the canonical base only. Beta **production** sample is the BYOI Cost-only template ([7679 G2](COST-7679.md) done).
 12. Pause annotation ([7680 G1](COST-7680.md)) + fix Ready Event spam ([7680 G3](COST-7680.md)).
 13. Envoy ConfigMap checksum rollout + ingress timeouts ([7688 R3/R1](COST-7688.md)).
 14. User/proxy CA merge into combined bundle ([7691 G3](COST-7691.md) / COST-7694 overlap).
@@ -167,24 +165,23 @@ Tickets marked ✅ in `tasks.md` that gap audits found incomplete: **7683, 7684,
 
 ### P2 — After beta / toward GA (Cost core)
 
-21. Shared **profile sizing maps** for Cost workloads + wire ([7678 G4](COST-7678.md) + 7686/87/89/90/93). ROS/Kruize map rows → COST-8054.
-22. HA sample + `profile: ha` behavior ([7679 G2](COST-7679.md)).
-23. Monitoring: real **Cost** scrape targets, operator metrics, alert parity ([7692](COST-7692.md)). ROS/Kruize scrapes → COST-8054.
-24. Full NetworkPolicy / dedicated SA matrix for **core** ([7691](COST-7691.md)). ROS/Kruize matrix → COST-8054.
-25. Route admission gating ([7691 G4](COST-7691.md)); UI Route global-domain fallback ([7691 R4](COST-7691.md)); `Available` vs `StorageReady` policy ([7683 R2](COST-7683.md)).
-26. Wait-path exponential backoff ([7680 G2](COST-7680.md)); richer Events ([7692 G4](COST-7692.md)).
-27. Secret rotation annotation (COST-7694); upgrade rollback / rolling strategy (COST-7693).
-28. E2E + OpenShift CI (COST-7697–7699); tighten `Env` maps ([7678 R1](COST-7678.md)).
-29. `dataRetentionMonths` → `RETAIN_NUM_MONTHS` wired in `KokuCommonEnv` with Go-level fallback to `4` ([7678 G3](COST-7678.md) closed).
+21. Shared **profile sizing maps** + HA sample CR (`profile: ha`) ([COST-8095](https://redhat.atlassian.net/browse/COST-8095); was [7678 G4](COST-7678.md) / 7686/87/89/90/93 + Jira’s HA clause on [7679](COST-7679.md)). Beta production sample remains BYOI Cost-only ([7679 G2](COST-7679.md) done). UI partial wiring already landed ([#65](https://github.com/project-koku/koku-service-operator/pull/65)); ROS/Kruize map rows when those components reconcile (coordinate with COST-8054).
+22. Monitoring: real **Cost** scrape targets, operator metrics, alert parity ([7692](COST-7692.md)). ROS/Kruize scrapes → COST-8054.
+23. Full NetworkPolicy / dedicated SA matrix for **core** ([7691](COST-7691.md)). ROS/Kruize matrix → COST-8054.
+24. Route admission gating ([7691 G4](COST-7691.md)); UI Route global-domain fallback ([7691 R4](COST-7691.md)); `Available` vs `StorageReady` policy ([7683 R2](COST-7683.md)).
+25. Wait-path exponential backoff ([7680 G2](COST-7680.md)); richer Events ([7692 G4](COST-7692.md)).
+26. Secret rotation annotation (COST-7694); upgrade rollback / rolling strategy (COST-7693).
+27. E2E + OpenShift CI (COST-7697–7699); tighten `Env` maps ([7678 R1](COST-7678.md)).
+28. `dataRetentionMonths` → `RETAIN_NUM_MONTHS` wired in `KokuCommonEnv` with Go-level fallback to `4` ([7678 G3](COST-7678.md) closed).
 
 ### → [COST-8054](../jira/COST-8054.md) — ROS and Kruize (not Cost beta)
 
 Track separately; do not conflate the two components. **Partial progress already in-tree** (`spec.ros.enabled` gate + cleanup + BYOI samples).
 
-30. Finish Cost-only honesty: conditional `ros-*` / `kruize-*` Validation keys; independent Kruize enablement (or document “Kruize requires ROS”); day-2 enable without reinstall.
-31. Wire ROS Processor/Poller/Housekeeper to ROS SA ([7691 G2](COST-7691.md)); ROS NPs.
-32. Kruize DB secret keys in Validation ([7684 R3](COST-7684.md)); Kruize SM port/`metrics` ([7692](COST-7692.md)).
-33. ROS processor/poller Services + scrape; ROS/Kruize profile sizing rows; optional ROS bucket discovery ([7683](COST-7683.md)).
+29. Finish Cost-only honesty: conditional `ros-*` / `kruize-*` Validation keys; independent Kruize enablement (or document “Kruize requires ROS”); day-2 enable without reinstall.
+30. Wire ROS Processor/Poller/Housekeeper to ROS SA ([7691 G2](COST-7691.md)); ROS NPs.
+31. Kruize DB secret keys in Validation ([7684 R3](COST-7684.md)); Kruize SM port/`metrics` ([7692](COST-7692.md)).
+32. ROS processor/poller Services + scrape; optional ROS bucket discovery ([7683](COST-7683.md)).
 
 ### Accept / defer
 
@@ -218,7 +215,7 @@ Track separately; do not conflate the two components. **Partial progress already
 | Validation always requires `ros-user` / `ros-password` | Cost-only BYOI secrets cannot omit ROS keys |
 | No independent Kruize flag (tied to ROS) | Product optionality incomplete |
 | Day-2 enable polish / docs | Full AC of 8054 |
-| Hardening (SA, NP, SM, profile rows, bucket discovery) | Post-beta ROS/Kruize quality |
+| Hardening (SA, NP, SM, bucket discovery) | Post-beta ROS/Kruize quality |
 
 **Beta posture today:** CRD and samples default `ros.enabled: false`; do not gate Available on ROS/Kruize; treat unused `ros-*` secret keys as a known COST-8054 footgun until Validation is conditional.
 
@@ -231,22 +228,23 @@ S3/OBC items stay relevant either way — Ingress/uploads still need object stor
 | Ticket | Verdict from audit | Highest open gap for beta |
 |--------|--------------------|---------------------------|
 | [COST-7678](COST-7678.md) | Not done | Password in Spec (R1 / P0); validation/webhooks (P1) |
-| [COST-7679](COST-7679.md) | Not done | Minimal sample + legacy CRD (P1) |
+| [COST-7679](COST-7679.md) | Not done | Minimal sample (P1); beta production BYOI G2 done; HA sample → [COST-8095](https://redhat.atlassian.net/browse/COST-8095) |
 | [COST-7680](COST-7680.md) | Not done | Pause + Ready Event bug (P1); wait-path backoff Partial (P2) |
 | [COST-7681](COST-7681.md) | Largely done | Bundled SSA — defer |
 | [COST-7682](COST-7682.md) | Done | BYOI StorageClass soft-fail (P0) |
 | [COST-7683](COST-7683.md) | Not fully done | OBC RBAC (P0 if OBC in scope) |
 | [COST-7684](COST-7684.md) | Not fully done | S3 keys + Auth overwrite + OIDC (P0); always-required `ros-*` keys + Kruize keys R3 → [COST-8054](../jira/COST-8054.md) |
 | [COST-7685](COST-7685.md) | Done | Tests only (G1); ROS migrate skip already gated by `ros.enabled` |
-| [COST-7687](COST-7687.md) | Not fully done | SaaS queue exclusion (P0); ROS/Kruize workloads gated when disabled; sizing → [COST-8054](../jira/COST-8054.md) |
+| [COST-7686](COST-7686.md) | Not fully done | Readiness timeout (P1); profile sizing → [COST-8095](https://redhat.atlassian.net/browse/COST-8095) |
+| [COST-7687](COST-7687.md) | Not fully done | SaaS queue exclusion (P0) |
 | [COST-7688](COST-7688.md) | Largely done | Auth condition collision (P0) |
 | [COST-7689](COST-7689.md) | Not done | RBAC readiness (P0) |
-| [COST-7690](COST-7690.md) | Not fully done | Profile sizing (P2); Related `UIReady` ≠ pods Ready (T1 trust) |
+| [COST-7690](COST-7690.md) | Done (UI AC) | Related `UIReady` ≠ pods Ready (T1 trust) |
 | [COST-7691](COST-7691.md) | Not done | CA merge + core NPs (P1); ROS/Kruize SA/NP → [COST-8054](../jira/COST-8054.md) |
-| [COST-7692](COST-7692.md) | Not done | Monitoring completeness (P2); Kruize SM only when `ROSEnabled`; ROS/Kruize SM → [COST-8054](../jira/COST-8054.md) |
+| [COST-7692](COST-7692.md) | Not done | Monitoring completeness (P2); Kruize SM still applied when ROS disabled → [COST-8054](../jira/COST-8054.md) |
 | [COST-8054](../jira/COST-8054.md) | In progress (partial) | Conditional Validation keys; independent Kruize; day-2; hardening gaps |
 
-No gap doc yet for **COST-7686** (app services) — treat readiness timeout as P1 and profile sizing as part of T5.
+No gap doc yet for **COST-7693**–**7700**.
 
 ---
 
@@ -258,5 +256,6 @@ No gap doc yet for **COST-7686** (app services) — treat readiness timeout as P
 - On-prem Celery footprint excludes SaaS queues by default.
 - RBAC API readiness participates in core Available.
 - Install path documented (and OLM-bundled if that is the channel); samples/docs use `ros.enabled: false` and call ROS/Kruize unsupported in beta (remaining optionality → [COST-8054](../jira/COST-8054.md)).
+- **Production sample** for beta = monitoring-enabled BYOI Cost-only (`profile: standard`); bundled = CRC/dev only; HA sample → [COST-8095](https://redhat.atlassian.net/browse/COST-8095).
 - Ideally: Cost-only Validation does not require `ros-*` keys (COST-8054 P1 item above).
-- ROS and Kruize hardening, `profile: ha`, full NetworkPolicy matrix, scrapable metrics, secret rotation, and E2E remain explicitly out of Cost beta scope unless product expands the bar.
+- ROS and Kruize hardening, shared profile sizing maps ([COST-8095](https://redhat.atlassian.net/browse/COST-8095)), full NetworkPolicy matrix, scrapable metrics, secret rotation, and E2E remain explicitly out of Cost beta scope unless product expands the bar.

--- a/docs/gap_analysis/COST-7678.md
+++ b/docs/gap_analysis/COST-7678.md
@@ -3,16 +3,11 @@
 **Jira:** [COST-7678](https://redhat.atlassian.net/browse/COST-7678)
 **Audited:** 2026-08-10 · **Closed (docs):** 2026-08-16
 **Purpose:** Handoff audit of CRD type surface vs ticket acceptance criteria.
-**Beta scope:** ROS and Kruize are **out of beta** ([BETA-PRIORITY.md](BETA-PRIORITY.md)). Keeping `ros` / `kruize` Spec types and defaulted partition flags is fine; optional enablement and ROS/Kruize profile sizing → [COST-8054](../jira/COST-8054.md).
+**Beta scope:** ROS and Kruize are **out of beta** ([BETA-PRIORITY.md](BETA-PRIORITY.md)). Keeping `ros` / `kruize` Spec types and defaulted partition flags is fine; optional enablement → [COST-8054](../jira/COST-8054.md).
 
 ## Verdict
 
-**COST-7678 is done** for the CRD/API deliverables in scope. G1–G3 merged on `main`; intentional deviations documented below. **G4 (profile sizing maps)** is **partially delivered and partially deferred** — not a blocker for closing this ticket:
-
-- `spec.profile` enum `standard` / `ha` with CRD default `standard` ([#65](https://github.com/project-koku/koku-service-operator/pull/65) re-added `ha`; [#28](https://github.com/project-koku/koku-service-operator/pull/28) had temporarily removed it).
-- **Partial wiring:** `spec.profile` is read by the UI builder when `spec.ui.oauthProxy.resources` / `spec.ui.app.resources` are unset — [`uiProfileResources`](../../internal/resources/ui.go) ([#65](https://github.com/project-koku/koku-service-operator/pull/65)).
-- **Deferred:** shared `profiles.go` sizing maps and reconciler wiring for Celery, Koku API, Masu, Listener, RBAC, etc. → [COST-7686](https://redhat.atlassian.net/browse/COST-7686) / [COST-7687](https://redhat.atlassian.net/browse/COST-7687) and [BETA-PRIORITY.md](BETA-PRIORITY.md) item 21 (P2 post-beta).
-- ROS/Kruize profile rows → [COST-8054](../jira/COST-8054.md).
+**COST-7678 is done** for the CRD/API deliverables in scope. G1–G3 merged on `main`; intentional deviations documented below. **G4 (profile sizing maps)** is **partially delivered** (enum + UI wiring via [#65](https://github.com/project-koku/koku-service-operator/pull/65)); shared maps are **post-beta** → [COST-8095](https://redhat.atlassian.net/browse/COST-8095), out of Cost beta scope.
 
 Out of scope per ticket: reconciler logic, resource builders.
 
@@ -48,7 +43,7 @@ Out of scope per ticket: reconciler logic, resource builders.
 | App types + `dataRetentionMonths` | Done — default 4, range 1–60, wired to `RETAIN_NUM_MONTHS` |
 | Status: phase, conditions, DiscoveredConfig | Done with intentional phase rename |
 | `ComponentStatus` | Removed (intentional; conditions instead) |
-| `profiles.go`: enum + resource sizing maps | **Partial** — enum `standard`/`ha` ✅ ([#65](https://github.com/project-koku/koku-service-operator/pull/65)); UI defaults from profile ✅ ([#65](https://github.com/project-koku/koku-service-operator/pull/65)); shared maps for other workloads → COST-7686/7687 |
+| `profiles.go`: enum + resource sizing maps | **Partial** — enum + UI ✅ ([#65](https://github.com/project-koku/koku-service-operator/pull/65)); shared maps post-beta → [COST-8095](https://redhat.atlassian.net/browse/COST-8095) |
 | `defaults.go` mutating webhook | Done — noop defaulter; CRD OpenAPI defaults cover profile/monitoring/dataRetentionMonths |
 | `validation.go` webhook + CEL | Done — [#50](https://github.com/project-koku/koku-service-operator/pull/50)/[#51](https://github.com/project-koku/koku-service-operator/pull/51) CEL + [#52](https://github.com/project-koku/koku-service-operator/pull/52) validating webhook |
 | External-only infra (no type field) | Deviated — `deploy *bool` for DB/cache (dev/CI only) |
@@ -90,7 +85,7 @@ Documented in [design-vs-jira.md](../design/design-vs-jira.md) §1–3:
 | `credentialsSecretRef` | `secretName` / Kafka `sasl.existingSecret` | Simpler string refs |
 | `authentication.issuerUrl` required | `auth.keycloak.issuerURL` optional | JWKS `url` can be in-cluster HTTP |
 | External-only infra | `database.deploy` / `cache.deploy` default true | Dev/CI only; production is BYOI |
-| `profiles.go` sizing maps | Partial UI wiring ([#65](https://github.com/project-koku/koku-service-operator/pull/65)); Celery/core maps deferred to COST-7686/7687 | JIRA names a single maps file; beta ships `profile: standard` for most workloads ([BETA-PRIORITY.md](BETA-PRIORITY.md) T5) |
+| `profiles.go` sizing maps | Partial UI wiring ([#65](https://github.com/project-koku/koku-service-operator/pull/65)); remainder post-beta → [COST-8095](https://redhat.atlassian.net/browse/COST-8095) | Out of Cost beta scope |
 
 ---
 
@@ -118,24 +113,9 @@ Mutating + validating webhooks registered. Mutating `Default()` is intentionally
 
 Field, CRD default/range, reconciler `RETAIN_NUM_MONTHS` wiring, and zero-value guard.
 
-### G4. Profile resource sizing maps — partial; remainder deferred (not blocking 7678 closure)
+### G4. Profile resource sizing maps — partial (not blocking 7678 closure)
 
-JIRA names `profiles.go` with sizing maps. **Delivered on `main`:**
-
-| Scope | Status | PR |
-|-------|--------|-----|
-| Enum `standard` / `ha` | Done | [#65](https://github.com/project-koku/koku-service-operator/pull/65) |
-| UI oauth-proxy + app resources from `spec.profile` when `spec.ui.*.resources` unset | Done | [#65](https://github.com/project-koku/koku-service-operator/pull/65) — [`uiProfileResources`](../../internal/resources/ui.go) |
-
-**Deferred** to workload tickets (shared maps + wiring beyond UI):
-
-| Follow-up | Owns |
-|-----------|------|
-| [COST-7686](https://redhat.atlassian.net/browse/COST-7686) | Core app Deployments — profile sizing when wired |
-| [COST-7687](https://redhat.atlassian.net/browse/COST-7687) | Celery workers — sizing maps |
-| [COST-8054](https://redhat.atlassian.net/browse/COST-8054) | ROS/Kruize profile rows |
-
-Until full maps land: use per-component `spec.*.resources` for non-UI workloads; explicit UI `resources` still override profile defaults ([#65](https://github.com/project-koku/koku-service-operator/pull/65)).
+Enum `standard` / `ha` and UI defaults from `spec.profile` when `spec.ui.*.resources` unset are done ([#65](https://github.com/project-koku/koku-service-operator/pull/65) — [`uiProfileResources`](../../internal/resources/ui.go)). Shared maps for other workloads are **post-beta** (not a Cost beta blocker); use per-component `spec.*.resources` until then. Follow-up owner: [COST-8095](https://redhat.atlassian.net/browse/COST-8095).
 
 ---
 

--- a/docs/gap_analysis/COST-7679.md
+++ b/docs/gap_analysis/COST-7679.md
@@ -5,9 +5,11 @@
 **Purpose:** Handoff audit of sample CRs and generated manifests vs ticket acceptance criteria. This document does not update `docs/tasks.md` or other trackers.
 **Beta scope:** ROS and Kruize are **out of beta** ([BETA-PRIORITY.md](BETA-PRIORITY.md)); optional install → [COST-8054](../jira/COST-8054.md). Minimal/BYOI samples need not demonstrate ROS or Kruize; call them unsupported (or omit) in beta docs.
 
+**Production sample (beta definition):** monitoring-enabled **BYOI Cost-only** (`deploy: false`, external infra, `ros.enabled: false`, `profile: standard` / omit). This is **not** deferred with HA. A dedicated `profile: ha` sample is a separate post-beta deliverable → [COST-8095](https://redhat.atlassian.net/browse/COST-8095).
+
 ## Verdict
 
-COST-7679 is **not done**. Generated CRD YAML and CRC install docs exist, and there are useful bundled + BYOI samples beyond the ticket’s two-CR framing — but the acceptance criteria for a **minimal** required-fields sample and a **production/HA** sample (HA profile + resource overrides + monitoring) are unmet. “CR validation works” cannot be closed while CEL/OpenAPI rules from COST-7678 are still absent.
+COST-7679 is **not done**. Generated CRD YAML and CRC install docs exist; the **beta production** sample is met by the BYOI template (see G2). Still open: a **minimal** required-fields sample (G1), and “CR validation works” while CEL/OpenAPI rules from COST-7678 are thin (G3). Bundled sample remains **dev/CRC only**, not production.
 
 ## Sources
 
@@ -30,7 +32,7 @@ Out of scope per ticket: controller implementation.
 | Deliverable | Status |
 |-------------|--------|
 | Minimal sample CR with only required fields | **Missing** — no required-only / schema-minimal sample; existing samples are full surfaces |
-| Production sample CR (HA profile, resource overrides, monitoring enabled) | **Partial** — monitoring on some samples; **no `profile: ha`**, **no CMSC resource overrides** |
+| Production sample CR (beta = BYOI Cost-only, monitoring on) | **Done** — [`…_byoi.yaml`](../../config/samples/service.costmanagement_v1alpha1_costmanagementserviceconfig_byoi.yaml): external infra, `monitoring.enabled: true`, `ros.enabled: false`, `profile: standard` (CRD default). Jira’s `profile: ha` + HA resource overrides → [COST-8095](https://redhat.atlassian.net/browse/COST-8095) (not required to close this AC for beta) |
 | Generated CRD YAML via controller-gen | **Done** |
 | Verified CRD install on OCP 4.20+ (`kubectl`/`oc apply` succeeds, CR validation works) | **Partial** — CRC apply documented; no OCP 4.20 CI proof; validation surface too thin to claim “works” |
 
@@ -53,9 +55,9 @@ GVK: `service.costmanagement.openshift.io` / `v1alpha1` / `CostManagementService
 
 | Path | Role |
 |------|------|
-| [`config/samples/service.costmanagement_v1alpha1_costmanagementserviceconfig.yaml`](../../config/samples/service.costmanagement_v1alpha1_costmanagementserviceconfig.yaml) | Bundled CRC-oriented CR (`database.deploy` / `cache.deploy: true`); `monitoring.enabled: true`; includes ROS/Kruize images |
-| [`config/samples/service.costmanagement_v1alpha1_costmanagementserviceconfig_byoi.yaml`](../../config/samples/service.costmanagement_v1alpha1_costmanagementserviceconfig_byoi.yaml) | BYOI template (`deploy: false` + external hosts/secrets); `monitoring.enabled: true`; `ros.enabled: false` |
-| [`config/samples/byoi/`](../../config/samples/byoi/) | Ready-to-apply local fixture (PG, Valkey, MinIO, Kafka script, optional Prometheus/Grafana) + app CR (`ros.enabled: false`, `monitoring.enabled: false`) |
+| [`config/samples/service.costmanagement_v1alpha1_costmanagementserviceconfig.yaml`](../../config/samples/service.costmanagement_v1alpha1_costmanagementserviceconfig.yaml) | **Dev/CRC only** — bundled infra (`database.deploy` / `cache.deploy: true`); not the production sample |
+| [`config/samples/service.costmanagement_v1alpha1_costmanagementserviceconfig_byoi.yaml`](../../config/samples/service.costmanagement_v1alpha1_costmanagementserviceconfig_byoi.yaml) | **Beta production sample** — BYOI Cost-only (`deploy: false` + external hosts/secrets); `monitoring.enabled: true`; `ros.enabled: false`; `profile: standard` (default) |
+| [`config/samples/byoi/`](../../config/samples/byoi/) | Ready-to-apply local fixture (PG, Valkey, MinIO, Kafka script, optional Prometheus/Grafana) + app CR (`ros.enabled: false`, `monitoring.enabled: false`) — fixture, not the labeled production template |
 | [`config/samples/kustomization.yaml`](../../config/samples/kustomization.yaml) | Includes bundled + BYOI template samples (fixture applied separately via `byoi/{infra,app}`) |
 
 No `*minimal*` sample file exists under `config/samples/`.
@@ -74,8 +76,8 @@ This is stronger than “nothing verified,” but it is **CRC/dev evidence**, no
 | JIRA | Implementation | Rationale |
 |------|----------------|-----------|
 | Kind implied as Cost Management CR | `CostManagementServiceConfig` samples | Naming settled with COST-7678 / OLM |
-| “Two sample CRs” only | Extra BYOI kustomize fixture under `config/samples/byoi/` | Dev/CI convenience; does not replace production HA sample |
-| Production = full HA config | Production path is BYOI (external PG/cache/Kafka/S3) | Matches CLAUDE.md / design: bundled infra is dev-only |
+| “Two sample CRs” only | Extra BYOI kustomize fixture under `config/samples/byoi/` | Dev/CI convenience; production for beta is the BYOI template |
+| Jira “production” = HA profile + overrides + monitoring | **Beta production** = BYOI Cost-only + monitoring; HA sample deferred | Matches CLAUDE.md / design (BYOI) and [COST-8095](https://redhat.atlassian.net/browse/COST-8095) (sizing/`profile: ha`) |
 | Samples may still mention ROS/Kruize | BYOI samples set `ros.enabled: false`; bundled CRC sample still includes ROS/Kruize | ROS/Kruize out of Cost beta; optional enablement → COST-8054 |
 
 ---
@@ -95,19 +97,21 @@ What the CRD actually requires at top-level `spec`: **nothing**. An empty `spec:
 
 Until COST-7678 adds real required/CEL rules, a “minimal” sample should still exist as the smallest **operationally useful** BYOI (or schema-minimal) example, clearly labeled — not a full replica of the CRC bundled CR.
 
-### G2. Production / HA sample — missing (partial overlap only)
+### G2. Production sample (beta) — done; HA sample deferred
 
-Jira production sample must include:
+**Beta definition (explicit):** production = monitoring-enabled **BYOI Cost-only** with `profile: standard` — not deferred with HA.
 
-| Requirement | Status in samples |
-|-------------|-------------------|
-| `spec.profile: ha` | **Absent** — no CMSC sample sets `profile` (API/CRD default `standard`; enum `standard` \| `ha` in types/CRD) |
-| Resource overrides (`*.resources.requests` / `limits` on CMSC components) | **Absent** on all CMSC samples; CPU/memory only on BYOI **infra fixture** pods (PG/Valkey/MinIO/Kafka/Prometheus/Grafana) |
-| `monitoring.enabled: true` | Present on bundled + BYOI **template**; BYOI fixture app CR has `enabled: false` |
+| Requirement | Status |
+|-------------|--------|
+| External infra (`deploy: false` + hosts/secrets) | Done — BYOI template |
+| `monitoring.enabled: true` | Done — BYOI template |
+| Cost-only (`ros.enabled: false`) | Done — BYOI template |
+| `profile: standard` | Done — CRD default (field may be omitted) |
+| Bundled sample is not production | Documented — CRC/dev only |
 
-Closest stand-ins are the BYOI template (production topology intent) and bundled sample (monitoring on) — neither is an HA production profile sample.
+Jira’s original “HA profile + resource overrides” clause is **out of Cost beta** and tracked under [COST-8095](https://redhat.atlassian.net/browse/COST-8095) as a separate HA sample once shared sizing maps land. Do not treat missing `profile: ha` as an open COST-7679 beta gap.
 
-Note: even after adding `profile: ha` to a sample, profile **sizing maps** are still a COST-7678 gap — the sample can demonstrate the field, but HA behavior may not change until those maps land.
+Optional polish (not blocking G2): drop/comment the BYOI template `kruize:` block while ROS is disabled (R3); label the BYOI template as “production” in headers/docs if readers still confuse it with the bundled sample.
 
 ### G3. CR validation verification — blocked / not done
 

--- a/docs/gap_analysis/COST-7686.md
+++ b/docs/gap_analysis/COST-7686.md
@@ -1,13 +1,13 @@
 # COST-7686 Gap Analysis: Implement application services
 
 **Jira:** [COST-7686](https://redhat.atlassian.net/browse/COST-7686)
-**Audited:** 2026-08-13
+**Audited:** 2026-08-13 · **Refreshed:** 2026-08-17 (`spec.ros.enabled` gating restored; profile maps → [COST-8095](https://redhat.atlassian.net/browse/COST-8095))
 **Purpose:** Handoff audit vs ticket acceptance criteria. Does not update `docs/tasks.md` or other trackers.
-**Beta scope:** Per [BETA-PRIORITY.md](BETA-PRIORITY.md) and [docs/tasks.md](../tasks.md), ROS/Kruize readiness and profile sizing are **not Cost beta blockers**. This audit still reports them as ticket-scoped gaps because they are named acceptance criteria in COST-7686, and flags one item — **G1** — as urgent regardless of beta scope because it silently breaks the documented `spec.ros.enabled=false` opt-out.
+**Beta scope:** Per [BETA-PRIORITY.md](BETA-PRIORITY.md) and [docs/tasks.md](../tasks.md), ROS/Kruize readiness and profile sizing are **not Cost beta blockers**. Remaining Cost beta item on this ticket is the 5-minute readiness timeout (G1).
 
 ## Verdict
 
-Koku API/Masu/Listener, ROS API/Processor, and Kruize Deployment+Service+cluster RBAC (with finalizer cleanup) all exist in `internal/resources/` and are wired into the reconciler, and the Django key generator matches the ticket's exact 50-character/charset/create-once spec. However, three acceptance criteria are **not met**: (1) **`spec.ros.enabled=false` no longer skips anything** — the gating that `docs/tasks.md` and prior gap docs describe as "done" was reverted by a merge-conflict resolution and is now dead code, so ROS/Kruize Deployments, the ROS migration Job, and Kruize's ServiceMonitor always run; (2) **profile-based sizing** is entirely unimplemented (confirmed pre-existing gap, tracked in COST-7678); (3) **the 5-minute readiness timeout → Degraded condition** does not exist — only 3 of the ~14 Deployments this ticket delivers (Koku API, Valkey cache, Envoy) are readiness-gated at all, there is no timeout/backoff tracking, and the CR can reach `Ready`/`Available` while Masu, Listener, ROS, Kruize, and RBAC pods are still down.
+Koku API/Masu/Listener, ROS API/Processor, and Kruize Deployment+Service+cluster RBAC (with finalizer cleanup) all exist in `internal/resources/` and are wired into the reconciler, and the Django key generator matches the ticket's exact 50-character/charset/create-once spec. **`spec.ros.enabled=false` gating is restored** (`reconcileROSFeature` from `reconcileCoreServices`; `ROSEnabled()` on migrate/core/workers). Remaining Cost beta gap: **the 5-minute readiness timeout → Degraded condition** does not exist — only 3 of the ~14 Deployments this ticket delivers (Koku API, Valkey cache, Envoy) are readiness-gated at all, there is no timeout/backoff tracking, and the CR can reach `Ready`/`Available` while Masu, Listener, and RBAC pods are still down. Profile-based sizing is **deferred** post-beta → [COST-8095](https://redhat.atlassian.net/browse/COST-8095).
 
 ## Sources
 
@@ -18,9 +18,9 @@ Koku API/Masu/Listener, ROS API/Processor, and Kruize Deployment+Service+cluster
 - [internal/resources/kruize.go](../../internal/resources/kruize.go) — Kruize Deployment/Service/ClusterRole/ClusterRoleBinding
 - [internal/resources/secrets.go](../../internal/resources/secrets.go) — Django key + DB credentials Secret generation
 - [internal/controller/costmanagementserviceconfig_controller.go](../../internal/controller/costmanagementserviceconfig_controller.go) — `reconcileCoreServices`, `reconcileWorkers`, `reconcileMigration`, readiness gates
-- [internal/controller/ros_cleanup.go](../../internal/controller/ros_cleanup.go) — `reconcileROSFeature` / `reconcileROSCleanup` (currently unreferenced by `reconcile()`)
-- [api/v1alpha1/costmanagementserviceconfig_types.go](../../api/v1alpha1/costmanagementserviceconfig_types.go) — `Profile` type (documented not-yet-implemented), per-component `Resources` fields
-- [docs/tasks.md](../tasks.md), [docs/gap_analysis/BETA-PRIORITY.md](BETA-PRIORITY.md), [docs/gap_analysis/COST-7685.md](COST-7685.md), [docs/gap_analysis/COST-7687.md](COST-7687.md) — prior status claims, several of which G1 below invalidates
+- [internal/controller/ros_cleanup.go](../../internal/controller/ros_cleanup.go) — `reconcileROSFeature` / `reconcileROSCleanup` (called from `reconcileCoreServices`)
+- [api/v1alpha1/costmanagementserviceconfig_types.go](../../api/v1alpha1/costmanagementserviceconfig_types.go) — `Profile` enum (`standard`/`ha`); UI reads it ([#65](https://github.com/project-koku/koku-service-operator/pull/65)); shared maps post-beta → [COST-8095](https://redhat.atlassian.net/browse/COST-8095). Per-component `Resources` fields
+- [docs/tasks.md](../tasks.md), [docs/gap_analysis/BETA-PRIORITY.md](BETA-PRIORITY.md), [docs/gap_analysis/COST-7685.md](COST-7685.md), [docs/gap_analysis/COST-7687.md](COST-7687.md)
 
 Out of scope per ticket: *"Workers, CronJobs, Gateway"* (i.e. Celery workers/scheduled jobs are COST-7687; Envoy gateway is COST-7688). ROS API/Processor themselves are explicitly **in scope** for this ticket even though the reconciler applies them from the internal "Workers" pipeline stage — that is an implementation-staging detail, not a ticket deviation.
 
@@ -31,11 +31,11 @@ Out of scope per ticket: *"Workers, CronJobs, Gateway"* (i.e. Celery workers/sch
 | Deliverable | Status |
 |-------------|--------|
 | Koku — API, Masu, Listener Deployments + Services | Done |
-| ROS — API, Processor Deployments (+ Service for API) | Done, but see G1 (not actually optional) |
-| Kruize — Deployment + Service + cluster-scoped ClusterRole/ClusterRoleBinding, finalizer cleanup | Done, but see G1 (not actually optional) |
+| ROS — API, Processor Deployments (+ Service for API) | Done — gated by `spec.ros.enabled`; optional-install polish → [COST-8054](../jira/COST-8054.md) |
+| Kruize — Deployment + Service + cluster-scoped ClusterRole/ClusterRoleBinding, finalizer cleanup | Done — gated with ROS; optional-install polish → [COST-8054](../jira/COST-8054.md) |
 | Django key — 50 chars, `crypto/rand`, exact charset, Secret, created once, never regenerated | Done |
 | Deployments wired with env vars from CR spec | Done |
-| Profile-based sizing | Missing |
+| Profile-based sizing | **Deferred** — post-beta → [COST-8095](https://redhat.atlassian.net/browse/COST-8095); use per-component `spec.*.resources` for beta |
 | Per-component resource overrides | Done |
 | 5-minute readiness timeout → Degraded with non-ready component name, requeue with backoff | Missing |
 | Ungate Platform (Ready) phase only when all service pods are ready | Partial — phase model exists (intentional rename, see design-vs-jira.md §1) but only 3 of ~14 Deployments actually gate it |
@@ -58,32 +58,14 @@ Out of scope per ticket: *"Workers, CronJobs, Gateway"* (i.e. Celery workers/sch
 
 | JIRA | Implementation | Rationale |
 |------|----------------|-----------|
-| Linear `Deploying`/`Ready` phase | `Phase{Pending,Progressing,Ready,Degraded}` derived from `Available`/`Progressing`/`Degraded` conditions | Documented Kubernetes-API-conventions deviation; see [design-vs-jira.md §1](../design/design-vs-jira.md#1-status-api-conditions-over-phase-enum). "Ungate the Platform phase" maps to `cfg.Status.Phase = PhaseReady` at the end of `reconcile()` — the naming differs intentionally, the mechanism is the gap (G2 below), not the rename. |
+| Linear `Deploying`/`Ready` phase | `Phase{Pending,Progressing,Ready,Degraded}` derived from `Available`/`Progressing`/`Degraded` conditions | Documented Kubernetes-API-conventions deviation; see [design-vs-jira.md §1](../design/design-vs-jira.md#1-status-api-conditions-over-phase-enum). "Ungate the Platform phase" maps to `cfg.Status.Phase = PhaseReady` at the end of `reconcile()` — the naming differs intentionally, the mechanism is the gap (G1 below), not the rename. |
 | ROS API/Processor treated as "application services" | Applied from the reconciler's internal "Workers" stage (`reconcileWorkers`), alongside Celery workers that COST-7687 owns | Cosmetic — internal pipeline staging, not a functional gap. The ticket's own scope line lists ROS API/Processor as deliverables of *this* ticket regardless of which internal stage applies them. |
 
 ---
 
 ## Remaining gaps (ticket-scoped)
 
-### G1. `spec.ros.enabled=false` no longer skips ROS/Kruize — regression, contradicts `docs/tasks.md`
-
-**Missing / broken.** `docs/tasks.md` states ROS/Kruize are "optional via `spec.ros.enabled`" and `BETA-PRIORITY.md` / [COST-7685](COST-7685.md) / [COST-7687](COST-7687.md) describe the gating as "landed." This is no longer true on `main`:
-
-- `reconcileROSFeature(ctx, cfg)` — the function that sets the `ROSEnabled` condition and deletes leftover ROS/Kruize objects — is defined in [`internal/controller/ros_cleanup.go`](../../internal/controller/ros_cleanup.go) but is **never called** from `reconcile()`. It is only invoked directly by [`ros_cleanup_test.go`](../../internal/controller/ros_cleanup_test.go), so the tests pass while the production code path never exercises it.
-- `reconcileMigration()` builds the ROS migration step unconditionally — no `costv1alpha1.ROSEnabled(cfg)` check (compare [`costmanagementserviceconfig_controller.go:295-311`](../../internal/controller/costmanagementserviceconfig_controller.go)).
-- `reconcileCoreServices()` applies `kruizeObjs` (ServiceAccount, ConfigMap, Deployment, Service) and the Kruize ClusterRole/ClusterRoleBinding unconditionally (lines 400-417).
-- `reconcileWorkers()` applies `ROSAPIDeployment`, `ROSProcessorDeployment`, `ROSPollerDeployment`, `ROSHousekeeperDeployment` unconditionally (lines 479-486).
-- `internal/resources/monitoring.go` applies `KruizeServiceMonitor` unconditionally — no `ROSEnabled` check.
-
-Root cause, confirmed via `git log -m -S"reconcileROSFeature"`: PR #13 (`feat/ros-enabled-switch`) added all of this gating, but the merge-conflict resolution commit `c43b910` ("resolve merge conflict... by taking our main's version") reverted every one of these checks back to the unconditional pre-PR-13 code while *keeping* `ros_cleanup.go` and its tests in the tree. The dead code and passing tests mask the regression — nothing fails CI because the tests call `reconcileROSFeature` directly rather than through `Reconcile()`.
-
-**Still gated correctly (survived the revert):** `internal/resources/envoy.go` — Envoy's `/api/cost-management/v1/recommendations/openshift` route and the `ros-api-backend` cluster are still conditional on `ROSEnabled(cfg)` (per `envoy_test.go`).
-
-**Impact:** Any BYOI CR that sets `ros.enabled: false` (as the sample CRs in `config/samples/byoi/` do, per COST-7679) will still get a full ROS/Kruize install — extra migration Job, Deployments, cluster-scoped RBAC, and a `KruizeServiceMonitor` the customer did not ask for and that COST-8054 says is explicitly out of Cost-only beta scope. This silently invalidates the "Beta scope" section of `docs/tasks.md` and the "Landed" table in `BETA-PRIORITY.md` §"COST-8054."
-
-**Fix:** Re-wire `reconcileROSFeature` into `reconcile()` (the original 8-line hunk from commit `4b38da2`, adjusted for the current `reconcile()` shape — note the original call signature `(ctx, cfg) error` doesn't match the erroneous `if _, err := ...` from that commit's own diff, so re-check the signature when restoring it) and reinstate the `ROSEnabled(cfg)` guards in `reconcileMigration`, `reconcileCoreServices`, `reconcileWorkers`, and `KruizeServiceMonitor`.
-
-### G2. No 5-minute readiness timeout, no Degraded-on-timeout, no backoff — missing
+### G1. No 5-minute readiness timeout, no Degraded-on-timeout, no backoff — missing
 
 The ticket requires: *"If any Deployment does not reach Ready within 5 minutes, set Degraded condition with the non-ready component name and requeue with backoff."* None of this exists:
 
@@ -91,21 +73,28 @@ The ticket requires: *"If any Deployment does not reach Ready within 5 minutes, 
 - There is no timestamp/duration tracking anywhere in the controller (no `LastTransitionTime`-based timeout, no annotation, no in-memory timer) that could implement a "5 minutes" threshold. `grep` for `notReadySince`/`degradedSince`/timeout patterns returns nothing.
 - The only `Degraded`-with-component-name path that exists today is migration-Job failure (`runMigrationStep` → `"%s exhausted retries"`), which is a different failure mode (Job `backoffLimit` exhaustion, not Deployment un-readiness).
 - Un-ready Deployments simply cause a bare `Result{RequeueAfter: requeueSlow}` (30s) or `requeueFast` (10s) forever — no backoff growth, no cap, and no visible identification of *which* Deployment is stuck once past the two gated ones.
-- Consequence for G3 below: because most Deployments aren't gated at all, the CR can reach `Available`/`Ready` while, e.g., Masu or RBAC API pods are crash-looping.
+- Consequence for G2 below: because most Deployments aren't gated at all, the CR can reach `Available`/`Ready` while, e.g., Masu or RBAC API pods are crash-looping.
 
 **Fix:** Add an `isDeploymentReady` check (or a shared "wait for all Deployments in this stage" helper) for every Deployment introduced by this ticket, track first-seen-not-ready time (e.g. via the existing condition's `LastTransitionTime`, since `apimeta.SetStatusCondition` already preserves it across reconciles when the status is unchanged), and once that duration exceeds 5 minutes, set `Degraded` with the specific component name and switch to an exponential-backoff `RequeueAfter` (this overlaps with the pre-existing [COST-7680 G2](COST-7680.md) backoff gap).
 
-### G3. Platform/Ready phase is not actually gated on "all service pods ready"
+### G2. Platform/Ready phase is not actually gated on "all service pods ready"
 
-Given G2, `cfg.Status.Phase = PhaseReady` / `ConditionAvailable = True` at the end of `reconcile()` fires as soon as the *pipeline* completes without error — not when Masu, Listener, ROS, Kruize, or RBAC pods are individually confirmed `Ready`. This is the same underlying issue as [COST-7689 G2](COST-7689.md) ("RBAC Deployments applied but never gated") and the `BETA-PRIORITY.md` T1 theme ("`UIReady` / Ingress / workers not truly readiness-gated"), but scoped here to the literal COST-7686 acceptance criterion "on all service pods ready, ungate the Platform phase." Fixing G2 (readiness checks for every Deployment this ticket owns) is the direct fix for this criterion; it is listed separately because the ticket calls it out as its own bullet.
+Given G1, `cfg.Status.Phase = PhaseReady` / `ConditionAvailable = True` at the end of `reconcile()` fires as soon as the *pipeline* completes without error — not when Masu, Listener, ROS, Kruize, or RBAC pods are individually confirmed `Ready`. This is the same underlying issue as [COST-7689 G1](COST-7689.md) ("RBAC Deployments applied but never gated") and the `BETA-PRIORITY.md` T1 theme ("`UIReady` / Ingress / workers not truly readiness-gated"), but scoped here to the literal COST-7686 acceptance criterion "on all service pods ready, ungate the Platform phase." Fixing G1 (readiness checks for every Deployment this ticket owns) is the direct fix for this criterion; it is listed separately because the ticket calls it out as its own bullet.
 
-### G4. Profile-based sizing — confirmed pre-existing gap, still open
+---
 
-`spec.profile` (`Profile` type, `+kubebuilder:default:=standard`) is accepted by the API but never read by any resource builder in `internal/resources/`. This is already tracked as a cross-cutting gap in [COST-7678](COST-7678.md), [COST-7687](COST-7687.md), [COST-7689](COST-7689.md), [COST-7690](COST-7690.md), and `BETA-PRIORITY.md` T5 (ranked **P2 for beta**). No new finding here — confirming it is still unimplemented as of this audit and applies equally to every Deployment this ticket (COST-7686) owns. Use per-component `spec.*.resources` fields as the documented workaround until a shared sizing map lands.
+## Deferred (not a Cost beta blocker)
+
+Profile-based sizing for non-UI workloads is **post-beta** → [COST-8095](https://redhat.atlassian.net/browse/COST-8095). Beta uses per-component `spec.*.resources`. UI already applies `spec.profile` defaults when `spec.ui.*.resources` are unset ([#65](https://github.com/project-koku/koku-service-operator/pull/65)).
+
+---
+
+## Closed since 2026-08-13 audit
+
+**`spec.ros.enabled` gating restored.** The 2026-08-13 G1 (`reconcileROSFeature` never called; migrate/core/workers applied ROS/Kruize unconditionally) is **closed**. `reconcileCoreServices` calls `reconcileROSFeature`; migrate, core, workers, Envoy ROS routes, and ROS/Kruize NetworkPolicies are `ROSEnabled()`-gated. Residual: `reconcileMonitoring` still applies `KruizeServiceMonitor` when monitoring is on even if ROS is disabled (cleanup deletes it); tracked under [COST-7692](COST-7692.md) / [COST-8054](../jira/COST-8054.md), not a Cost-core always-deploy regression.
 
 ---
 
 ## Related gaps (not in Jira body; same surface)
 
 - **Untested Secret/Kruize builders.** `go test ./internal/resources/... -coverprofile` shows `0%` coverage on `DjangoSecret`, `djangoSecretKey`, `DBCredentialsSecret`, `randomPassword`, `KruizeDeployment`, `KruizeService`, `KruizeClusterRoleBinding`, `KruizeConfigMap`, and `KruizeServiceAccount`. Per `CLAUDE.md`'s PR review checklist, these are core to this ticket's Django-key acceptance criterion and the Kruize deliverable; worth closing before merge even though the ticket itself doesn't mandate tests.
-- **G1 undermines several "Done" claims elsewhere.** [COST-7685](COST-7685.md) ("ROS migrate skip when `ros.enabled=false` already landed"), [COST-7687](COST-7687.md) ("ROS Processor + Recommendation Poller + Housekeeper ✅ (when `spec.ros.enabled`)"), and `BETA-PRIORITY.md`'s COST-8054 "Landed" table all describe behavior that G1 shows is currently dead code. Recommend a follow-up sweep of those docs once G1 is fixed (out of scope for this file per the skill's "no collateral doc edits" rule — flagging here only).

--- a/docs/gap_analysis/COST-7687.md
+++ b/docs/gap_analysis/COST-7687.md
@@ -3,11 +3,11 @@
 **Jira:** [COST-7687](https://redhat.atlassian.net/browse/COST-7687)
 **Audited:** 2026-08-10
 **Purpose:** Handoff audit vs ticket acceptance criteria. Does not update `docs/tasks.md` or other trackers.
-**Beta scope:** ROS and Kruize are **out of beta** ([BETA-PRIORITY.md](BETA-PRIORITY.md)). ROS and Kruize worker AC rows below remain ticket status only — they are **not** Cost beta requirements. Beta cares about Celery on-prem queues (especially SaaS exclusion) and core Beat/workers; ROS sizing/Services and Kruize CronJob sizing are owned by [COST-8054](../jira/COST-8054.md).
+**Beta scope:** ROS and Kruize are **out of beta** ([BETA-PRIORITY.md](BETA-PRIORITY.md)). ROS and Kruize worker AC rows below remain ticket status only — they are **not** Cost beta requirements. Beta cares about Celery on-prem queues (especially SaaS exclusion) and core Beat/workers. Profile sizing (including ROS/Kruize rows when those components reconcile) → [COST-8095](https://redhat.atlassian.net/browse/COST-8095); ROS Processor/Poller Services → [COST-8054](../jira/COST-8054.md).
 
 ## Verdict
 
-Background workloads are largely implemented under `reconcileWorkers`: Celery Beat, the six named on-prem worker queues, ROS poller/housekeeper/partition-cleaner (when `spec.ros.enabled`), and Kruize partition deletion. COST-7687 is **not fully done**. Remaining ticket gaps are **profile-based sizing** (unused `spec.profile`) and **SaaS-only Celery queues not excluded** (`hcs`, `subs_extraction`, `subs_transmission` still deploy with CRD default `replicas: 1`). For beta, **G2 (SaaS exclusion) is the blocker**; ROS and Kruize profile sizing → [COST-8054](../jira/COST-8054.md).
+Background workloads are largely implemented under `reconcileWorkers`: Celery Beat, the six named on-prem worker queues, ROS poller/housekeeper/partition-cleaner (when `spec.ros.enabled`), and Kruize partition deletion. COST-7687 is **not fully done**. Remaining ticket gap for beta: **SaaS-only Celery queues not excluded** (`hcs`, `subs_extraction`, `subs_transmission` still deploy with CRD default `replicas: 1`).
 
 ## Sources
 
@@ -19,7 +19,7 @@ Background workloads are largely implemented under `reconcileWorkers`: Celery Be
 - [`internal/resources/kruize.go`](../../internal/resources/kruize.go) — create-partitions init + delete CronJob
 - [`api/v1alpha1/costmanagementserviceconfig_types.go`](../../api/v1alpha1/costmanagementserviceconfig_types.go) — Celery/ROS/Kruize specs
 - [docs/helm-vs-operator-comparison.md](../helm-vs-operator-comparison.md) — chart parity notes
-- [docs/tasks.md](../tasks.md) — profile sizing unfinished under COST-7686 / COST-7693 (not called out in `design-vs-jira.md`)
+- [docs/tasks.md](../tasks.md) — SaaS queue exclusion still open on this ticket
 
 Out of scope per ticket: Gateway, RBAC service (covered by COST-7688 / COST-7689).
 
@@ -36,7 +36,7 @@ Out of scope per ticket: Gateway, RBAC service (covered by COST-7688 / COST-7689
 | ROS Housekeeper | Done (ticket) — **not required for Cost beta** → [COST-8054](../jira/COST-8054.md) |
 | ROS Partition Cleaner CronJob | Done (ticket) — **not required for Cost beta** → [COST-8054](../jira/COST-8054.md) |
 | Kruize CronJobs | Done (ticket) / Deviated (create = init) — **not required for Cost beta** → [COST-8054](../jira/COST-8054.md) |
-| Profile-based sizing | **Missing** — `spec.profile` never read (Celery maps P2; ROS and Kruize maps → [COST-8054](../jira/COST-8054.md)) |
+| Profile-based sizing | **Deferred** — post-beta → [COST-8095](https://redhat.atlassian.net/browse/COST-8095) |
 
 ---
 
@@ -83,25 +83,7 @@ Reconciled in [`reconcileWorkers`](../../internal/controller/costmanagementservi
 
 ## Remaining gaps (ticket-scoped)
 
-### G1. Profile-based sizing — missing
-
-Ticket requires profile-based sizing. `Profile` enum (`standard` / `ha`) exists on the CR, but **no Go code reads `cfg.Spec.Profile`** (repo-wide grep: no `Spec.Profile` usage). There is no `profiles.go` / sizing map.
-
-Current sizing is per-component CR fields or hardcodes only:
-
-| Workload | Sizing today |
-|----------|----------------|
-| Celery workers | `CeleryWorkerSpec.Replicas` / `Resources` / `Concurrency` (CRD defaults 1 / empty / 5) |
-| Celery Beat | Hardcoded replicas `1`, **empty** `ResourceRequirements` |
-| ROS poller / housekeeper | Hardcoded replicas `1`; optional CR `resources` |
-| ROS processor | `spec.ros.processor.replicas` / `resources` |
-| CronJobs | Optional `resources` on partition cleaner / Kruize partitions |
-
-**Impact:** `profile: ha` does not change worker/CronJob replicas or requests/limits. Same cross-ticket gap as COST-7678 / COST-7686 / COST-7693.
-
-**Beta:** Profile sizing overall is P2 ([BETA-PRIORITY.md](BETA-PRIORITY.md) T5). If maps are built earlier, prioritize Celery Beat + six on-prem queues; ROS and Kruize rows → [COST-8054](../jira/COST-8054.md).
-
-### G2. SaaS-only Celery queues not excluded — missing
+### G1. SaaS-only Celery queues not excluded — missing
 
 Ticket: *“SaaS-only queues excluded.”*
 
@@ -123,7 +105,7 @@ Zero-replica Deployments are still applied (SSA lifecycle comment at `CeleryWork
 
 ## Related gaps (not in Jira body; same surface)
 
-- **Celery Beat empty resources** — chart has CPU/memory; operator passes `{}` ([helm-vs-operator-comparison.md](../helm-vs-operator-comparison.md) §1 / Beat row). Closely tied to G1.
+- **Celery Beat empty resources** — chart has CPU/memory; operator passes `{}` ([helm-vs-operator-comparison.md](../helm-vs-operator-comparison.md) §1 / Beat row). Post-beta polish → [COST-8095](https://redhat.atlassian.net/browse/COST-8095); not a Cost beta blocker.
 - **No worker/CronJob readiness gate** — `reconcileWorkers` applies objects and returns; no wait for Available replicas / successful CronJob create. Related to COST-7686’s 5-minute readiness timeout, not stated in COST-7687.
 - **No worker-specific conditions** — status has no Celery/ROS-worker condition; only naming tests for queue sanitization.
 - **ROS Processor/Poller Services missing** vs chart — metrics scrape gap ([helm-vs-operator-comparison.md](../helm-vs-operator-comparison.md) §3.1); outside this ticket’s AC; → [COST-8054](../jira/COST-8054.md) (ROS).

--- a/docs/gap_analysis/COST-7689.md
+++ b/docs/gap_analysis/COST-7689.md
@@ -7,7 +7,7 @@
 
 ## Verdict
 
-RBAC workloads are largely implemented and go beyond the ticket’s worker-only wording (API Deployment + Service + Celery worker, Stage 4 before Koku, DB/cache env wiring). COST-7689 is **not done**: profile-based resource sizing and RBAC readiness status reporting are still missing.
+RBAC workloads are largely implemented and go beyond the ticket’s worker-only wording (API Deployment + Service + Celery worker, Stage 4 before Koku, DB/cache env wiring). COST-7689 is **not done**: RBAC readiness status reporting is still missing.
 
 ## Sources
 
@@ -29,7 +29,7 @@ Out of scope per ticket: RBAC schema migration and data seeding (story 9 / COST-
 | Deliverable | Status |
 |-------------|--------|
 | RBAC worker Deployment with env wiring to external DB and cache | Done (superseded: also deploys RBAC API + Service) |
-| Profile-based resource sizing | **Missing** |
+| Profile-based resource sizing | **Deferred** — post-beta → [COST-8095](https://redhat.atlassian.net/browse/COST-8095) |
 | Status reporting for RBAC component readiness | **Missing** |
 
 ---
@@ -86,15 +86,7 @@ Also sets on-prem RBAC flags mirroring the Helm chart helpers (`BYPASS_BOP_VERIF
 
 ## Remaining gaps (ticket-scoped)
 
-### G1. Profile-based resource sizing — missing
-
-**Evidence:** `RBACAPIDeployment` / `RBACWorkerDeployment` pass through `spec.rbac.api.resources` and `spec.rbac.worker.resources` only ([`rbac.go`](../../internal/resources/rbac.go) ~L189, ~L260). There are no profile→requests/limits maps keyed by `spec.profile` (`standard` / `ha`) in `api/` or `internal/resources` — only the `Profile` enum exists ([`costmanagementserviceconfig_types.go`](../../api/v1alpha1/costmanagementserviceconfig_types.go)). Same cross-cutting gap as COST-7678 / COST-7686 / COST-7693 / COST-7690.
-
-Samples set `replicas: 1` only — no resource blocks and no profile-driven defaults.
-
-**Impact:** HA vs standard does not change RBAC CPU/memory (or replica defaults beyond CR/OpenAPI). Ticket AC unmet.
-
-### G2. Status reporting for RBAC readiness — missing
+### G1. Status reporting for RBAC readiness — missing
 
 **Evidence:**
 
@@ -103,6 +95,12 @@ Samples set `replicas: 1` only — no resource blocks and no profile-driven defa
 - Deep review D1 notes RBAC among Deployments applied without readiness gates; CR can reach `Available=True` / `Phase=Ready` while RBAC has zero available replicas.
 
 **Impact:** Operators and automation cannot see RBAC-specific readiness; failures surface only as opaque Koku/permission errors. Called out as a Cost beta blocker in [BETA-PRIORITY.md](BETA-PRIORITY.md) T1.
+
+---
+
+## Deferred (not a Cost beta blocker)
+
+Profile-based resource sizing is **post-beta** → [COST-8095](https://redhat.atlassian.net/browse/COST-8095). Beta uses per-component `spec.rbac.*.resources`.
 
 ---
 
@@ -118,5 +116,5 @@ Only `API_PATH_PREFIX` is asserted. No tests for DB/cache secret key refs, TLS/a
 
 ### R3. No readiness wait before Koku in Stage 4
 
-Even without a dedicated condition (G2), applying Koku immediately after RBAC SSA without waiting for RBAC AvailableReplicas increases race risk on cold start. Closely tied to G2.
+Even without a dedicated condition (G1), applying Koku immediately after RBAC SSA without waiting for RBAC AvailableReplicas increases race risk on cold start. Closely tied to G1.
 

--- a/docs/gap_analysis/COST-7690.md
+++ b/docs/gap_analysis/COST-7690.md
@@ -7,7 +7,7 @@
 
 ## Verdict
 
-UI Deployment (oauth2-proxy sidecar + nginx), ClusterIP Service with service-CA TLS, operator-managed cookie Secret / nginx ConfigMap, and cluster-scoped ConsoleLink with finalizer cleanup are implemented under Edge (`reconcileUI`). COST-7690 ticket AC is **done**, including profile-based UI resource sizing (`spec.profile` `standard` / `ha`). Other workloads still ignore `spec.profile` (COST-7678 G4).
+UI Deployment (oauth2-proxy sidecar + nginx), ClusterIP Service with service-CA TLS, operator-managed cookie Secret / nginx ConfigMap, and cluster-scoped ConsoleLink with finalizer cleanup are implemented under Edge (`reconcileUI`). COST-7690 ticket AC is **done**, including profile-based UI resource sizing (`spec.profile` `standard` / `ha`).
 
 ## Sources
 
@@ -18,7 +18,7 @@ UI Deployment (oauth2-proxy sidecar + nginx), ClusterIP Service with service-CA 
 - [`internal/controller/costmanagementserviceconfig_controller.go`](../../internal/controller/costmanagementserviceconfig_controller.go) (`reconcileEdge`, `reconcileUI`, `reconcileDelete`)
 - [`api/v1alpha1/costmanagementserviceconfig_types.go`](../../api/v1alpha1/costmanagementserviceconfig_types.go) (`UIConfig`, `Profile`)
 - [`config/rbac/role.yaml`](../../config/rbac/role.yaml) (`consolelinks`)
-- [docs/gap_analysis/COST-7678.md](COST-7678.md) (profile sizing maps gap G4)
+- [docs/gap_analysis/COST-7678.md](COST-7678.md) (profile enum)
 
 Out of scope per ticket: Routes (separate story — COST-7691).
 
@@ -88,9 +88,9 @@ Built in [`UIDeployment`](../../internal/resources/ui.go) (~L145–303), applied
 
 ## Remaining gaps (ticket-scoped)
 
-### G1. Profile-based resource sizing — closed
+### G1. Profile-based resource sizing — closed (UI only)
 
-[`UIDeployment`](../../internal/resources/ui.go) reads `cfg.Spec.Profile` via `uiProfileResources`. `standard`/unset keep 50m/64Mi request and 100m/128Mi limit; `ha` uses 100m/128Mi and 200m/256Mi. Per-component `spec.ui.*.resources` win when set. Other workloads still ignore `spec.profile` (COST-7678 G4 / COST-7686 / COST-7693).
+[`UIDeployment`](../../internal/resources/ui.go) reads `cfg.Spec.Profile` via `uiProfileResources` when `spec.ui.*.resources` unset ([#65](https://github.com/project-koku/koku-service-operator/pull/65)). Shared maps for other workloads are **post-beta** → [COST-8095](https://redhat.atlassian.net/browse/COST-8095).
 
 ---
 

--- a/docs/jira/COST-7678.md
+++ b/docs/jira/COST-7678.md
@@ -21,8 +21,9 @@ Deliver the full CRD API surface split across multiple files in api/v1alpha1/:* 
 - validation.go -- webhook + CEL validation rules: required fields (database.host, database.credentialsSecretRef, cache.host, cache.credentialsSecretRef, kafka.bootstrapServers, authentication.issuerUrl), value constraints (database.port 1-65535, database.sslMode one of disable/require/verify-ca/verify-full, authentication.issuerUrl must be HTTPS, authentication.audiences non-empty, profile one of standard/ha, dataRetentionMonths 1-60), cross-field rules (resource requests must not exceed limits)
 All infra is external-only (no type field). CR directly accepts connection details (host, port, credentialsSecretRef, bootstrapServers, issuerUrl).
 
+**Scope note (repo):** Profile enum + UI defaults from `spec.profile` landed ([#65](https://github.com/project-koku/koku-service-operator/pull/65)). Shared sizing maps for other workloads are **deferred** (post-beta) → [COST-8095](https://redhat.atlassian.net/browse/COST-8095).
+
 
 ### Out of Scope
 
 - Reconciler logic, resource builders
-

--- a/docs/jira/COST-7679.md
+++ b/docs/jira/COST-7679.md
@@ -20,7 +20,8 @@ Deliver two sample CRs (minimal, production), generated CRD YAML, and verified i
 - Generated CRD YAML via controller-gen
 - Verified CRD install on OCP 4.20+ (kubectl apply succeeds, CR validation works)
 
+**Scope note (repo):** For **beta**, “production sample” = monitoring-enabled **BYOI Cost-only** (`deploy: false`, external infra, `ros.enabled: false`, `profile: standard` / omit) — met by `config/samples/service.costmanagement_v1alpha1_costmanagementserviceconfig_byoi.yaml`. Bundled sample is **dev/CRC only**. Jira’s HA profile + HA resource overrides are a **separate** post-beta sample → [COST-8095](https://redhat.atlassian.net/browse/COST-8095); do not defer the whole production AC with HA. Beta still needs a **minimal** required-fields sample.
+
 ### Out of Scope
 
 - Controller implementation
-

--- a/docs/jira/COST-7686.md
+++ b/docs/jira/COST-7686.md
@@ -18,8 +18,9 @@ Deliver all core service Deployments + Services for the cost management platform
 - Django key -- generate a 50-character random string using crypto/rand with charset abcdefghijklmnopqrstuvwxyz0123456789!@#$%^&*(-_=+), stored in a Secret. Created once on first reconciliation and persisted across subsequent reconciliations (never regenerated unless rotation is triggered via story 18)
 All Deployments wired with env vars from CR spec, profile-based sizing, per-component resource overrides. If any Deployment does not reach Ready within 5 minutes, set Degraded condition with the non-ready component name and requeue with backoff. On all service pods ready, ungate the Platform phase.
 
+**Scope note (repo):** Profile-based sizing for non-UI workloads is **deferred** (post-beta) → [COST-8095](https://redhat.atlassian.net/browse/COST-8095). Beta uses per-component `spec.*.resources`.
+
 
 ### Out of Scope
 
 - Workers, CronJobs, Gateway
-

--- a/docs/jira/COST-7687.md
+++ b/docs/jira/COST-7687.md
@@ -17,8 +17,9 @@ Deliver all background processing workloads:* Celery -- Beat Deployment + six Wo
 - Kruize -- CronJobs
 Profile-based sizing. SaaS-only queues excluded.
 
+**Scope note (repo):** Profile-based sizing is **deferred** (post-beta) → [COST-8095](https://redhat.atlassian.net/browse/COST-8095). Cost beta still requires SaaS-only queue exclusion.
+
 
 ### Out of Scope
 
 - Gateway, RBAC service
-

--- a/docs/jira/COST-7689.md
+++ b/docs/jira/COST-7689.md
@@ -19,7 +19,8 @@ Deliver RBAC worker Deployment. Wired to external DB and cache.
 - Profile-based resource sizing
 - Status reporting for RBAC component readiness
 
+**Scope note (repo):** Profile-based resource sizing is **deferred** (post-beta) → [COST-8095](https://redhat.atlassian.net/browse/COST-8095). Cost beta still requires RBAC readiness status reporting.
+
 ### Out of Scope
 
 - RBAC schema migration and data seeding (covered in story 9)
-

--- a/docs/jira/COST-7690.md
+++ b/docs/jira/COST-7690.md
@@ -20,7 +20,8 @@ Deliver UI Deployment with OAuth2 Proxy sidecar, ClusterIP Service, and cluster-
 - Cluster-scoped ConsoleLink resource with finalizer-based cleanup on CR deletion
 - Profile-based resource sizing
 
+**Scope note (repo):** Profile-based resource sizing for UI is **done** ([#65](https://github.com/project-koku/koku-service-operator/pull/65)). Shared maps for other workloads → [COST-8095](https://redhat.atlassian.net/browse/COST-8095).
+
 ### Out of Scope
 
 - Routes (separate story)
-

--- a/docs/jira/COST-7693.md
+++ b/docs/jira/COST-7693.md
@@ -18,7 +18,8 @@ Deliver Day-2 lifecycle management for version upgrades and scaling:* Version-pi
 - Rolling update strategy -- stateless services (API, Gateway, UI, Ingress): maxSurge=25%, maxUnavailable=25% for zero-downtime. Workers and Beat: maxSurge=0, maxUnavailable=1 (brief downtime acceptable)
 - Operator self-upgrade -- OLM handles operator binary upgrades. On new operator version, re-reconcile all resources to apply any template changes
 
+**Scope note (repo):** Profile-driven replica defaults are **deferred** (post-beta) → [COST-8095](https://redhat.atlassian.net/browse/COST-8095). Beta/day-2 scaling continues via per-component overrides + SSA.
+
 ### Out of Scope
 
 - Secret rotation (story 18), TLS certificate renewal, downgrade flows
-

--- a/docs/jira/COST-8054.md
+++ b/docs/jira/COST-8054.md
@@ -48,8 +48,8 @@ Track and close these under COST-8054 (or child issues), naming **ROS** vs **Kru
 | [COST-7684 G4](../gap_analysis/COST-7684.md) | External DB secret validation omits `kruize-user` / `kruize-password` | Kruize |
 | [COST-7684](../gap_analysis/COST-7684.md) / Validation | `ros-user` / `ros-password` required even when ROS unsupported | ROS |
 | [COST-7685](../gap_analysis/COST-7685.md) | `SchemaUpToDate` / stage gate always waits on `ROSMigrationJob` | ROS |
-| [COST-7687](../gap_analysis/COST-7687.md) | ROS worker/CronJob profile sizing; Processor/Poller Services | ROS |
-| [COST-7687](../gap_analysis/COST-7687.md) | Kruize partition CronJob / init sizing when profile maps land | Kruize |
+| [COST-7687](../gap_analysis/COST-7687.md) | ROS Processor/Poller Services | ROS |
+| [COST-7687](../gap_analysis/COST-7687.md) | Kruize partition CronJob / init when gated | Kruize |
 | [COST-7691](../gap_analysis/COST-7691.md) | ROS Processor/Poller/Housekeeper missing `ServiceAccountName`; ROS NPs | ROS |
 | [COST-7691](../gap_analysis/COST-7691.md) | Kruize NetworkPolicy / SA coverage beyond today’s scaffolding | Kruize |
 | [COST-7692](../gap_analysis/COST-7692.md) | Kruize ServiceMonitor port/`metrics` wiring | Kruize |
@@ -60,4 +60,4 @@ Track and close these under COST-8054 (or child issues), naming **ROS** vs **Kru
 ### Out of scope for this story
 
 - Closing Cost-core beta gaps (S3/OIDC/auth conditions, SaaS Celery exclusion, RBAC readiness, etc.) — remain on COST-7678–7692 / [BETA-PRIORITY.md](../gap_analysis/BETA-PRIORITY.md).
-- Full HA profile sizing for Celery/UI (shared post-beta theme; only ROS/Kruize rows owned here).
+- Shared `spec.profile` sizing maps (Cost core + optional ROS/Kruize rows) — owned by [COST-8095](https://redhat.atlassian.net/browse/COST-8095) (post-beta); not a Cost beta blocker.

--- a/docs/tasks.md
+++ b/docs/tasks.md
@@ -1,7 +1,7 @@
 # Operator Task Tracker
 
-Tracks implementation status against the COST-7678–7700 Jira backlog.
-Last audited: 2026-08-15.
+Tracks implementation status against the COST-7678–7700 Jira backlog (+ [COST-8054](https://redhat.atlassian.net/browse/COST-8054), [COST-8095](https://redhat.atlassian.net/browse/COST-8095)).
+Last audited: 2026-08-17.
 
 ## Legend
 - ✅ Done — implements the ticket's acceptance criteria
@@ -14,8 +14,8 @@ Last audited: 2026-08-15.
 
 | Ticket | Summary | Status | Notes |
 |--------|---------|--------|-------|
-| [COST-7678](https://redhat.atlassian.net/browse/COST-7678) | Define CostManagement CRD types | ✅ | CRD types ✅, CEL + admission webhooks ([#50](https://github.com/project-koku/koku-service-operator/pull/50)/[#51](https://github.com/project-koku/koku-service-operator/pull/51)/[#52](https://github.com/project-koku/koku-service-operator/pull/52)) ✅, `dataRetentionMonths` wired ([#59](https://github.com/project-koku/koku-service-operator/pull/59)) ✅. **G4 partial:** enum `standard`/`ha` + UI profile defaults ([#65](https://github.com/project-koku/koku-service-operator/pull/65)) ✅; shared sizing maps for Celery/core workloads deferred to COST-7686/7687. See [gap analysis](gap_analysis/COST-7678.md). |
-| [COST-7679](https://redhat.atlassian.net/browse/COST-7679) | Create sample CRs and generate manifests | 🔄 | Bundled CR ✅, BYOI CR ✅, BYOI kustomize fixture ✅, CRD installs on CRC ✅. Missing: HA profile sample, CEL validation verified. |
+| [COST-7678](https://redhat.atlassian.net/browse/COST-7678) | Define CostManagement CRD types | ✅ | CRD types ✅, CEL + admission webhooks ([#50](https://github.com/project-koku/koku-service-operator/pull/50)/[#51](https://github.com/project-koku/koku-service-operator/pull/51)/[#52](https://github.com/project-koku/koku-service-operator/pull/52)) ✅, `dataRetentionMonths` wired ([#59](https://github.com/project-koku/koku-service-operator/pull/59)) ✅. **G4 partial:** enum `standard`/`ha` + UI profile defaults ([#65](https://github.com/project-koku/koku-service-operator/pull/65)) ✅; shared maps post-beta → [COST-8095](https://redhat.atlassian.net/browse/COST-8095). See [gap analysis](gap_analysis/COST-7678.md). |
+| [COST-7679](https://redhat.atlassian.net/browse/COST-7679) | Create sample CRs and generate manifests | 🔄 | Bundled CR ✅ (dev/CRC only), **beta production** = BYOI Cost-only template ✅ (`monitoring.enabled: true`, `ros.enabled: false`, `profile: standard`), BYOI kustomize fixture ✅, CRD installs on CRC ✅. Missing: minimal required-fields sample, CEL validation verified. HA sample (`profile: ha`) → [COST-8095](https://redhat.atlassian.net/browse/COST-8095). |
 
 ## Reconciler Core
 
@@ -37,10 +37,10 @@ Last audited: 2026-08-15.
 
 | Ticket | Summary | Status | Notes |
 |--------|---------|--------|-------|
-| [COST-7686](https://redhat.atlassian.net/browse/COST-7686) | Implement application services | 🔄 | Koku API + Masu + Listener `1/1 Running` on CRC ✅, ROS API + Processor ✅ (optional via `spec.ros.enabled`), Kruize Deployment + Service + ClusterRole/Binding ✅ (gated with ROS), Bundled DB/Cache (dev-only extension) ✅. **Beta: ROS/Kruize not required** — see Beta scope below. Missing: profile-based sizing, 5-minute readiness timeout with Degraded condition. |
-| [COST-7687](https://redhat.atlassian.net/browse/COST-7687) | Implement workers and scheduled jobs | ✅ | Celery Beat + 10 workers ✅, ROS Processor + Recommendation Poller + Housekeeper ✅ (when `spec.ros.enabled`), ROS Partition Cleaner CronJob ✅, Kruize DeletePartitions CronJob ✅. Ticket's six on-prem queues all present. |
+| [COST-7686](https://redhat.atlassian.net/browse/COST-7686) | Implement application services | 🔄 | Koku API + Masu + Listener `1/1 Running` on CRC ✅, ROS API + Processor ✅ (optional via `spec.ros.enabled`), Kruize Deployment + Service + ClusterRole/Binding ✅ (gated with ROS), Bundled DB/Cache (dev-only extension) ✅. **Beta: ROS/Kruize not required** — see Beta scope below. Missing: 5-minute readiness timeout with Degraded condition. Profile sizing → [COST-8095](https://redhat.atlassian.net/browse/COST-8095). |
+| [COST-7687](https://redhat.atlassian.net/browse/COST-7687) | Implement workers and scheduled jobs | 🔄 | Celery Beat + on-prem workers ✅, ROS Processor + Recommendation Poller + Housekeeper ✅ (when `spec.ros.enabled`), ROS Partition Cleaner CronJob ✅, Kruize DeletePartitions CronJob ✅. **Missing (beta P0):** SaaS-only queues (`hcs`, `subs_extraction`, `subs_transmission`) still deploy at CRD default `replicas: 1` — see [gap analysis](gap_analysis/COST-7687.md). Profile sizing → [COST-8095](https://redhat.atlassian.net/browse/COST-8095). |
 | [COST-7688](https://redhat.atlassian.net/browse/COST-7688) | Implement Gateway and Ingress | ✅ | Envoy JWT proxy Deployment + Service + ConfigMap wired to OIDC issuer/audiences ✅, OpenShift Route for gateway API ✅, insights-ingress-go Deployment + Service ✅ (S3/Kafka/CA wiring, port 8080 matching Envoy backend config). |
-| [COST-7689](https://redhat.atlassian.net/browse/COST-7689) | Implement RBAC Service | ✅ | RBAC API Deployment + Service + RBAC Celery worker Deployment ✅. Deployed in Stage 4 before Koku. Both wired with rbac-user/rbac-password from DB credentials secret + cache env vars. Keycloak-to-RBAC principal sync CronJob + ConfigMap ✅ ([PR #53](https://github.com/project-koku/koku-service-operator/pull/53)). |
+| [COST-7689](https://redhat.atlassian.net/browse/COST-7689) | Implement RBAC Service | 🔄 | RBAC API Deployment + Service + RBAC Celery worker Deployment ✅. Deployed in Stage 4 before Koku. Both wired with rbac-user/rbac-password from DB credentials secret + cache env vars. Keycloak-to-RBAC principal sync CronJob + ConfigMap ✅ ([PR #53](https://github.com/project-koku/koku-service-operator/pull/53)). **Missing (beta P0):** RBAC readiness gate / `RBACReady` condition — see [gap analysis](gap_analysis/COST-7689.md). Profile sizing → [COST-8095](https://redhat.atlassian.net/browse/COST-8095). |
 | [COST-7690](https://redhat.atlassian.net/browse/COST-7690) | Implement UI and ConsoleLink | ✅ | UI Deployment (oauth2-proxy sidecar + nginx app container) ✅, ClusterIP Service with OpenShift service-CA TLS annotation ✅, UINginxConfigMap (proxies `/api/` to Envoy) ✅, operator-generated cookie Secret ✅, ConsoleLink (cluster-scoped, finalizer cleanup in `reconcileDelete`) ✅. UIRoute deferred to COST-7691. |
 | [COST-7691](https://redhat.atlassian.net/browse/COST-7691) | Implement Routes, NetworkPolicies, and TLS | ✅ | NetworkPolicies (gateway, ingress, kruize, rbac-api, koku-api, ros-api, cache, database) ✅, restricted-v2 SCC compliance (no hardcoded runAsUser, seccompProfile: RuntimeDefault) ✅, `status.phase → Ready` ✅, Gateway Route ✅, UI Route (deferred until cluster domain resolved) ✅. Dedicated SAs: koku, ros, kruize ✅. |
 | [COST-7692](https://redhat.atlassian.net/browse/COST-7692) | Implement monitoring and alerting | ✅ | Kubernetes Events (Ready, MigrationStarted/Complete/Failed, ReconcileError) ✅, AppServiceMonitor + KruizeServiceMonitor ✅, PrometheusRules (5 alert rules) ✅. All guarded by `spec.monitoring.enabled`. ServiceMonitors/Rules applied as unstructured — silently skipped when Prometheus Operator CRDs absent. |
@@ -49,7 +49,7 @@ Last audited: 2026-08-15.
 
 | Ticket | Summary | Status | Notes |
 |--------|---------|--------|-------|
-| [COST-7693](https://redhat.atlassian.net/browse/COST-7693) | Implement upgrade and scaling flows | 🔄 | Image-tag-triggered migration re-run per service ✅, SSA re-applies desired replicas ✅. Missing: automatic rollback on migration failure, rolling update strategy (maxSurge/maxUnavailable per workload type), profile-based replica scaling. |
+| [COST-7693](https://redhat.atlassian.net/browse/COST-7693) | Implement upgrade and scaling flows | 🔄 | Image-tag-triggered migration re-run per service ✅, SSA re-applies desired replicas ✅. Missing: automatic rollback on migration failure, rolling update strategy (maxSurge/maxUnavailable per workload type). Profile-driven replica defaults → [COST-8095](https://redhat.atlassian.net/browse/COST-8095). |
 | [COST-7694](https://redhat.atlassian.net/browse/COST-7694) | Implement secret rotation and CA management | 🔄 | CA bundle combine init container ✅, service-ca ConfigMap with OCP injection annotation ✅, Django key charset fixed (`abcdefghijklmnopqrstuvwxyz0123456789!@#$%^&*(-_=+)`) ✅. Missing: `cost.redhat.com/rotate-secrets` annotation trigger, pod template annotation rolling restart, `SecretRotated` Event. |
 
 ## OLM & CI
@@ -76,9 +76,15 @@ explicitly. Full ROS/Kruize delivery remains tracked under COST-8054 / post-Beta
 ## Intentional Deviations and Known Gaps
 
 See [docs/design/design-vs-jira.md](design/design-vs-jira.md) for the full analysis.
-Short version: bundled infra is dev-only (intentional), profile-based sizing is not yet implemented (COST-7693 gap), `RealmUser.Password` in spec is a security issue to fix pre-GA.
+Short version: bundled infra is dev-only (intentional), shared `spec.profile` sizing maps are post-beta → [COST-8095](https://redhat.atlassian.net/browse/COST-8095) (beta uses `profile: standard` + per-component `spec.*.resources`), `RealmUser.Password` in spec is a security issue to fix pre-GA.
 
 ---
+
+## Post-beta follow-ups
+
+| Ticket | Summary | Status | Notes |
+|--------|---------|--------|-------|
+| [COST-8095](https://redhat.atlassian.net/browse/COST-8095) | Implement `spec.profile` sizing maps | ❌ | Shared `standard`/`ha` maps + wire Cost workloads; HA sample CR; optional ROS/Kruize rows when those components reconcile. Not a Cost beta blocker. See [BETA-PRIORITY.md](gap_analysis/BETA-PRIORITY.md) T5. |
 
 ## Technical Debt
 


### PR DESCRIPTION
## Summary

- Defers shared `spec.profile` sizing maps (and the HA sample CR) to [COST-8095](https://redhat.atlassian.net/browse/COST-8095) — explicitly out of Cost beta scope per [BETA-PRIORITY.md](docs/gap_analysis/BETA-PRIORITY.md) T5.
- Clarifies beta **production sample** = monitoring-enabled BYOI Cost-only (`profile: standard`); bundled sample remains dev/CRC only; `profile: ha` sample follows COST-8095.
- Refreshes gap analyses and `docs/tasks.md`: COST-7686 ROS gating regression marked closed; profile sizing removed as an open gap from COST-7687/7689/7690; remaining beta blockers unchanged (SaaS Celery exclusion, RBAC readiness, readiness timeout).
- Adds repo scope notes to Jira mirror docs (COST-7678–7693, COST-8054) pointing profile work at COST-8095.

## Test plan

- [x] Docs-only change — no code or generated manifests modified
- [ ] Review cross-links (COST-8095, BETA-PRIORITY T5, BYOI sample path) render correctly
- [ ] Confirm beta P0/P1 priorities in BETA-PRIORITY.md still read correctly after renumbering


Made with [Cursor](https://cursor.com)

## Summary by Sourcery

Update beta gap and Jira documentation to defer shared profile sizing and HA samples to post-beta while clarifying the beta production sample and current blocking gaps.

Documentation:
- Clarify that the beta production sample is a monitoring-enabled BYOI Cost-only configuration and mark the bundled sample as dev/CRC-only.
- Reclassify shared `spec.profile` sizing maps and the HA sample CR as post-beta work owned by COST-8095 across beta priority and gap analysis docs.
- Refresh gap analysis verdicts for COST-7678–7692 to reflect restored ROS gating, completed UI profile sizing, and remaining beta blockers like SaaS queue exclusion and RBAC readiness.
- Add explicit scope notes to Jira mirror docs (COST-7678–7693, COST-8054, COST-8095) documenting that profile-based sizing is deferred post-beta except for UI.
- Update the operator task tracker to align ticket statuses and notes with the revised beta scope, remaining gaps, and new post-beta follow-up for COST-8095.