### PR TITLE
feat: gate Available on RBAC API readiness (COST-7689)

### DIFF
--- a/api/v1alpha1/costmanagementserviceconfig_types.go
+++ b/api/v1alpha1/costmanagementserviceconfig_types.go
@@ -26,7 +26,9 @@ const (
 	ConditionKafkaReady        = "KafkaReady"
 	ConditionAuthReady         = "AuthenticationReady"
 	ConditionSchemaUpToDate    = "SchemaUpToDate"
-	ConditionUIReady           = "UIReady"
+	// ConditionRBACReady reports RBAC API Deployment readiness (not the worker).
+	ConditionRBACReady = "RBACReady"
+	ConditionUIReady   = "UIReady"
 	// ConditionROSEnabled reports whether ROS/Kruize are active per spec.ros.enabled.
 	ConditionROSEnabled = "ROSEnabled"
 	// ConditionPaused is True when reconciliation is halted via the pause annotation.

--- a/api/v1alpha1/costmanagementserviceconfig_types.go
+++ b/api/v1alpha1/costmanagementserviceconfig_types.go
@@ -28,7 +28,10 @@ const (
 	ConditionSchemaUpToDate    = "SchemaUpToDate"
 	// ConditionRBACReady reports RBAC API Deployment readiness (not the worker).
 	ConditionRBACReady = "RBACReady"
-	ConditionUIReady   = "UIReady"
+	// ConditionRBACWorkerReady reports the RBAC Celery worker Deployment. It
+	// does not gate Available — Koku/Envoy call the API, not the worker.
+	ConditionRBACWorkerReady = "RBACWorkerReady"
+	ConditionUIReady         = "UIReady"
 	// ConditionROSEnabled reports whether ROS/Kruize are active per spec.ros.enabled.
 	ConditionROSEnabled = "ROSEnabled"
 	// ConditionPaused is True when reconciliation is halted via the pause annotation.

--- a/docs/code-review-fixmes.md
+++ b/docs/code-review-fixmes.md
@@ -9,11 +9,13 @@ gap-analysis notes (for example D11, D18, D20, F3, F4).
 
 #### 1. Ready ignores most workload health [D1]
 
-Only 4 resources are readiness-gated: Database StatefulSet, Cache Deployment,
-Koku API Deployment, and Envoy Deployment. Everything else — Masu, Listener,
-Celery, all ROS deployments, RBAC API/Worker, Kruize, Ingress, UI — is applied
-without readiness checks. A bad image on any of those leaves the CR reporting
-`Available=True` with zero running replicas.
+Only 4 resources were readiness-gated at the 2026-08-15 audit: Database
+StatefulSet, Cache Deployment, Koku API Deployment, and Envoy Deployment.
+**RBAC API is now gated** (`RBACReady` / `WaitingForRBAC` before `Available`;
+COST-7689 G2). Everything else — Masu, Listener, Celery, all ROS deployments,
+RBAC worker, Kruize, Ingress, UI — is still applied without readiness checks.
+A bad image on any of those leaves the CR reporting `Available=True` with zero
+running replicas.
 
 #### 2. Progressing status causes a continuous reconcile loop [D2]
 

--- a/docs/design/design-vs-jira.md
+++ b/docs/design/design-vs-jira.md
@@ -39,7 +39,7 @@ uses **three top-level conditions** as the primary machine-readable API:
 
 Below these, **component-specific conditions** carry the detail:
 `DatabaseReady`, `CacheReady`, `KafkaReady`, `StorageReady`,
-`AuthenticationReady`, `SchemaUpToDate`, `DiscoveryComplete`.
+`AuthenticationReady`, `SchemaUpToDate`, `DiscoveryComplete`, `RBACReady`.
 
 We keep a `Phase` field — **Pending / Progressing / Ready / Degraded** —
 as a human-readable convenience for `kubectl get cmsc`, not as the primary

--- a/docs/design/design-vs-jira.md
+++ b/docs/design/design-vs-jira.md
@@ -39,7 +39,8 @@ uses **three top-level conditions** as the primary machine-readable API:
 
 Below these, **component-specific conditions** carry the detail:
 `DatabaseReady`, `CacheReady`, `KafkaReady`, `StorageReady`,
-`AuthenticationReady`, `SchemaUpToDate`, `DiscoveryComplete`, `RBACReady`.
+`AuthenticationReady`, `SchemaUpToDate`, `DiscoveryComplete`, `RBACReady`,
+`RBACWorkerReady`.
 
 We keep a `Phase` field — **Pending / Progressing / Ready / Degraded** —
 as a human-readable convenience for `kubectl get cmsc`, not as the primary

--- a/docs/development/pre-prod-install.md
+++ b/docs/development/pre-prod-install.md
@@ -239,7 +239,12 @@ kubectl -n "$NAMESPACE" describe cmsc "$CR_NAME"
 ```
 
 Useful conditions: `DatabaseReady`, `CacheReady`, `KafkaReady`,
-`SchemaUpToDate`, `AuthenticationReady` (gateway), `UIReady`, `Available`.
+`SchemaUpToDate`, `RBACReady` (API — this is what `Available` waits on),
+`RBACWorkerReady` (Celery worker; does **not** gate `Available`),
+`AuthenticationReady` (gateway), `UIReady`, `Available`.
+
+`Available=True` means the RBAC **API** and Koku API are up. A down RBAC
+worker shows up as `RBACWorkerReady=False` and does not flip `Available`.
 
 Phase is human-readable only — prefer conditions.
 

--- a/docs/gap_analysis/BETA-PRIORITY.md
+++ b/docs/gap_analysis/BETA-PRIORITY.md
@@ -39,10 +39,10 @@ Several paths report success while the underlying dependency is wrong or while a
 | OIDC HTTP probe accepts any status &lt; 500 | [7684 G3](COST-7684.md) | 401/404 still `AuthenticationReady=True` |
 | External DB secret validation omits `kruize-user` / `kruize-password` | [7684 R3](COST-7684.md) | **→ [COST-8054](../jira/COST-8054.md)** (Kruize); not a Cost beta blocker |
 | External DB secret validation always requires `ros-user` / `ros-password` | [7684](COST-7684.md), [8054](../jira/COST-8054.md) | **→ [COST-8054](../jira/COST-8054.md)** — blocks true Cost-only BYOI even when `ros.enabled=false` |
-| RBAC Deployments applied but never gated; no `RBACReady` | [7689 G2](COST-7689.md) | Core can go Available while RBAC is down |
+| RBAC Deployments applied but never gated; no `RBACReady` | [7689 G2](COST-7689.md) | **Closed** — `RBACReady` gates on the RBAC API before `Available` |
 | `UIReady` / Ingress / workers not truly readiness-gated | [7690 R2](COST-7690.md), [7688 R4](COST-7688.md), [7687](COST-7687.md) | Weaker than RBAC/S3; still erodes trust in status |
 
-**Beta minimum:** fix Auth condition collision + S3 secret-key check + tighten OIDC success + RBAC readiness gate.
+**Beta minimum:** fix Auth condition collision + S3 secret-key check + tighten OIDC success. RBAC readiness gate is closed ([7689 G2](COST-7689.md)).
 
 ---
 
@@ -77,11 +77,11 @@ Several paths report success while the underlying dependency is wrong or while a
 
 ---
 
-### T5. Profile / HA sizing (many tickets, one deliverable) — **P2 for beta**
+### T5. Profile / HA sizing — **P2 for beta** → [COST-8095](../jira/COST-8095.md)
 
-`spec.profile` exists; **no code reads it**. Called out as G1/G4 across [7678](COST-7678.md), [7687](COST-7687.md), [7689](COST-7689.md), [7690](COST-7690.md); also [tasks.md](../tasks.md) COST-7686 / 7693.
+UI already reads `spec.profile` when `spec.ui.*.resources` are unset ([#65](https://github.com/project-koku/koku-service-operator/pull/65)). Remaining Cost workload maps (Koku, Celery, RBAC, …) and a meaningful `profile: ha` sample are **[COST-8095](https://redhat.atlassian.net/browse/COST-8095)**. ROS/Kruize rows stay with [COST-8054](../jira/COST-8054.md).
 
-**Beta stance:** ship `profile: standard` only; document that `ha` is reserved. Implement one shared sizing map post-beta (or late beta if HA demos are required).
+**Beta stance:** ship `profile: standard` only; document that `ha` is reserved until COST-8095.
 
 ---
 
@@ -127,13 +127,13 @@ Several paths report success while the underlying dependency is wrong or while a
 | Ticket | Summary | Suggested beta rank |
 |--------|---------|---------------------|
 | [COST-7695](https://redhat.atlassian.net/browse/COST-7695) | OLM bundle | **P0** if beta is delivered via OLM; else P1 |
-| [COST-7686](https://redhat.atlassian.net/browse/COST-7686) | App services — profile sizing + 5m readiness → Degraded | Profile **P2**; readiness timeout **P1** |
+| [COST-7686](https://redhat.atlassian.net/browse/COST-7686) | App services — 5m readiness → Degraded | Readiness timeout **P1**; profile sizing → [COST-8095](../jira/COST-8095.md) **P2** |
 | [COST-7693](https://redhat.atlassian.net/browse/COST-7693) | Upgrade/scaling/rollback | **P2** (basic image-tag migrate exists) |
 | [COST-7694](https://redhat.atlassian.net/browse/COST-7694) | Secret rotation annotation | **P2** (day-2); CA merge overlaps [7691 G3](COST-7691.md) **P1** |
 | [COST-7696](https://redhat.atlassian.net/browse/COST-7696)–[7699](https://redhat.atlassian.net/browse/COST-7699) | Bundle CI / E2E / OpenShift CI | **P2** for beta; **P1** if beta needs automated install proof |
 | [COST-7700](https://redhat.atlassian.net/browse/COST-7700) | Install/config guides | **P1** (beta customers need a BYOI quickstart with `ros.enabled: false`) |
 
-Tickets marked ✅ in `tasks.md` that gap audits found incomplete: **7683, 7684, 7687, 7688, 7689, 7690, 7691, 7692** (docs drift — do not treat tracker checkmarks as beta-ready).
+Tickets marked ✅ in `tasks.md` that gap audits found incomplete: **7683, 7684, 7687, 7688, 7690, 7691, 7692** (docs drift — do not treat tracker checkmarks as beta-ready). COST-7689 readiness (G2) is closed; sizing moved to COST-8095.
 
 ---
 
@@ -148,7 +148,7 @@ Tickets marked ✅ in `tasks.md` that gap audits found incomplete: **7683, 7684,
 5. **BYOI StorageClass soft-fail** when no bundled PVC consumers ([7682 R1](COST-7682.md)).
 6. **`objectbucket.io` RBAC** if OBC is in-scope for beta ([7683 G1](COST-7683.md)); otherwise document user-secret-only.
 7. **OIDC probe** — require 2xx + parse JWKS `keys` ([7684 G3](COST-7684.md)).
-8. **RBAC readiness gate + condition** before core Available ([7689 G2](COST-7689.md)).
+8. **RBAC readiness gate + condition** before core Available ([7689 G2](COST-7689.md)) — **closed** (`RBACReady` on the RBAC API).
 9. **OLM bundle** ([COST-7695](../tasks.md)) if that is the beta install vehicle.
 
 ### P1 — Ship with beta if possible
@@ -167,7 +167,7 @@ Tickets marked ✅ in `tasks.md` that gap audits found incomplete: **7683, 7684,
 
 ### P2 — After beta / toward GA (Cost core)
 
-21. Shared **profile sizing maps** for Cost workloads + wire ([7678 G4](COST-7678.md) + 7686/87/89/90/93). ROS/Kruize map rows → COST-8054.
+21. Shared **profile sizing maps** for Cost workloads + wire — **[COST-8095](../jira/COST-8095.md)** ([7678 G4](COST-7678.md) + former 7686/87/89/90/93 ACs). ROS/Kruize map rows → COST-8054.
 22. HA sample + `profile: ha` behavior ([7679 G2](COST-7679.md)).
 23. Monitoring: real **Cost** scrape targets, operator metrics, alert parity ([7692](COST-7692.md)). ROS/Kruize scrapes → COST-8054.
 24. Full NetworkPolicy / dedicated SA matrix for **core** ([7691](COST-7691.md)). ROS/Kruize matrix → COST-8054.
@@ -240,13 +240,13 @@ S3/OBC items stay relevant either way — Ingress/uploads still need object stor
 | [COST-7685](COST-7685.md) | Done | Tests only (G1); ROS migrate skip already gated by `ros.enabled` |
 | [COST-7687](COST-7687.md) | Not fully done | SaaS queue exclusion (P0); ROS/Kruize workloads gated when disabled; sizing → [COST-8054](../jira/COST-8054.md) |
 | [COST-7688](COST-7688.md) | Largely done | Auth condition collision (P0) |
-| [COST-7689](COST-7689.md) | Not done | RBAC readiness (P0) |
-| [COST-7690](COST-7690.md) | Not fully done | Profile sizing (P2); Related `UIReady` ≠ pods Ready (T1 trust) |
+| [COST-7689](COST-7689.md) | Done | Readiness closed; sizing → [COST-8095](../jira/COST-8095.md) |
+| [COST-7690](COST-7690.md) | Not fully done | UI profile sizing done; remaining maps → [COST-8095](../jira/COST-8095.md) **P2**; Related `UIReady` ≠ pods Ready (T1 trust) |
 | [COST-7691](COST-7691.md) | Not done | CA merge + core NPs (P1); ROS/Kruize SA/NP → [COST-8054](../jira/COST-8054.md) |
 | [COST-7692](COST-7692.md) | Not done | Monitoring completeness (P2); Kruize SM only when `ROSEnabled`; ROS/Kruize SM → [COST-8054](../jira/COST-8054.md) |
 | [COST-8054](../jira/COST-8054.md) | In progress (partial) | Conditional Validation keys; independent Kruize; day-2; hardening gaps |
 
-No gap doc yet for **COST-7686** (app services) — treat readiness timeout as P1 and profile sizing as part of T5.
+No gap doc yet for **COST-7686** (app services) — treat readiness timeout as P1 and profile sizing as [COST-8095](../jira/COST-8095.md) (T5).
 
 ---
 

--- a/docs/gap_analysis/COST-7678.md
+++ b/docs/gap_analysis/COST-7678.md
@@ -11,7 +11,7 @@
 
 - `spec.profile` enum `standard` / `ha` with CRD default `standard` ([#65](https://github.com/project-koku/koku-service-operator/pull/65) re-added `ha`; [#28](https://github.com/project-koku/koku-service-operator/pull/28) had temporarily removed it).
 - **Partial wiring:** `spec.profile` is read by the UI builder when `spec.ui.oauthProxy.resources` / `spec.ui.app.resources` are unset — [`uiProfileResources`](../../internal/resources/ui.go) ([#65](https://github.com/project-koku/koku-service-operator/pull/65)).
-- **Deferred:** shared `profiles.go` sizing maps and reconciler wiring for Celery, Koku API, Masu, Listener, RBAC, etc. → [COST-7686](https://redhat.atlassian.net/browse/COST-7686) / [COST-7687](https://redhat.atlassian.net/browse/COST-7687) and [BETA-PRIORITY.md](BETA-PRIORITY.md) item 21 (P2 post-beta).
+- **Deferred:** shared `profiles.go` sizing maps and reconciler wiring for Celery, Koku API, Masu, Listener, RBAC, etc. → [COST-8095](https://redhat.atlassian.net/browse/COST-8095) ([BETA-PRIORITY.md](BETA-PRIORITY.md) T5, P2 post-beta).
 - ROS/Kruize profile rows → [COST-8054](../jira/COST-8054.md).
 
 Out of scope per ticket: reconciler logic, resource builders.
@@ -48,7 +48,7 @@ Out of scope per ticket: reconciler logic, resource builders.
 | App types + `dataRetentionMonths` | Done — default 4, range 1–60, wired to `RETAIN_NUM_MONTHS` |
 | Status: phase, conditions, DiscoveredConfig | Done with intentional phase rename |
 | `ComponentStatus` | Removed (intentional; conditions instead) |
-| `profiles.go`: enum + resource sizing maps | **Partial** — enum `standard`/`ha` ✅ ([#65](https://github.com/project-koku/koku-service-operator/pull/65)); UI defaults from profile ✅ ([#65](https://github.com/project-koku/koku-service-operator/pull/65)); shared maps for other workloads → COST-7686/7687 |
+| `profiles.go`: enum + resource sizing maps | **Partial** — enum `standard`/`ha` ✅ ([#65](https://github.com/project-koku/koku-service-operator/pull/65)); UI defaults from profile ✅ ([#65](https://github.com/project-koku/koku-service-operator/pull/65)); shared maps for other workloads → [COST-8095](https://redhat.atlassian.net/browse/COST-8095) |
 | `defaults.go` mutating webhook | Done — noop defaulter; CRD OpenAPI defaults cover profile/monitoring/dataRetentionMonths |
 | `validation.go` webhook + CEL | Done — [#50](https://github.com/project-koku/koku-service-operator/pull/50)/[#51](https://github.com/project-koku/koku-service-operator/pull/51) CEL + [#52](https://github.com/project-koku/koku-service-operator/pull/52) validating webhook |
 | External-only infra (no type field) | Deviated — `deploy *bool` for DB/cache (dev/CI only) |
@@ -90,7 +90,7 @@ Documented in [design-vs-jira.md](../design/design-vs-jira.md) §1–3:
 | `credentialsSecretRef` | `secretName` / Kafka `sasl.existingSecret` | Simpler string refs |
 | `authentication.issuerUrl` required | `auth.keycloak.issuerURL` optional | JWKS `url` can be in-cluster HTTP |
 | External-only infra | `database.deploy` / `cache.deploy` default true | Dev/CI only; production is BYOI |
-| `profiles.go` sizing maps | Partial UI wiring ([#65](https://github.com/project-koku/koku-service-operator/pull/65)); Celery/core maps deferred to COST-7686/7687 | JIRA names a single maps file; beta ships `profile: standard` for most workloads ([BETA-PRIORITY.md](BETA-PRIORITY.md) T5) |
+| `profiles.go` sizing maps | Partial UI wiring ([#65](https://github.com/project-koku/koku-service-operator/pull/65)); remaining maps → [COST-8095](https://redhat.atlassian.net/browse/COST-8095) | JIRA names a single maps file; beta ships `profile: standard` for most workloads ([BETA-PRIORITY.md](BETA-PRIORITY.md) T5) |
 
 ---
 
@@ -127,13 +127,12 @@ JIRA names `profiles.go` with sizing maps. **Delivered on `main`:**
 | Enum `standard` / `ha` | Done | [#65](https://github.com/project-koku/koku-service-operator/pull/65) |
 | UI oauth-proxy + app resources from `spec.profile` when `spec.ui.*.resources` unset | Done | [#65](https://github.com/project-koku/koku-service-operator/pull/65) — [`uiProfileResources`](../../internal/resources/ui.go) |
 
-**Deferred** to workload tickets (shared maps + wiring beyond UI):
+**Deferred** to [COST-8095](https://redhat.atlassian.net/browse/COST-8095) (shared maps + wiring beyond UI):
 
 | Follow-up | Owns |
 |-----------|------|
-| [COST-7686](https://redhat.atlassian.net/browse/COST-7686) | Core app Deployments — profile sizing when wired |
-| [COST-7687](https://redhat.atlassian.net/browse/COST-7687) | Celery workers — sizing maps |
-| [COST-8054](https://redhat.atlassian.net/browse/COST-8054) | ROS/Kruize profile rows |
+| [COST-8095](https://redhat.atlassian.net/browse/COST-8095) | Shared `profiles.go` maps + Cost core / RBAC / Celery builders |
+| [COST-8054](https://redhat.atlassian.net/browse/COST-8054) | ROS/Kruize profile rows (when those components reconcile) |
 
 Until full maps land: use per-component `spec.*.resources` for non-UI workloads; explicit UI `resources` still override profile defaults ([#65](https://github.com/project-koku/koku-service-operator/pull/65)).
 

--- a/docs/gap_analysis/COST-7680.md
+++ b/docs/gap_analysis/COST-7680.md
@@ -155,6 +155,8 @@ Event surface now covers:
 
 All transition Events use condition or `priorPhase` guards to avoid firing on every drift pass. The Ready Event transition bug (overwriting phase to Progressing before the guard) was fixed by capturing `priorPhase` before the reset.
 
+`CoreServicesAvailable` + mid-pipeline `Available=True` (`KokuAvailable`) before Edge/workers finish → [COST-8103](../jira/COST-8103.md) (post-beta). `MigrationComplete` / `Paused` still fire every pass, not only on transition.
+
 ---
 
 ## Related gaps (not in Jira body; same surface)

--- a/docs/gap_analysis/COST-7686.md
+++ b/docs/gap_analysis/COST-7686.md
@@ -35,7 +35,7 @@ Out of scope per ticket: *"Workers, CronJobs, Gateway"* (i.e. Celery workers/sch
 | Kruize — Deployment + Service + cluster-scoped ClusterRole/ClusterRoleBinding, finalizer cleanup | Done, but see G1 (not actually optional) |
 | Django key — 50 chars, `crypto/rand`, exact charset, Secret, created once, never regenerated | Done |
 | Deployments wired with env vars from CR spec | Done |
-| Profile-based sizing | Missing |
+| Profile-based sizing | Moved to [COST-8095](https://redhat.atlassian.net/browse/COST-8095) |
 | Per-component resource overrides | Done |
 | 5-minute readiness timeout → Degraded with non-ready component name, requeue with backoff | Missing |
 | Ungate Platform (Ready) phase only when all service pods are ready | Partial — phase model exists (intentional rename, see design-vs-jira.md §1) but only 3 of ~14 Deployments actually gate it |
@@ -97,11 +97,11 @@ The ticket requires: *"If any Deployment does not reach Ready within 5 minutes, 
 
 ### G3. Platform/Ready phase is not actually gated on "all service pods ready"
 
-Given G2, `cfg.Status.Phase = PhaseReady` / `ConditionAvailable = True` at the end of `reconcile()` fires as soon as the *pipeline* completes without error — not when Masu, Listener, ROS, Kruize, or RBAC pods are individually confirmed `Ready`. This is the same underlying issue as [COST-7689 G2](COST-7689.md) ("RBAC Deployments applied but never gated") and the `BETA-PRIORITY.md` T1 theme ("`UIReady` / Ingress / workers not truly readiness-gated"), but scoped here to the literal COST-7686 acceptance criterion "on all service pods ready, ungate the Platform phase." Fixing G2 (readiness checks for every Deployment this ticket owns) is the direct fix for this criterion; it is listed separately because the ticket calls it out as its own bullet.
+Given G2, `cfg.Status.Phase = PhaseReady` / `ConditionAvailable = True` at the end of `reconcile()` fires as soon as the *pipeline* completes without error — not when Masu, Listener, ROS, Kruize, or RBAC pods are individually confirmed `Ready`. This is the same underlying issue as [COST-7689 G2](COST-7689.md) (RBAC API is now gated; Masu/Listener/ROS still are not) and the `BETA-PRIORITY.md` T1 theme ("`UIReady` / Ingress / workers not truly readiness-gated"), but scoped here to the literal COST-7686 acceptance criterion "on all service pods ready, ungate the Platform phase." Fixing G2 (readiness checks for every Deployment this ticket owns) is the direct fix for this criterion; it is listed separately because the ticket calls it out as its own bullet.
 
-### G4. Profile-based sizing — confirmed pre-existing gap, still open
+### G4. Profile-based sizing — moved to [COST-8095](https://redhat.atlassian.net/browse/COST-8095)
 
-`spec.profile` (`Profile` type, `+kubebuilder:default:=standard`) is accepted by the API but never read by any resource builder in `internal/resources/`. This is already tracked as a cross-cutting gap in [COST-7678](COST-7678.md), [COST-7687](COST-7687.md), [COST-7689](COST-7689.md), [COST-7690](COST-7690.md), and `BETA-PRIORITY.md` T5 (ranked **P2 for beta**). No new finding here — confirming it is still unimplemented as of this audit and applies equally to every Deployment this ticket (COST-7686) owns. Use per-component `spec.*.resources` fields as the documented workaround until a shared sizing map lands.
+`spec.profile` is read by the UI builder only. Shared maps for Koku/Masu/Listener (and other Cost workloads) are COST-8095, not this ticket. Use per-component `spec.*.resources` until those maps land.
 
 ---
 

--- a/docs/gap_analysis/COST-7687.md
+++ b/docs/gap_analysis/COST-7687.md
@@ -36,7 +36,7 @@ Out of scope per ticket: Gateway, RBAC service (covered by COST-7688 / COST-7689
 | ROS Housekeeper | Done (ticket) — **not required for Cost beta** → [COST-8054](../jira/COST-8054.md) |
 | ROS Partition Cleaner CronJob | Done (ticket) — **not required for Cost beta** → [COST-8054](../jira/COST-8054.md) |
 | Kruize CronJobs | Done (ticket) / Deviated (create = init) — **not required for Cost beta** → [COST-8054](../jira/COST-8054.md) |
-| Profile-based sizing | **Missing** — `spec.profile` never read (Celery maps P2; ROS and Kruize maps → [COST-8054](../jira/COST-8054.md)) |
+| Profile-based sizing | Moved to [COST-8095](https://redhat.atlassian.net/browse/COST-8095) (Celery maps); ROS/Kruize rows → [COST-8054](../jira/COST-8054.md) |
 
 ---
 
@@ -83,23 +83,9 @@ Reconciled in [`reconcileWorkers`](../../internal/controller/costmanagementservi
 
 ## Remaining gaps (ticket-scoped)
 
-### G1. Profile-based sizing — missing
+### G1. Profile-based sizing — moved to [COST-8095](https://redhat.atlassian.net/browse/COST-8095)
 
-Ticket requires profile-based sizing. `Profile` enum (`standard` / `ha`) exists on the CR, but **no Go code reads `cfg.Spec.Profile`** (repo-wide grep: no `Spec.Profile` usage). There is no `profiles.go` / sizing map.
-
-Current sizing is per-component CR fields or hardcodes only:
-
-| Workload | Sizing today |
-|----------|----------------|
-| Celery workers | `CeleryWorkerSpec.Replicas` / `Resources` / `Concurrency` (CRD defaults 1 / empty / 5) |
-| Celery Beat | Hardcoded replicas `1`, **empty** `ResourceRequirements` |
-| ROS poller / housekeeper | Hardcoded replicas `1`; optional CR `resources` |
-| ROS processor | `spec.ros.processor.replicas` / `resources` |
-| CronJobs | Optional `resources` on partition cleaner / Kruize partitions |
-
-**Impact:** `profile: ha` does not change worker/CronJob replicas or requests/limits. Same cross-ticket gap as COST-7678 / COST-7686 / COST-7693.
-
-**Beta:** Profile sizing overall is P2 ([BETA-PRIORITY.md](BETA-PRIORITY.md) T5). If maps are built earlier, prioritize Celery Beat + six on-prem queues; ROS and Kruize rows → [COST-8054](../jira/COST-8054.md).
+Ticket originally required profile-based sizing. UI already reads `spec.profile`; Celery/Beat maps are owned by COST-8095. ROS/Kruize rows → [COST-8054](../jira/COST-8054.md). Use per-component `spec.*.resources` until those maps land.
 
 ### G2. SaaS-only Celery queues not excluded — missing
 

--- a/docs/gap_analysis/COST-7689.md
+++ b/docs/gap_analysis/COST-7689.md
@@ -101,7 +101,7 @@ ticket. Same UI-only wiring as today ([`uiProfileResources`](../../internal/reso
 
 ### G2. Status reporting for RBAC readiness — closed
 
-`ConditionRBACReady` in [`costmanagementserviceconfig_types.go`](../../api/v1alpha1/costmanagementserviceconfig_types.go). Stage 4 applies RBAC + Koku in parallel, then `isDeploymentReady` on `NameRBACAPI` (not the worker). Not ready → `RBACReady=False` / `Available=False` reason `WaitingForRBAC`. Ready → `RBACReady=True` (`RBACAvailable`), then the existing Koku API gate. Tests in [`core_services_test.go`](../../internal/controller/core_services_test.go).
+`ConditionRBACReady` in [`costmanagementserviceconfig_types.go`](../../api/v1alpha1/costmanagementserviceconfig_types.go). Stage 4 applies RBAC + Koku in parallel, then `isDeploymentReady` on `NameRBACAPI` (not the worker). Not ready → `RBACReady=False` / `Available=False` reason `WaitingForRBAC`. Ready → `RBACReady=True` (`RBACAvailable`), then the existing Koku API gate. The worker is reported separately as `RBACWorkerReady` and does not gate `Available`. Tests in [`core_services_test.go`](../../internal/controller/core_services_test.go).
 
 ---
 

--- a/docs/gap_analysis/COST-7689.md
+++ b/docs/gap_analysis/COST-7689.md
@@ -1,13 +1,19 @@
 # COST-7689 Gap Analysis: Implement RBAC Service
 
 **Jira:** [COST-7689](https://redhat.atlassian.net/browse/COST-7689)
-**Audited:** 2026-08-10
+**Audited:** 2026-08-10 · **Closed (docs):** 2026-08-17
 **Purpose:** Handoff audit vs ticket acceptance criteria. Does not update `docs/tasks.md` or other trackers.
-**Beta scope:** ROS and Kruize are **out of beta** ([BETA-PRIORITY.md](BETA-PRIORITY.md)); optional install → [COST-8054](../jira/COST-8054.md). RBAC API readiness remains a Cost beta concern; unrelated to ROS or Kruize.
+**Beta scope:** ROS and Kruize are **out of beta** ([BETA-PRIORITY.md](BETA-PRIORITY.md)); optional install → [COST-8054](../jira/COST-8054.md). RBAC API readiness is a Cost beta concern; unrelated to ROS or Kruize.
 
 ## Verdict
 
-RBAC workloads are largely implemented and go beyond the ticket’s worker-only wording (API Deployment + Service + Celery worker, Stage 4 before Koku, DB/cache env wiring). COST-7689 is **not done**: profile-based resource sizing and RBAC readiness status reporting are still missing.
+**COST-7689 is done** for the ticket-scoped deliverables that remain here.
+RBAC workloads go beyond the ticket’s worker-only wording (API Deployment +
+Service + Celery worker, Stage 4 before Koku, DB/cache env wiring, Keycloak
+sync). **G2 (RBAC readiness status) is closed**: `RBACReady` gates on the RBAC
+API Deployment before `Available`. **G1 (profile-based resource sizing)** moved
+to [COST-8095](https://redhat.atlassian.net/browse/COST-8095) — not required to
+close this ticket.
 
 ## Sources
 
@@ -29,8 +35,8 @@ Out of scope per ticket: RBAC schema migration and data seeding (story 9 / COST-
 | Deliverable | Status |
 |-------------|--------|
 | RBAC worker Deployment with env wiring to external DB and cache | Done (superseded: also deploys RBAC API + Service) |
-| Profile-based resource sizing | **Missing** |
-| Status reporting for RBAC component readiness | **Missing** |
+| Profile-based resource sizing | Moved to [COST-8095](https://redhat.atlassian.net/browse/COST-8095) (post-beta) |
+| Status reporting for RBAC component readiness | **Done** — `RBACReady` + gate before `Available` |
 
 ---
 
@@ -69,6 +75,7 @@ Also sets on-prem RBAC flags mirroring the Helm chart helpers (`BYPASS_BOP_VERIF
 ### Tests
 
 - [`rbac_test.go`](../../internal/resources/rbac_test.go) asserts `API_PATH_PREFIX=/api/rbac`
+- [`core_services_test.go`](../../internal/controller/core_services_test.go) — `RBACReady` / `WaitingForRBAC` gate (API only; worker does not block `Available`)
 - Controllers/other packages exercise RBAC naming in Envoy backend tests and DB secret key validation (`rbac-user` / `rbac-password`)
 
 ---
@@ -86,37 +93,29 @@ Also sets on-prem RBAC flags mirroring the Helm chart helpers (`BYPASS_BOP_VERIF
 
 ## Remaining gaps (ticket-scoped)
 
-### G1. Profile-based resource sizing — missing
+### G1. Profile-based resource sizing — moved to [COST-8095](https://redhat.atlassian.net/browse/COST-8095)
 
-**Evidence:** `RBACAPIDeployment` / `RBACWorkerDeployment` pass through `spec.rbac.api.resources` and `spec.rbac.worker.resources` only ([`rbac.go`](../../internal/resources/rbac.go) ~L189, ~L260). There are no profile→requests/limits maps keyed by `spec.profile` (`standard` / `ha`) in `api/` or `internal/resources` — only the `Profile` enum exists ([`costmanagementserviceconfig_types.go`](../../api/v1alpha1/costmanagementserviceconfig_types.go)). Same cross-cutting gap as COST-7678 / COST-7686 / COST-7693 / COST-7690.
+RBAC API/worker still pass through `spec.rbac.*.resources` only. Shared
+`spec.profile` maps (including RBAC rows) are owned by COST-8095, not this
+ticket. Same UI-only wiring as today ([`uiProfileResources`](../../internal/resources/ui.go)).
 
-Samples set `replicas: 1` only — no resource blocks and no profile-driven defaults.
+### G2. Status reporting for RBAC readiness — closed
 
-**Impact:** HA vs standard does not change RBAC CPU/memory (or replica defaults beyond CR/OpenAPI). Ticket AC unmet.
-
-### G2. Status reporting for RBAC readiness — missing
-
-**Evidence:**
-
-- No `RBACReady` (or similar) condition constant in [`costmanagementserviceconfig_types.go`](../../api/v1alpha1/costmanagementserviceconfig_types.go) (component conditions include `DatabaseReady` … `UIReady` / `ROSEnabled`; nothing for RBAC).
-- Stage 4 applies RBAC objects then gates only on **Koku API** readiness (`isDeploymentReady` → `Available` / `WaitingForAPI`) — never checks `NameRBACAPI` or `NameRBACWorker` ([controller ~L448–458](../../internal/controller/costmanagementserviceconfig_controller.go)).
-- Deep review D1 notes RBAC among Deployments applied without readiness gates; CR can reach `Available=True` / `Phase=Ready` while RBAC has zero available replicas.
-
-**Impact:** Operators and automation cannot see RBAC-specific readiness; failures surface only as opaque Koku/permission errors. Called out as a Cost beta blocker in [BETA-PRIORITY.md](BETA-PRIORITY.md) T1.
+`ConditionRBACReady` in [`costmanagementserviceconfig_types.go`](../../api/v1alpha1/costmanagementserviceconfig_types.go). Stage 4 applies RBAC + Koku in parallel, then `isDeploymentReady` on `NameRBACAPI` (not the worker). Not ready → `RBACReady=False` / `Available=False` reason `WaitingForRBAC`. Ready → `RBACReady=True` (`RBACAvailable`), then the existing Koku API gate. Tests in [`core_services_test.go`](../../internal/controller/core_services_test.go).
 
 ---
 
 ## Related gaps (not in Jira body; same surface)
 
-### R1. `REDIS_PORT` hardcoded to `6379`
+### R1. `REDIS_PORT` hardcoded to `6379` — closed
 
-[`rbacEnv`](../../internal/resources/rbac.go) sets `REDIS_PORT` to `"6379"` while Koku env wiring in [`env.go`](../../internal/resources/env.go) and `WaitForValkeyInitContainer` use `spec.cache.port`. External cache on a non-default port can pass validation/init TCP checks and still break RBAC connections (deep review D18).
+[`rbacEnv`](../../internal/resources/rbac.go) uses `cachePortStr(cfg)` (same as Koku / wait-for-Valkey).
 
 ### R2. Thin unit coverage for RBAC builders
 
 Only `API_PATH_PREFIX` is asserted. No tests for DB/cache secret key refs, TLS/auth env branches, replica defaults, or that worker/API Deployments are produced with expected names/commands.
 
-### R3. No readiness wait before Koku in Stage 4
+### R3. No readiness wait before Koku in Stage 4 — accepted
 
-Even without a dedicated condition (G2), applying Koku immediately after RBAC SSA without waiting for RBAC AvailableReplicas increases race risk on cold start. Closely tied to G2.
+Koku is still applied in the same pass as RBAC (faster cold start). `Available` waits on the RBAC API (G2). A Koku wait-for-RBAC init container is out of scope.
 

--- a/docs/gap_analysis/COST-7690.md
+++ b/docs/gap_analysis/COST-7690.md
@@ -7,7 +7,7 @@
 
 ## Verdict
 
-UI Deployment (oauth2-proxy sidecar + nginx), ClusterIP Service with service-CA TLS, operator-managed cookie Secret / nginx ConfigMap, and cluster-scoped ConsoleLink with finalizer cleanup are implemented under Edge (`reconcileUI`). COST-7690 ticket AC is **done**, including profile-based UI resource sizing (`spec.profile` `standard` / `ha`). Other workloads still ignore `spec.profile` (COST-7678 G4).
+UI Deployment (oauth2-proxy sidecar + nginx), ClusterIP Service with service-CA TLS, operator-managed cookie Secret / nginx ConfigMap, and cluster-scoped ConsoleLink with finalizer cleanup are implemented under Edge (`reconcileUI`). COST-7690 ticket AC is **done**, including profile-based UI resource sizing (`spec.profile` `standard` / `ha`). Other workloads still ignore `spec.profile` ([COST-8095](https://redhat.atlassian.net/browse/COST-8095)).
 
 ## Sources
 
@@ -90,7 +90,7 @@ Built in [`UIDeployment`](../../internal/resources/ui.go) (~L145–303), applied
 
 ### G1. Profile-based resource sizing — closed
 
-[`UIDeployment`](../../internal/resources/ui.go) reads `cfg.Spec.Profile` via `uiProfileResources`. `standard`/unset keep 50m/64Mi request and 100m/128Mi limit; `ha` uses 100m/128Mi and 200m/256Mi. Per-component `spec.ui.*.resources` win when set. Other workloads still ignore `spec.profile` (COST-7678 G4 / COST-7686 / COST-7693).
+[`UIDeployment`](../../internal/resources/ui.go) reads `cfg.Spec.Profile` via `uiProfileResources`. `standard`/unset keep 50m/64Mi request and 100m/128Mi limit; `ha` uses 100m/128Mi and 200m/256Mi. Per-component `spec.ui.*.resources` win when set. Other workloads still ignore `spec.profile` ([COST-8095](https://redhat.atlassian.net/browse/COST-8095)).
 
 ---
 

--- a/docs/jira/COST-7689.md
+++ b/docs/jira/COST-7689.md
@@ -14,10 +14,11 @@
 Deliver RBAC worker Deployment. Wired to external DB and cache.
 
 
-### Acceptance Criteria* RBAC worker Deployment with proper env var wiring to external DB and cache
+### Acceptance Criteria
 
-- Profile-based resource sizing
+- RBAC worker Deployment with proper env var wiring to external DB and cache
 - Status reporting for RBAC component readiness
+- ~~Profile-based resource sizing~~ — moved to [COST-8095](https://redhat.atlassian.net/browse/COST-8095)
 
 ### Out of Scope
 

--- a/docs/jira/COST-8095.md
+++ b/docs/jira/COST-8095.md
@@ -1,0 +1,28 @@
+# COST-8095: Implement spec.profile sizing maps for managed workloads
+
+**Jira:** [COST-8095](https://redhat.atlassian.net/browse/COST-8095)
+**Type:** Task
+**Status:** Backlog
+**Parent:** [COST-8091](https://redhat.atlassian.net/browse/COST-8091) — Operator fit and finish
+
+## Description
+
+Shared `spec.profile` (`standard` / `ha`) resource and replica maps for Cost
+workloads. **Not a Cost beta blocker.** Beta ships `profile: standard` plus
+per-component `spec.*.resources`. UI already applies profile defaults when
+`spec.ui.*.resources` are unset ([PR #65](https://github.com/project-koku/koku-service-operator/pull/65)).
+
+Consolidates sizing ACs that were previously split across COST-7678 G4,
+COST-7686, COST-7687, COST-7689, COST-7690, COST-7693, and COST-7679 (HA sample).
+
+ROS/Kruize profile rows remain coordinated with [COST-8054](COST-8054.md).
+SaaS Celery exclusion stays on [COST-7687](COST-7687.md).
+
+## Acceptance Criteria (summary)
+
+- Shared `internal/resources/profiles.go` (or equivalent) for `standard` / `ha`
+- Wire builders when per-component `resources` (and replica fields) are unset
+- Explicit CR fields always win (same rule as UI today)
+- HA sample CR becomes meaningful once maps land (COST-7679)
+
+Full AC list is on the Jira.

--- a/docs/jira/COST-8103.md
+++ b/docs/jira/COST-8103.md
@@ -1,0 +1,27 @@
+# COST-8103: Align CoreServicesAvailable Event and mid-pipeline Available with Ready
+
+**Jira:** [COST-8103](https://redhat.atlassian.net/browse/COST-8103)
+**Type:** Task
+**Status:** New
+**Parent:** [COST-8091](https://redhat.atlassian.net/browse/COST-8091) — Operator fit and finish
+
+## Description
+
+`CoreServicesAvailable` fires when the Koku API Deployment becomes ready, and
+the same pass sets `Available=True` (`KokuAvailable`) **before** workers and
+Edge finish. The name reads as “core is up”; `Ready` is the real all-stages
+signal. **Not a Cost beta blocker.**
+
+Came out of [PR #76](https://github.com/project-koku/koku-service-operator/pull/76):
+we declined a matching `RBACAvailable` Event. Success Events should stay
+sparse (`Ready` + warnings). Conditions remain the health API.
+
+Related: [COST-7680](COST-7680.md) Event surface, [COST-7689](COST-7689.md).
+
+## Acceptance Criteria (summary)
+
+- `CoreServicesAvailable` must not imply the Cost stack is serving before
+  Edge/workers complete (remove, or rename/retime)
+- Do not publish `Available=True` (`KokuAvailable`) mid-pipeline while later
+  stages can still requeue
+- Tests for Event/condition timing; update COST-7680 Event table

--- a/docs/tasks.md
+++ b/docs/tasks.md
@@ -14,7 +14,7 @@ Last audited: 2026-08-15.
 
 | Ticket | Summary | Status | Notes |
 |--------|---------|--------|-------|
-| [COST-7678](https://redhat.atlassian.net/browse/COST-7678) | Define CostManagement CRD types | ✅ | CRD types ✅, CEL + admission webhooks ([#50](https://github.com/project-koku/koku-service-operator/pull/50)/[#51](https://github.com/project-koku/koku-service-operator/pull/51)/[#52](https://github.com/project-koku/koku-service-operator/pull/52)) ✅, `dataRetentionMonths` wired ([#59](https://github.com/project-koku/koku-service-operator/pull/59)) ✅. **G4 partial:** enum `standard`/`ha` + UI profile defaults ([#65](https://github.com/project-koku/koku-service-operator/pull/65)) ✅; shared sizing maps for Celery/core workloads deferred to COST-7686/7687. See [gap analysis](gap_analysis/COST-7678.md). |
+| [COST-7678](https://redhat.atlassian.net/browse/COST-7678) | Define CostManagement CRD types | ✅ | CRD types ✅, CEL + admission webhooks ([#50](https://github.com/project-koku/koku-service-operator/pull/50)/[#51](https://github.com/project-koku/koku-service-operator/pull/51)/[#52](https://github.com/project-koku/koku-service-operator/pull/52)) ✅, `dataRetentionMonths` wired ([#59](https://github.com/project-koku/koku-service-operator/pull/59)) ✅. **G4 partial:** enum `standard`/`ha` + UI profile defaults ([#65](https://github.com/project-koku/koku-service-operator/pull/65)) ✅; shared sizing maps for remaining workloads → [COST-8095](https://redhat.atlassian.net/browse/COST-8095). See [gap analysis](gap_analysis/COST-7678.md). |
 | [COST-7679](https://redhat.atlassian.net/browse/COST-7679) | Create sample CRs and generate manifests | 🔄 | Bundled CR ✅, BYOI CR ✅, BYOI kustomize fixture ✅, CRD installs on CRC ✅. Missing: HA profile sample, CEL validation verified. |
 
 ## Reconciler Core
@@ -37,10 +37,10 @@ Last audited: 2026-08-15.
 
 | Ticket | Summary | Status | Notes |
 |--------|---------|--------|-------|
-| [COST-7686](https://redhat.atlassian.net/browse/COST-7686) | Implement application services | 🔄 | Koku API + Masu + Listener `1/1 Running` on CRC ✅, ROS API + Processor ✅ (optional via `spec.ros.enabled`), Kruize Deployment + Service + ClusterRole/Binding ✅ (gated with ROS), Bundled DB/Cache (dev-only extension) ✅. **Beta: ROS/Kruize not required** — see Beta scope below. Missing: profile-based sizing, 5-minute readiness timeout with Degraded condition. |
+| [COST-7686](https://redhat.atlassian.net/browse/COST-7686) | Implement application services | 🔄 | Koku API + Masu + Listener `1/1 Running` on CRC ✅, ROS API + Processor ✅ (optional via `spec.ros.enabled`), Kruize Deployment + Service + ClusterRole/Binding ✅ (gated with ROS), Bundled DB/Cache (dev-only extension) ✅. **Beta: ROS/Kruize not required** — see Beta scope below. Missing: 5-minute readiness timeout with Degraded condition. Profile-based sizing → [COST-8095](https://redhat.atlassian.net/browse/COST-8095). |
 | [COST-7687](https://redhat.atlassian.net/browse/COST-7687) | Implement workers and scheduled jobs | ✅ | Celery Beat + 10 workers ✅, ROS Processor + Recommendation Poller + Housekeeper ✅ (when `spec.ros.enabled`), ROS Partition Cleaner CronJob ✅, Kruize DeletePartitions CronJob ✅. Ticket's six on-prem queues all present. |
 | [COST-7688](https://redhat.atlassian.net/browse/COST-7688) | Implement Gateway and Ingress | ✅ | Envoy JWT proxy Deployment + Service + ConfigMap wired to OIDC issuer/audiences ✅, OpenShift Route for gateway API ✅, insights-ingress-go Deployment + Service ✅ (S3/Kafka/CA wiring, port 8080 matching Envoy backend config). |
-| [COST-7689](https://redhat.atlassian.net/browse/COST-7689) | Implement RBAC Service | ✅ | RBAC API Deployment + Service + RBAC Celery worker Deployment ✅. Deployed in Stage 4 before Koku. Both wired with rbac-user/rbac-password from DB credentials secret + cache env vars. Keycloak-to-RBAC principal sync CronJob + ConfigMap ✅ ([PR #53](https://github.com/project-koku/koku-service-operator/pull/53)). |
+| [COST-7689](https://redhat.atlassian.net/browse/COST-7689) | Implement RBAC Service | ✅ | RBAC API Deployment + Service + RBAC Celery worker Deployment ✅. Deployed in Stage 4 before Koku. Both wired with rbac-user/rbac-password from DB credentials secret + cache env vars. Keycloak-to-RBAC principal sync CronJob + ConfigMap ✅ ([PR #53](https://github.com/project-koku/koku-service-operator/pull/53)). `RBACReady` gates on the RBAC API before `Available`. Profile sizing → [COST-8095](https://redhat.atlassian.net/browse/COST-8095). See [gap analysis](gap_analysis/COST-7689.md). |
 | [COST-7690](https://redhat.atlassian.net/browse/COST-7690) | Implement UI and ConsoleLink | ✅ | UI Deployment (oauth2-proxy sidecar + nginx app container) ✅, ClusterIP Service with OpenShift service-CA TLS annotation ✅, UINginxConfigMap (proxies `/api/` to Envoy) ✅, operator-generated cookie Secret ✅, ConsoleLink (cluster-scoped, finalizer cleanup in `reconcileDelete`) ✅. UIRoute deferred to COST-7691. |
 | [COST-7691](https://redhat.atlassian.net/browse/COST-7691) | Implement Routes, NetworkPolicies, and TLS | ✅ | NetworkPolicies (gateway, ingress, kruize, rbac-api, koku-api, ros-api, cache, database) ✅, restricted-v2 SCC compliance (no hardcoded runAsUser, seccompProfile: RuntimeDefault) ✅, `status.phase → Ready` ✅, Gateway Route ✅, UI Route (deferred until cluster domain resolved) ✅. Dedicated SAs: koku, ros, kruize ✅. |
 | [COST-7692](https://redhat.atlassian.net/browse/COST-7692) | Implement monitoring and alerting | ✅ | Kubernetes Events (Ready, MigrationStarted/Complete/Failed, ReconcileError) ✅, AppServiceMonitor + KruizeServiceMonitor ✅, PrometheusRules (5 alert rules) ✅. All guarded by `spec.monitoring.enabled`. ServiceMonitors/Rules applied as unstructured — silently skipped when Prometheus Operator CRDs absent. |
@@ -76,7 +76,7 @@ explicitly. Full ROS/Kruize delivery remains tracked under COST-8054 / post-Beta
 ## Intentional Deviations and Known Gaps
 
 See [docs/design/design-vs-jira.md](design/design-vs-jira.md) for the full analysis.
-Short version: bundled infra is dev-only (intentional), profile-based sizing is not yet implemented (COST-7693 gap), `RealmUser.Password` in spec is a security issue to fix pre-GA.
+Short version: bundled infra is dev-only (intentional), profile-based sizing for remaining workloads is [COST-8095](https://redhat.atlassian.net/browse/COST-8095) (post-beta), `RealmUser.Password` in spec is a security issue to fix pre-GA.
 
 ---
 
@@ -89,6 +89,14 @@ Short version: bundled infra is dev-only (intentional), profile-based sizing is 
 | **`relatedImages` in OLM bundle** | Runtime-constructed images not in CSV `relatedImages`; breaks airgapped deployments. COST-7695. See [review follow-ups](review-follow-ups.md#3-relatedimages-in-olm-bundle-cost-7695). |
 | **RBAC migration/bootstrap code provenance** | Heredoc-embedded Django ORM scripts fail code-provenance audit. Needs `insights-rbac` management commands. See [review follow-ups](review-follow-ups.md#4-rbac-migrationbootstrap-code-provenance). |
 | **`ResolveBootstrapAdmin` fallback values** | Silently substitutes test-fixture IDs (`org1234567`) when CR fields are empty. Pre-existing. See [review follow-ups](review-follow-ups.md#1-resolvebootstrapadmin-silently-substitutes-test-fixture-ids). |
+
+---
+
+## Post-beta follow-ups
+
+| Ticket | Summary | Notes |
+|--------|---------|-------|
+| [COST-8095](https://redhat.atlassian.net/browse/COST-8095) | `spec.profile` sizing maps | Shared `standard`/`ha` maps for remaining Cost workloads. UI already wired. ROS/Kruize rows stay with COST-8054. See [jira snapshot](jira/COST-8095.md). |
 
 ---
 

--- a/docs/tasks.md
+++ b/docs/tasks.md
@@ -97,6 +97,7 @@ Short version: bundled infra is dev-only (intentional), profile-based sizing for
 | Ticket | Summary | Notes |
 |--------|---------|-------|
 | [COST-8095](https://redhat.atlassian.net/browse/COST-8095) | `spec.profile` sizing maps | Shared `standard`/`ha` maps for remaining Cost workloads. UI already wired. ROS/Kruize rows stay with COST-8054. See [jira snapshot](jira/COST-8095.md). |
+| [COST-8103](https://redhat.atlassian.net/browse/COST-8103) | `CoreServicesAvailable` / mid-pipeline `Available` | Sparse success Events (`Ready`); stop treating Koku-API-up as product-available. See [jira snapshot](jira/COST-8103.md). |
 
 ---
 

--- a/internal/controller/core_services_test.go
+++ b/internal/controller/core_services_test.go
@@ -47,12 +47,16 @@ func TestReconcileCoreServices_ROSOff_APINotReady(t *testing.T) {
 	mustNotExist(t, r.Client, "", resources.NameKruizeClusterRole(cfg), &rbacv1.ClusterRole{})
 
 	cond := findCondition(cfg.Status.Conditions, costv1alpha1.ConditionAvailable)
-	if cond == nil || cond.Status != metav1.ConditionFalse || cond.Reason != "WaitingForRBAC" {
-		t.Fatalf("expected Available=False WaitingForRBAC, got %+v", cond)
+	if cond == nil || cond.Status != metav1.ConditionFalse || cond.Reason != reasonWaitingForRBAC {
+		t.Fatalf("expected Available=False %s, got %+v", reasonWaitingForRBAC, cond)
 	}
 	rbac := findCondition(cfg.Status.Conditions, costv1alpha1.ConditionRBACReady)
-	if rbac == nil || rbac.Status != metav1.ConditionFalse || rbac.Reason != "WaitingForRBAC" {
-		t.Fatalf("expected RBACReady=False WaitingForRBAC, got %+v", rbac)
+	if rbac == nil || rbac.Status != metav1.ConditionFalse || rbac.Reason != reasonWaitingForRBAC {
+		t.Fatalf("expected RBACReady=False %s, got %+v", reasonWaitingForRBAC, rbac)
+	}
+	worker := findCondition(cfg.Status.Conditions, costv1alpha1.ConditionRBACWorkerReady)
+	if worker == nil || worker.Status != metav1.ConditionFalse || worker.Reason != reasonWaitingForRBACWorker {
+		t.Fatalf("expected RBACWorkerReady=False %s, got %+v", reasonWaitingForRBACWorker, worker)
 	}
 }
 
@@ -87,8 +91,8 @@ func TestReconcileCoreServices_ROSOn_APINotReady(t *testing.T) {
 	mustExist(t, r.Client, testNamespace, resources.NameKokuAPI(cfg), &appsv1.Deployment{})
 
 	cond := findCondition(cfg.Status.Conditions, costv1alpha1.ConditionAvailable)
-	if cond == nil || cond.Status != metav1.ConditionFalse || cond.Reason != "WaitingForRBAC" {
-		t.Fatalf("expected Available=False WaitingForRBAC, got %+v", cond)
+	if cond == nil || cond.Status != metav1.ConditionFalse || cond.Reason != reasonWaitingForRBAC {
+		t.Fatalf("expected Available=False %s, got %+v", reasonWaitingForRBAC, cond)
 	}
 }
 
@@ -111,6 +115,7 @@ func TestReconcileCoreServices_ROSOff_APIReady(t *testing.T) {
 	}
 
 	markDeploymentReady(t, c, testNamespace, resources.NameRBACAPI(cfg))
+	markDeploymentReady(t, c, testNamespace, resources.NameRBACWorker(cfg))
 	markDeploymentReady(t, c, testNamespace, resources.NameKokuAPI(cfg))
 
 	result, err = r.reconcileCoreServices(context.Background(), cfg)
@@ -129,6 +134,9 @@ func TestReconcileCoreServices_ROSOff_APIReady(t *testing.T) {
 	}
 	if !apimeta.IsStatusConditionTrue(cfg.Status.Conditions, costv1alpha1.ConditionRBACReady) {
 		t.Fatal("expected RBACReady=True")
+	}
+	if !apimeta.IsStatusConditionTrue(cfg.Status.Conditions, costv1alpha1.ConditionRBACWorkerReady) {
+		t.Fatal("expected RBACWorkerReady=True")
 	}
 }
 
@@ -158,12 +166,12 @@ func TestReconcileCoreServices_RBACNotReady_BlocksAvailable(t *testing.T) {
 	}
 
 	avail := findCondition(cfg.Status.Conditions, costv1alpha1.ConditionAvailable)
-	if avail == nil || avail.Status != metav1.ConditionFalse || avail.Reason != "WaitingForRBAC" {
-		t.Fatalf("expected Available=False WaitingForRBAC, got %+v", avail)
+	if avail == nil || avail.Status != metav1.ConditionFalse || avail.Reason != reasonWaitingForRBAC {
+		t.Fatalf("expected Available=False %s, got %+v", reasonWaitingForRBAC, avail)
 	}
 	rbac := findCondition(cfg.Status.Conditions, costv1alpha1.ConditionRBACReady)
-	if rbac == nil || rbac.Status != metav1.ConditionFalse || rbac.Reason != "WaitingForRBAC" {
-		t.Fatalf("expected RBACReady=False WaitingForRBAC, got %+v", rbac)
+	if rbac == nil || rbac.Status != metav1.ConditionFalse || rbac.Reason != reasonWaitingForRBAC {
+		t.Fatalf("expected RBACReady=False %s, got %+v", reasonWaitingForRBAC, rbac)
 	}
 }
 
@@ -191,6 +199,10 @@ func TestReconcileCoreServices_RBACReady_KokuNotReady(t *testing.T) {
 	}
 	if !apimeta.IsStatusConditionTrue(cfg.Status.Conditions, costv1alpha1.ConditionRBACReady) {
 		t.Fatal("expected RBACReady=True")
+	}
+	worker := findCondition(cfg.Status.Conditions, costv1alpha1.ConditionRBACWorkerReady)
+	if worker == nil || worker.Status != metav1.ConditionFalse || worker.Reason != reasonWaitingForRBACWorker {
+		t.Fatalf("expected RBACWorkerReady=False %s, got %+v", reasonWaitingForRBACWorker, worker)
 	}
 	avail := findCondition(cfg.Status.Conditions, costv1alpha1.ConditionAvailable)
 	if avail == nil || avail.Status != metav1.ConditionFalse || avail.Reason != "WaitingForAPI" {
@@ -226,6 +238,10 @@ func TestReconcileCoreServices_WorkerNotReady_DoesNotBlock(t *testing.T) {
 	}
 	if !apimeta.IsStatusConditionTrue(cfg.Status.Conditions, costv1alpha1.ConditionRBACReady) {
 		t.Fatal("expected RBACReady=True without waiting on RBAC worker")
+	}
+	worker := findCondition(cfg.Status.Conditions, costv1alpha1.ConditionRBACWorkerReady)
+	if worker == nil || worker.Status != metav1.ConditionFalse || worker.Reason != reasonWaitingForRBACWorker {
+		t.Fatalf("expected RBACWorkerReady=False %s, got %+v", reasonWaitingForRBACWorker, worker)
 	}
 }
 

--- a/internal/controller/core_services_test.go
+++ b/internal/controller/core_services_test.go
@@ -47,8 +47,12 @@ func TestReconcileCoreServices_ROSOff_APINotReady(t *testing.T) {
 	mustNotExist(t, r.Client, "", resources.NameKruizeClusterRole(cfg), &rbacv1.ClusterRole{})
 
 	cond := findCondition(cfg.Status.Conditions, costv1alpha1.ConditionAvailable)
-	if cond == nil || cond.Status != metav1.ConditionFalse || cond.Reason != "WaitingForAPI" {
-		t.Fatalf("expected Available=False WaitingForAPI, got %+v", cond)
+	if cond == nil || cond.Status != metav1.ConditionFalse || cond.Reason != "WaitingForRBAC" {
+		t.Fatalf("expected Available=False WaitingForRBAC, got %+v", cond)
+	}
+	rbac := findCondition(cfg.Status.Conditions, costv1alpha1.ConditionRBACReady)
+	if rbac == nil || rbac.Status != metav1.ConditionFalse || rbac.Reason != "WaitingForRBAC" {
+		t.Fatalf("expected RBACReady=False WaitingForRBAC, got %+v", rbac)
 	}
 }
 
@@ -83,8 +87,8 @@ func TestReconcileCoreServices_ROSOn_APINotReady(t *testing.T) {
 	mustExist(t, r.Client, testNamespace, resources.NameKokuAPI(cfg), &appsv1.Deployment{})
 
 	cond := findCondition(cfg.Status.Conditions, costv1alpha1.ConditionAvailable)
-	if cond == nil || cond.Status != metav1.ConditionFalse || cond.Reason != "WaitingForAPI" {
-		t.Fatalf("expected Available=False WaitingForAPI, got %+v", cond)
+	if cond == nil || cond.Status != metav1.ConditionFalse || cond.Reason != "WaitingForRBAC" {
+		t.Fatalf("expected Available=False WaitingForRBAC, got %+v", cond)
 	}
 }
 
@@ -106,6 +110,7 @@ func TestReconcileCoreServices_ROSOff_APIReady(t *testing.T) {
 		t.Fatal("first pass should requeue while API is not ready")
 	}
 
+	markDeploymentReady(t, c, testNamespace, resources.NameRBACAPI(cfg))
 	markDeploymentReady(t, c, testNamespace, resources.NameKokuAPI(cfg))
 
 	result, err = r.reconcileCoreServices(context.Background(), cfg)
@@ -121,6 +126,106 @@ func TestReconcileCoreServices_ROSOff_APIReady(t *testing.T) {
 	cond := findCondition(cfg.Status.Conditions, costv1alpha1.ConditionAvailable)
 	if cond == nil || cond.Reason != "KokuAvailable" {
 		t.Fatalf("expected Available reason KokuAvailable, got %+v", cond)
+	}
+	if !apimeta.IsStatusConditionTrue(cfg.Status.Conditions, costv1alpha1.ConditionRBACReady) {
+		t.Fatal("expected RBACReady=True")
+	}
+}
+
+// Koku Ready must not make the CR Available while the RBAC API is still down.
+func TestReconcileCoreServices_RBACNotReady_BlocksAvailable(t *testing.T) {
+	scheme := ownershipScheme(t)
+	cfg := minimalCR(testCRName, testNamespace)
+	c := fakeClientPreservingStatus(scheme)
+	r := &CostManagementServiceConfigReconciler{
+		Client:   c,
+		Scheme:   scheme,
+		Recorder: &noopRecorder{},
+	}
+
+	if _, err := r.reconcileCoreServices(context.Background(), cfg); err != nil {
+		t.Fatalf("first pass: %v", err)
+	}
+	mustExist(t, c, testNamespace, resources.NameKokuAPI(cfg), &appsv1.Deployment{})
+	markDeploymentReady(t, c, testNamespace, resources.NameKokuAPI(cfg))
+
+	result, err := r.reconcileCoreServices(context.Background(), cfg)
+	if err != nil {
+		t.Fatalf("second pass: %v", err)
+	}
+	if result.RequeueAfter == 0 {
+		t.Fatal("expected requeue while RBAC API is not ready")
+	}
+
+	avail := findCondition(cfg.Status.Conditions, costv1alpha1.ConditionAvailable)
+	if avail == nil || avail.Status != metav1.ConditionFalse || avail.Reason != "WaitingForRBAC" {
+		t.Fatalf("expected Available=False WaitingForRBAC, got %+v", avail)
+	}
+	rbac := findCondition(cfg.Status.Conditions, costv1alpha1.ConditionRBACReady)
+	if rbac == nil || rbac.Status != metav1.ConditionFalse || rbac.Reason != "WaitingForRBAC" {
+		t.Fatalf("expected RBACReady=False WaitingForRBAC, got %+v", rbac)
+	}
+}
+
+func TestReconcileCoreServices_RBACReady_KokuNotReady(t *testing.T) {
+	scheme := ownershipScheme(t)
+	cfg := minimalCR(testCRName, testNamespace)
+	c := fakeClientPreservingStatus(scheme)
+	r := &CostManagementServiceConfigReconciler{
+		Client:   c,
+		Scheme:   scheme,
+		Recorder: &noopRecorder{},
+	}
+
+	if _, err := r.reconcileCoreServices(context.Background(), cfg); err != nil {
+		t.Fatalf("first pass: %v", err)
+	}
+	markDeploymentReady(t, c, testNamespace, resources.NameRBACAPI(cfg))
+
+	result, err := r.reconcileCoreServices(context.Background(), cfg)
+	if err != nil {
+		t.Fatalf("second pass: %v", err)
+	}
+	if result.RequeueAfter == 0 {
+		t.Fatal("expected requeue while Koku API is not ready")
+	}
+	if !apimeta.IsStatusConditionTrue(cfg.Status.Conditions, costv1alpha1.ConditionRBACReady) {
+		t.Fatal("expected RBACReady=True")
+	}
+	avail := findCondition(cfg.Status.Conditions, costv1alpha1.ConditionAvailable)
+	if avail == nil || avail.Status != metav1.ConditionFalse || avail.Reason != "WaitingForAPI" {
+		t.Fatalf("expected Available=False WaitingForAPI, got %+v", avail)
+	}
+}
+
+func TestReconcileCoreServices_WorkerNotReady_DoesNotBlock(t *testing.T) {
+	scheme := ownershipScheme(t)
+	cfg := minimalCR(testCRName, testNamespace)
+	c := fakeClientPreservingStatus(scheme)
+	r := &CostManagementServiceConfigReconciler{
+		Client:   c,
+		Scheme:   scheme,
+		Recorder: &noopRecorder{},
+	}
+
+	if _, err := r.reconcileCoreServices(context.Background(), cfg); err != nil {
+		t.Fatalf("first pass: %v", err)
+	}
+	markDeploymentReady(t, c, testNamespace, resources.NameRBACAPI(cfg))
+	markDeploymentReady(t, c, testNamespace, resources.NameKokuAPI(cfg))
+
+	result, err := r.reconcileCoreServices(context.Background(), cfg)
+	if err != nil {
+		t.Fatalf("second pass: %v", err)
+	}
+	if !result.IsZero() {
+		t.Fatalf("expected zero Result when RBAC API and Koku API are ready, got %+v", result)
+	}
+	if !apimeta.IsStatusConditionTrue(cfg.Status.Conditions, costv1alpha1.ConditionAvailable) {
+		t.Fatal("expected Available=True without waiting on RBAC worker")
+	}
+	if !apimeta.IsStatusConditionTrue(cfg.Status.Conditions, costv1alpha1.ConditionRBACReady) {
+		t.Fatal("expected RBACReady=True without waiting on RBAC worker")
 	}
 }
 

--- a/internal/controller/core_services_test.go
+++ b/internal/controller/core_services_test.go
@@ -129,8 +129,8 @@ func TestReconcileCoreServices_ROSOff_APIReady(t *testing.T) {
 		t.Fatal("expected Available=True")
 	}
 	cond := findCondition(cfg.Status.Conditions, costv1alpha1.ConditionAvailable)
-	if cond == nil || cond.Reason != "KokuAvailable" {
-		t.Fatalf("expected Available reason KokuAvailable, got %+v", cond)
+	if cond == nil || cond.Reason != reasonKokuAvailable {
+		t.Fatalf("expected Available reason %s, got %+v", reasonKokuAvailable, cond)
 	}
 	if !apimeta.IsStatusConditionTrue(cfg.Status.Conditions, costv1alpha1.ConditionRBACReady) {
 		t.Fatal("expected RBACReady=True")
@@ -205,8 +205,8 @@ func TestReconcileCoreServices_RBACReady_KokuNotReady(t *testing.T) {
 		t.Fatalf("expected RBACWorkerReady=False %s, got %+v", reasonWaitingForRBACWorker, worker)
 	}
 	avail := findCondition(cfg.Status.Conditions, costv1alpha1.ConditionAvailable)
-	if avail == nil || avail.Status != metav1.ConditionFalse || avail.Reason != "WaitingForAPI" {
-		t.Fatalf("expected Available=False WaitingForAPI, got %+v", avail)
+	if avail == nil || avail.Status != metav1.ConditionFalse || avail.Reason != reasonWaitingForAPI {
+		t.Fatalf("expected Available=False %s, got %+v", reasonWaitingForAPI, avail)
 	}
 }
 

--- a/internal/controller/costmanagementserviceconfig_controller.go
+++ b/internal/controller/costmanagementserviceconfig_controller.go
@@ -43,8 +43,11 @@ const (
 	reasonRBACAvailable        = "RBACAvailable"
 	reasonWaitingForRBACWorker = "WaitingForRBACWorker"
 	reasonRBACWorkerAvailable  = "RBACWorkerAvailable"
+	reasonWaitingForAPI        = "WaitingForAPI"
+	reasonKokuAvailable        = "KokuAvailable"
 	msgWaitingForRBACAPI       = "waiting for RBAC API"
 	msgWaitingForRBACWorker    = "waiting for RBAC worker"
+	msgWaitingForKokuAPI       = "waiting for Koku API"
 )
 
 type CostManagementServiceConfigReconciler struct {
@@ -567,13 +570,13 @@ func (r *CostManagementServiceConfigReconciler) reconcileCoreServices(ctx contex
 		return Result{}, err
 	}
 	if !ready {
-		r.setCondition(cfg, costv1alpha1.ConditionAvailable, metav1.ConditionFalse, "WaitingForAPI", "waiting for Koku API")
+		r.setCondition(cfg, costv1alpha1.ConditionAvailable, metav1.ConditionFalse, reasonWaitingForAPI, msgWaitingForKokuAPI)
 		return Result{RequeueAfter: requeueSlow}, nil
 	}
 	if !apimeta.IsStatusConditionTrue(cfg.Status.Conditions, costv1alpha1.ConditionAvailable) {
 		r.Recorder.Event(cfg, corev1.EventTypeNormal, "CoreServicesAvailable", "Koku API is ready")
 	}
-	r.setCondition(cfg, costv1alpha1.ConditionAvailable, metav1.ConditionTrue, "KokuAvailable", "")
+	r.setCondition(cfg, costv1alpha1.ConditionAvailable, metav1.ConditionTrue, reasonKokuAvailable, "")
 	return Result{}, nil
 }
 

--- a/internal/controller/costmanagementserviceconfig_controller.go
+++ b/internal/controller/costmanagementserviceconfig_controller.go
@@ -528,6 +528,19 @@ func (r *CostManagementServiceConfigReconciler) reconcileCoreServices(ctx contex
 		}
 	}
 
+	// Gate on the RBAC API (not the worker). Koku and Envoy call this
+	// service for authorization; do not report Available while it is down.
+	rbacReady, err := r.isDeploymentReady(ctx, cfg.Namespace, resources.NameRBACAPI(cfg))
+	if err != nil {
+		return Result{}, err
+	}
+	if !rbacReady {
+		r.setCondition(cfg, costv1alpha1.ConditionRBACReady, metav1.ConditionFalse, "WaitingForRBAC", "waiting for RBAC API")
+		r.setCondition(cfg, costv1alpha1.ConditionAvailable, metav1.ConditionFalse, "WaitingForRBAC", "waiting for RBAC API")
+		return Result{RequeueAfter: requeueSlow}, nil
+	}
+	r.setCondition(cfg, costv1alpha1.ConditionRBACReady, metav1.ConditionTrue, "RBACAvailable", "")
+
 	// Gate on the API being available.
 	ready, err := r.isDeploymentReady(ctx, cfg.Namespace, resources.NameKokuAPI(cfg))
 	if err != nil {

--- a/internal/controller/costmanagementserviceconfig_controller.go
+++ b/internal/controller/costmanagementserviceconfig_controller.go
@@ -37,6 +37,14 @@ const (
 	requeueFast    = 10 * time.Second
 	requeueSlow    = 30 * time.Second
 	requeueDrift   = 5 * time.Minute
+
+	// Status condition reasons shared with tests so the strings cannot drift.
+	reasonWaitingForRBAC       = "WaitingForRBAC"
+	reasonRBACAvailable        = "RBACAvailable"
+	reasonWaitingForRBACWorker = "WaitingForRBACWorker"
+	reasonRBACWorkerAvailable  = "RBACWorkerAvailable"
+	msgWaitingForRBACAPI       = "waiting for RBAC API"
+	msgWaitingForRBACWorker    = "waiting for RBAC worker"
 )
 
 type CostManagementServiceConfigReconciler struct {
@@ -528,6 +536,18 @@ func (r *CostManagementServiceConfigReconciler) reconcileCoreServices(ctx contex
 		}
 	}
 
+	// RBAC worker is independent of Available: surface it as its own
+	// condition so a down worker is not hidden behind RBACReady=True.
+	workerReady, err := r.isDeploymentReady(ctx, cfg.Namespace, resources.NameRBACWorker(cfg))
+	if err != nil {
+		return Result{}, err
+	}
+	if !workerReady {
+		r.setCondition(cfg, costv1alpha1.ConditionRBACWorkerReady, metav1.ConditionFalse, reasonWaitingForRBACWorker, msgWaitingForRBACWorker)
+	} else {
+		r.setCondition(cfg, costv1alpha1.ConditionRBACWorkerReady, metav1.ConditionTrue, reasonRBACWorkerAvailable, "")
+	}
+
 	// Gate on the RBAC API (not the worker). Koku and Envoy call this
 	// service for authorization; do not report Available while it is down.
 	rbacReady, err := r.isDeploymentReady(ctx, cfg.Namespace, resources.NameRBACAPI(cfg))
@@ -535,11 +555,11 @@ func (r *CostManagementServiceConfigReconciler) reconcileCoreServices(ctx contex
 		return Result{}, err
 	}
 	if !rbacReady {
-		r.setCondition(cfg, costv1alpha1.ConditionRBACReady, metav1.ConditionFalse, "WaitingForRBAC", "waiting for RBAC API")
-		r.setCondition(cfg, costv1alpha1.ConditionAvailable, metav1.ConditionFalse, "WaitingForRBAC", "waiting for RBAC API")
+		r.setCondition(cfg, costv1alpha1.ConditionRBACReady, metav1.ConditionFalse, reasonWaitingForRBAC, msgWaitingForRBACAPI)
+		r.setCondition(cfg, costv1alpha1.ConditionAvailable, metav1.ConditionFalse, reasonWaitingForRBAC, msgWaitingForRBACAPI)
 		return Result{RequeueAfter: requeueSlow}, nil
 	}
-	r.setCondition(cfg, costv1alpha1.ConditionRBACReady, metav1.ConditionTrue, "RBACAvailable", "")
+	r.setCondition(cfg, costv1alpha1.ConditionRBACReady, metav1.ConditionTrue, reasonRBACAvailable, "")
 
 	// Gate on the API being available.
 	ready, err := r.isDeploymentReady(ctx, cfg.Namespace, resources.NameKokuAPI(cfg))

--- a/internal/controller/event_transition_test.go
+++ b/internal/controller/event_transition_test.go
@@ -90,7 +90,7 @@ func TestCoreServicesAvailableEvent_GuardLogic(t *testing.T) {
 	if !apimeta.IsStatusConditionTrue(cfg.Status.Conditions, costv1alpha1.ConditionAvailable) {
 		r.Recorder.Event(cfg, "Normal", "CoreServicesAvailable", "Koku API is ready")
 	}
-	r.setCondition(cfg, costv1alpha1.ConditionAvailable, metav1.ConditionTrue, "KokuAvailable", "")
+	r.setCondition(cfg, costv1alpha1.ConditionAvailable, metav1.ConditionTrue, reasonKokuAvailable, "")
 	assertEvent(t, rec, "CoreServicesAvailable")
 
 	// Simulate second pass: Available already True → no Event.


### PR DESCRIPTION
## Summary
- Gate Stage 4 on the **RBAC API** Deployment (`RBACReady` / `WaitingForRBAC`) before `Available`. Worker is not in the gate. Koku is still applied in the same pass.
- Close COST-7689 G2 (status reporting). Profile sizing ACs that were spread across 7678/7686/7687/7689/7690/7693 now point at **[COST-8095](https://redhat.atlassian.net/browse/COST-8095)**.
- Tracker/docs: `docs/gap_analysis/COST-7689.md`, `docs/tasks.md`, `BETA-PRIORITY.md` T5, `docs/jira/COST-8095.md`.

Closes the remaining COST-7689 gap (readiness). Sizing is out of this ticket.

## Test plan
- [x] `go test ./internal/controller/ -run TestReconcileCoreServices_`
- [ ] Confirm CR stays `Available=False` / `RBACReady=False` while the RBAC API Deployment has 0 available replicas
- [ ] Confirm `RBACReady=True` then existing Koku `WaitingForAPI` / `KokuAvailable` path
- [ ] Confirm a not-ready RBAC worker does not block `Available`

## Summary by Sourcery

Gate overall service availability on RBAC API readiness while exposing worker health separately and updating the related project tracking documentation.

New Features:
- Add RBAC API and worker readiness conditions, with the RBAC API readiness reflected in overall availability.

Bug Fixes:
- Prevent the service configuration from reporting Available while the RBAC API Deployment is unavailable.
- Ensure an unavailable RBAC worker is reported without blocking overall availability.

Enhancements:
- Expand reconciliation tests to cover RBAC API, worker, and Koku readiness combinations.

Documentation:
- Update readiness guidance, gap analyses, task tracking, beta priorities, and Jira documentation to reflect the RBAC readiness gate and move profile sizing to COST-8095.

Tests:
- Add coverage for RBAC readiness gating, Koku sequencing, and independent worker status reporting.