### PR TITLE
ci: suppress staticcheck SA5011 in test files

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -69,6 +69,11 @@ linters:
       # actual values under test, not code duplication.
       - linters: [errcheck, gosec, unparam, goconst, gocyclo]
         path: _test\.go
+      # SA5011: staticcheck on Go <1.26 does not recognize t.Fatal as noreturn,
+      # so `if x == nil { t.Fatal(...) }; x.Field` triggers a false positive.
+      - linters: [staticcheck]
+        path: _test\.go
+        text: SA5011
       # test/utils uses kubectl exec with variable args by design
       - linters: [gosec]
         path: test/


### PR DESCRIPTION
## Summary
- Suppress staticcheck SA5011 (possible nil pointer dereference) in test files only
- Root cause: staticcheck on Go <1.26 doesn't recognize `t.Fatal` as noreturn, so the idiomatic `if x == nil { t.Fatal(...) }; x.Field` pattern triggers a false positive
- Go 1.26+ staticcheck handles this correctly; suppression can be removed when CI upgrades
- Fixes lint failures on PRs #74, #79, and any other branch

## Test plan
- [ ] `golangci-lint config verify` passes
- [ ] `golangci-lint run ./...` reports 0 issues
- [ ] CI Lint job passes

## Summary by Sourcery

Suppress false-positive SA5011 reports in Go test files to keep CI lint checks passing on older Go toolchains.

Bug Fixes:
- Prevent false-positive SA5011 lint failures in Go test files caused by older staticcheck versions not recognizing testing.Fatal as non-returning.

CI:
- Restrict the SA5011 staticcheck suppression to test files in the golangci-lint configuration.