### PR TITLE
test: lock ObjectBucketClaim CSV grant on namespaced permissions

### DIFF
--- a/internal/controller/rbac_manifest_test.go
+++ b/internal/controller/rbac_manifest_test.go
@@ -31,18 +31,29 @@ func decodeYAMLFile(t *testing.T, path string, into any) {
 	}
 }
 
-// olmCSVClusterPermissions is the CSV fragment we round-trip. Avoids adding
-// operator-framework/api just to inspect install.spec.clusterPermissions.
-type olmCSVClusterPermissions struct {
+// olmCSVInstallPermissions is the CSV fragment we round-trip. Avoids adding
+// operator-framework/api just to inspect install.spec.{permissions,clusterPermissions}.
+type olmCSVInstallPermissions struct {
 	Spec struct {
 		Install struct {
 			Spec struct {
-				ClusterPermissions []struct {
-					Rules []rbacv1.PolicyRule `json:"rules"`
-				} `json:"clusterPermissions"`
+				ClusterPermissions []olmCSVPermissionRules `json:"clusterPermissions"`
+				Permissions        []olmCSVPermissionRules `json:"permissions"`
 			} `json:"spec"`
 		} `json:"install"`
 	} `json:"spec"`
+}
+
+type olmCSVPermissionRules struct {
+	Rules []rbacv1.PolicyRule `json:"rules"`
+}
+
+func csvPolicyRules(perms []olmCSVPermissionRules) []rbacv1.PolicyRule {
+	var rules []rbacv1.PolicyRule
+	for _, p := range perms {
+		rules = append(rules, p.Rules...)
+	}
+	return rules
 }
 
 func assertObjectBucketClaimGetList(t *testing.T, source string, rules []rbacv1.PolicyRule) {
@@ -159,17 +170,23 @@ func TestManagerRole_GrantsObjectBucketClaimGetList(t *testing.T) {
 	}
 
 	// OLM installs from the CSV, not role.yaml. CI does not regenerate the
-	// bundle, so lock clusterPermissions to the same get+list grant.
-	var csv olmCSVClusterPermissions
+	// bundle, so lock namespaced permissions to the same get+list grant.
+	// ObjectBucketClaim is namespace-scoped, so the grant belongs in
+	// permissions (OwnNamespace), not clusterPermissions.
+	var csv olmCSVInstallPermissions
 	decodeYAMLFile(t, bundleCSVPath(t), &csv)
-	var csvRules []rbacv1.PolicyRule
-	for _, p := range csv.Spec.Install.Spec.ClusterPermissions {
-		csvRules = append(csvRules, p.Rules...)
+	if len(csv.Spec.Install.Spec.Permissions) == 0 {
+		t.Fatal("CSV spec.install.spec.permissions is empty (unmarshal failed or field moved)")
 	}
 	if len(csv.Spec.Install.Spec.ClusterPermissions) == 0 {
 		t.Fatal("CSV spec.install.spec.clusterPermissions is empty (unmarshal failed or field moved)")
 	}
-	assertObjectBucketClaimGetList(t, "CSV clusterPermissions", csvRules)
+	assertObjectBucketClaimGetList(t, "CSV permissions", csvPolicyRules(csv.Spec.Install.Spec.Permissions))
+	for _, rule := range csvPolicyRules(csv.Spec.Install.Spec.ClusterPermissions) {
+		if slices.Contains(rule.APIGroups, "objectbucket.io") {
+			t.Errorf("CSV clusterPermissions must not grant objectbucket.io: %+v", rule)
+		}
+	}
 }
 
 func TestManagerRole_StillGrantsNamespacedSecrets(t *testing.T) {


### PR DESCRIPTION
## Summary
- `TestManagerRole_GrantsObjectBucketClaimGetList` was locking the ObjectBucketClaim `get`+`list` grant on CSV `clusterPermissions`. OwnNamespace maps `manager-role` (RoleBinding) into namespaced `permissions`, so the assertion was looking at the wrong bucket.
- After [PR #73](https://github.com/project-koku/koku-service-operator/pull/73) regenerated the bundle, the grant moved to `permissions` and CI started failing on otherwise-unrelated PRs (e.g. [#91](https://github.com/project-koku/koku-service-operator/pull/91)).
- This change asserts the grant on CSV `permissions` and forbids `objectbucket.io` on `clusterPermissions`, matching `role.yaml` vs `cluster_access_role.yaml`.

## How this broke

[PR #81](https://github.com/project-koku/koku-service-operator/pull/81) (COST-7683) did the right thing in generated RBAC: a namespaced `+kubebuilder:rbac` marker, the grant in `config/rbac/role.yaml`, and no grant on `manager-cluster-role`.

The CSV was then **hand-patched** into `spec.install.spec.clusterPermissions` (the cluster-scoped OLM bucket). A follow-up test in that PR locked that location.

That CSV placement was inconsistent with OwnNamespace: `manager-role` is bound via a namespace-scoped RoleBinding, so `operator-sdk generate bundle` / `make bundle` emits those rules under `permissions`. When PR #73 merged main and regenerated the bundle, the grant moved to the correct namespaced section. The lock test still inspected `clusterPermissions` and failed.

The operator RBAC itself was never wrong after COST-7683. Only the CSV lock test tracked the hand-edit instead of the OwnNamespace mapping.

## Test plan
- [x] `go test ./internal/controller -run 'TestManagerRole_GrantsObjectBucketClaimGetList|TestManagerRoleBinding_IsNamespacedRoleBinding|TestClusterAccessRole_NarrowNooBaaSecretGet|TestManagerRole_StillGrantsNamespacedSecrets' -count=1`
- [x] `golangci-lint run ./internal/controller`