### PR TITLE
fix: grant namespaced get/list on ObjectBucketClaims for S3 discovery…

### DIFF
--- a/bundle/manifests/koku-service-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/koku-service-operator.clusterserviceversion.yaml
@@ -270,6 +270,13 @@ spec:
           - update
           - watch
         - apiGroups:
+          - objectbucket.io
+          resources:
+          - objectbucketclaims
+          verbs:
+          - get
+          - list
+        - apiGroups:
           - rbac.authorization.k8s.io
           resources:
           - clusterrolebindings

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -79,6 +79,13 @@ rules:
   - update
   - watch
 - apiGroups:
+  - objectbucket.io
+  resources:
+  - objectbucketclaims
+  verbs:
+  - get
+  - list
+- apiGroups:
   - rbac.authorization.k8s.io
   resources:
   - rolebindings

--- a/internal/controller/costmanagementserviceconfig_controller.go
+++ b/internal/controller/costmanagementserviceconfig_controller.go
@@ -72,6 +72,8 @@ type CostManagementServiceConfigReconciler struct {
 // +kubebuilder:rbac:groups=rbac.authorization.k8s.io,resources=roles;rolebindings,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=networking.k8s.io,resources=networkpolicies,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=core,resources=events,verbs=create;patch
+// ObjectBucketClaims: namespaced Get/List during reconcile (findBoundOBC), not a watcher.
+// +kubebuilder:rbac:groups=objectbucket.io,resources=objectbucketclaims,verbs=get;list
 // Cluster-scoped resources (ingresses, storageclasses, consolelinks, clusterroles,
 // clusterrolebindings, noobaa-admin secret) live in cluster_access_role.yaml
 // (hand-maintained, bound via ClusterRoleBinding) — not here.

--- a/internal/controller/rbac_manifest_test.go
+++ b/internal/controller/rbac_manifest_test.go
@@ -15,6 +15,11 @@ func rbacManifestPath(t *testing.T, name string) string {
 	return filepath.Join("..", "..", "config", "rbac", name)
 }
 
+func bundleCSVPath(t *testing.T) string {
+	t.Helper()
+	return filepath.Join("..", "..", "bundle", "manifests", "koku-service-operator.clusterserviceversion.yaml")
+}
+
 func decodeYAMLFile(t *testing.T, path string, into any) {
 	t.Helper()
 	data, err := os.ReadFile(path)
@@ -23,6 +28,66 @@ func decodeYAMLFile(t *testing.T, path string, into any) {
 	}
 	if err := yaml.Unmarshal(data, into); err != nil {
 		t.Fatalf("decode %s: %v", path, err)
+	}
+}
+
+// olmCSVClusterPermissions is the CSV fragment we round-trip. Avoids adding
+// operator-framework/api just to inspect install.spec.clusterPermissions.
+type olmCSVClusterPermissions struct {
+	Spec struct {
+		Install struct {
+			Spec struct {
+				ClusterPermissions []struct {
+					Rules []rbacv1.PolicyRule `json:"rules"`
+				} `json:"clusterPermissions"`
+			} `json:"spec"`
+		} `json:"install"`
+	} `json:"spec"`
+}
+
+func assertObjectBucketClaimGetList(t *testing.T, source string, rules []rbacv1.PolicyRule) {
+	t.Helper()
+	const (
+		wantGroup    = "objectbucket.io"
+		wantResource = "objectbucketclaims"
+	)
+	extraVerbs := map[string]struct{}{
+		"watch":  {},
+		"create": {},
+		"update": {},
+		"patch":  {},
+		"delete": {},
+	}
+
+	var found bool
+	for _, rule := range rules {
+		if !slices.Contains(rule.APIGroups, wantGroup) {
+			continue
+		}
+		if !slices.Contains(rule.Resources, wantResource) {
+			continue
+		}
+
+		hasGet, hasList := false, false
+		for _, v := range rule.Verbs {
+			switch v {
+			case "get":
+				hasGet = true
+			case "list":
+				hasList = true
+			}
+			if _, extra := extraVerbs[v]; extra {
+				t.Errorf("%s objectbucketclaims rule must not include verb %q: %+v", source, v, rule)
+			}
+		}
+		if !hasGet || !hasList {
+			t.Errorf("%s objectbucketclaims rule missing get and/or list: %+v", source, rule)
+			continue
+		}
+		found = true
+	}
+	if !found {
+		t.Fatalf("%s must grant get+list on objectbucket.io/objectbucketclaims", source)
 	}
 }
 
@@ -83,57 +148,28 @@ func TestManagerRole_GrantsObjectBucketClaimGetList(t *testing.T) {
 	if cr.Name != "manager-role" {
 		t.Fatalf("manager role name: got %q", cr.Name)
 	}
-
-	const (
-		wantGroup    = "objectbucket.io"
-		wantResource = "objectbucketclaims"
-	)
-	extraVerbs := map[string]struct{}{
-		"watch":  {},
-		"create": {},
-		"update": {},
-		"patch":  {},
-		"delete": {},
-	}
-
-	var found bool
-	for _, rule := range cr.Rules {
-		if !slices.Contains(rule.APIGroups, wantGroup) {
-			continue
-		}
-		if !slices.Contains(rule.Resources, wantResource) {
-			continue
-		}
-
-		hasGet, hasList := false, false
-		for _, v := range rule.Verbs {
-			switch v {
-			case "get":
-				hasGet = true
-			case "list":
-				hasList = true
-			}
-			if _, extra := extraVerbs[v]; extra {
-				t.Errorf("objectbucketclaims rule must not include verb %q: %+v", v, rule)
-			}
-		}
-		if !hasGet || !hasList {
-			t.Errorf("objectbucketclaims rule missing get and/or list: %+v", rule)
-			continue
-		}
-		found = true
-	}
-	if !found {
-		t.Fatal("manager-role must grant get+list on objectbucket.io/objectbucketclaims")
-	}
+	assertObjectBucketClaimGetList(t, "manager-role", cr.Rules)
 
 	var clusterCR rbacv1.ClusterRole
 	decodeYAMLFile(t, rbacManifestPath(t, "cluster_access_role.yaml"), &clusterCR)
 	for _, rule := range clusterCR.Rules {
-		if slices.Contains(rule.APIGroups, wantGroup) {
+		if slices.Contains(rule.APIGroups, "objectbucket.io") {
 			t.Errorf("manager-cluster-role must not grant objectbucket.io: %+v", rule)
 		}
 	}
+
+	// OLM installs from the CSV, not role.yaml. CI does not regenerate the
+	// bundle, so lock clusterPermissions to the same get+list grant.
+	var csv olmCSVClusterPermissions
+	decodeYAMLFile(t, bundleCSVPath(t), &csv)
+	var csvRules []rbacv1.PolicyRule
+	for _, p := range csv.Spec.Install.Spec.ClusterPermissions {
+		csvRules = append(csvRules, p.Rules...)
+	}
+	if len(csv.Spec.Install.Spec.ClusterPermissions) == 0 {
+		t.Fatal("CSV spec.install.spec.clusterPermissions is empty (unmarshal failed or field moved)")
+	}
+	assertObjectBucketClaimGetList(t, "CSV clusterPermissions", csvRules)
 }
 
 func TestManagerRole_StillGrantsNamespacedSecrets(t *testing.T) {

--- a/internal/controller/rbac_manifest_test.go
+++ b/internal/controller/rbac_manifest_test.go
@@ -3,6 +3,7 @@ package controller
 import (
 	"os"
 	"path/filepath"
+	"slices"
 	"testing"
 
 	rbacv1 "k8s.io/api/rbac/v1"
@@ -73,6 +74,65 @@ func TestClusterAccessRole_NarrowNooBaaSecretGet(t *testing.T) {
 	}
 	if !foundNoobaa {
 		t.Fatal("expected secrets get with resourceNames=[noobaa-admin] on manager-cluster-role")
+	}
+}
+
+func TestManagerRole_GrantsObjectBucketClaimGetList(t *testing.T) {
+	var cr rbacv1.ClusterRole
+	decodeYAMLFile(t, rbacManifestPath(t, "role.yaml"), &cr)
+	if cr.Name != "manager-role" {
+		t.Fatalf("manager role name: got %q", cr.Name)
+	}
+
+	const (
+		wantGroup    = "objectbucket.io"
+		wantResource = "objectbucketclaims"
+	)
+	extraVerbs := map[string]struct{}{
+		"watch":  {},
+		"create": {},
+		"update": {},
+		"patch":  {},
+		"delete": {},
+	}
+
+	var found bool
+	for _, rule := range cr.Rules {
+		if !slices.Contains(rule.APIGroups, wantGroup) {
+			continue
+		}
+		if !slices.Contains(rule.Resources, wantResource) {
+			continue
+		}
+
+		hasGet, hasList := false, false
+		for _, v := range rule.Verbs {
+			switch v {
+			case "get":
+				hasGet = true
+			case "list":
+				hasList = true
+			}
+			if _, extra := extraVerbs[v]; extra {
+				t.Errorf("objectbucketclaims rule must not include verb %q: %+v", v, rule)
+			}
+		}
+		if !hasGet || !hasList {
+			t.Errorf("objectbucketclaims rule missing get and/or list: %+v", rule)
+			continue
+		}
+		found = true
+	}
+	if !found {
+		t.Fatal("manager-role must grant get+list on objectbucket.io/objectbucketclaims")
+	}
+
+	var clusterCR rbacv1.ClusterRole
+	decodeYAMLFile(t, rbacManifestPath(t, "cluster_access_role.yaml"), &clusterCR)
+	for _, rule := range clusterCR.Rules {
+		if slices.Contains(rule.APIGroups, wantGroup) {
+			t.Errorf("manager-cluster-role must not grant objectbucket.io: %+v", rule)
+		}
 	}
 }
 


### PR DESCRIPTION
## Summary
This PR represents the number 4 item in the checklist in the Jira ticket:
https://redhat.atlassian.net/browse/COST-7683

Grant namespaced `get` and `list` on `ObjectBucketClaim` so S3 discovery path 2 is no longer Forbidden.

## Proof that is working

<img width="756" height="101" alt="image" src="https://github.com/user-attachments/assets/de19cc0c-1db9-4add-bc95-aea10e4c1326" />


## Test plan

- [ ] `go test ./internal/controller/ -count=1 -run TestManagerRole`
- [ ] After `./hack/deploy-dev.sh cost-byoi`:

```bash
NS=cost-byoi
SA=system:serviceaccount:${NS}:default
oc auth can-i --list --as="$SA" -n "$NS" | grep objectbucket
```

Expect `objectbucketclaims.objectbucket.io` with verbs `[get list]`.
(`oc auth can-i get objectbucketclaims.objectbucket.io` says no on Cluster Bot because the OBC CRD is not installed.)



## Summary by Sourcery

Grant namespaced ObjectBucketClaim discovery permissions without adding cluster-scoped access.

Bug Fixes:
- Grant the operator namespaced get and list access to ObjectBucketClaims for S3 discovery during reconciliation.

Tests:
- Add RBAC manifest coverage to verify ObjectBucketClaim access is limited to get/list and is absent from the cluster access role.

## Summary by Sourcery

Allow namespaced ObjectBucketClaim discovery while keeping cluster-scoped permissions restricted.

Bug Fixes:
- Grant the operator namespaced get and list access to ObjectBucketClaims so S3 discovery can complete without Forbidden errors.

Tests:
- Add RBAC manifest coverage ensuring ObjectBucketClaim access is limited to get/list and excluded from the cluster access role.

## Summary by Sourcery

Allow namespaced ObjectBucketClaim discovery while keeping cluster-scoped permissions restricted.

Bug Fixes:
- Grant the operator namespaced get and list access to ObjectBucketClaims so S3 discovery can complete without Forbidden errors.

Tests:
- Add RBAC manifest coverage ensuring ObjectBucketClaim access is limited to get/list and excluded from the cluster access role.