### PR TITLE
feat: tmux/klock pre-prod demo driver

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,6 +32,15 @@ jobs:
           go install golang.org/x/vuln/cmd/govulncheck@latest
           govulncheck ./...
 
+  hack-scripts:
+    name: Hack Scripts
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: demo-preprod helpers
+        run: make test-hack
+
   build:
     name: Build
     runs-on: ubuntu-latest

--- a/.gitignore
+++ b/.gitignore
@@ -26,6 +26,9 @@ go.work
 *.swo
 *~
 
+# Machine-local demo settings (CHART_ROOT, etc.)
+hack/demo-preprod.local.env
+
 # Git worktrees and Claude session data
 .worktrees/
 .claude/

--- a/Makefile
+++ b/Makefile
@@ -114,6 +114,10 @@ vet: ## Run go vet against code.
 test: manifests generate fmt vet setup-envtest ## Run tests.
 	KUBEBUILDER_ASSETS="$(shell $(ENVTEST) use $(ENVTEST_K8S_VERSION) --bin-dir $(LOCALBIN) -p path)" go test $$(go list ./... | grep -v /e2e) -coverprofile cover.out
 
+.PHONY: test-hack
+test-hack: ## Run no-cluster hack/ script tests (demo-preprod helpers).
+	./hack/demo-preprod_test.sh
+
 # Statement coverage across internal/controller + internal/resources (coverpkg),
 # not make test's per-package cover.out. Override: make coverage-gate COVERAGE_MIN=84.0
 COVERAGE_PKG ?= ./internal/...

--- a/hack/demo-preprod.env.example
+++ b/hack/demo-preprod.env.example
@@ -1,0 +1,23 @@
+# Copy to hack/demo-preprod.local.env and edit.
+# Already-exported environment variables win over this file.
+#
+#   cp hack/demo-preprod.env.example hack/demo-preprod.local.env
+
+KUBE_CONTEXT=clusterbot
+NAMESPACE=cost-byoi
+CR_NAME=cost-management
+INFRA_NAMESPACE=cost-byoi-infra
+KAFKA_NAMESPACE=kafka
+KEYCLOAK_NAMESPACE=keycloak
+KAFKA_CLUSTER_NAME=cost-onprem-kafka
+
+# Sibling of the main git checkout (not of a worktree directory).
+# CHART_ROOT=/Users/you/Projects/koku/cost-onprem-chart
+
+OPEN_BROWSER=1
+ROS_ENABLED=false
+BUILD_MODE=auto
+IMAGE_TAG=preprod
+TMUX_SESSION=koku-demo-preprod
+WATCHER=klock
+LOG_LEVEL=INFO

--- a/hack/demo-preprod.env.example
+++ b/hack/demo-preprod.env.example
@@ -15,7 +15,6 @@ KAFKA_CLUSTER_NAME=cost-onprem-kafka
 # CHART_ROOT=/Users/you/Projects/koku/cost-onprem-chart
 
 OPEN_BROWSER=1
-ROS_ENABLED=false
 BUILD_MODE=auto
 IMAGE_TAG=preprod
 TMUX_SESSION=koku-demo-preprod

--- a/hack/demo-preprod.sh
+++ b/hack/demo-preprod.sh
@@ -1,0 +1,542 @@
+#!/usr/bin/env bash
+# Full pre-prod demo: BYOI (AMQ Streams + Keycloak) → in-cluster operator → UI.
+#
+# Usage (from repo root or hack/):
+#   ./hack/demo-preprod.sh
+#   ./hack/demo-preprod.sh --dry-run
+#   ./hack/demo-preprod.sh --reset          # delete app/infra/kafka/keycloak NS first
+#   ./hack/demo-preprod.sh --no-tmux
+#   ./hack/demo-preprod.sh --rebuild        # force operator image rebuild
+#
+# Settings: env vars, then hack/demo-preprod.local.env, then
+# hack/demo-preprod.env.example. See the example file.
+#
+# tmux (default): left pane = numbered steps; top-right = kubectl klock pods
+# in NAMESPACE; bottom-right = kubectl klock pods in KAFKA_NAMESPACE.
+# When the UI Deployment is Ready, `open` the UI Route (macOS).
+#
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+SCRIPT="${SCRIPT_DIR}/$(basename "${BASH_SOURCE[0]}")"
+cd "$ROOT"
+# shellcheck disable=SC1091
+source "${ROOT}/hack/lib/demo-preprod.bash"
+
+DEMO_RESET="${DEMO_RESET:-0}"
+DEMO_DRY_RUN="${DEMO_DRY_RUN:-0}"
+DEMO_NO_TMUX="${DEMO_NO_TMUX:-0}"
+DEMO_REBUILD="${DEMO_REBUILD:-0}"
+DEMO_NO_OPEN="${DEMO_NO_OPEN:-0}"
+
+usage() {
+  sed -n '2,18p' "$SCRIPT" | sed 's/^# \{0,1\}//'
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --reset) DEMO_RESET=1 ;;
+    --dry-run) DEMO_DRY_RUN=1 ;;
+    --no-tmux) DEMO_NO_TMUX=1 ;;
+    --rebuild) DEMO_REBUILD=1 ;;
+    --no-open) DEMO_NO_OPEN=1 ;;
+    -h|--help) usage; exit 0 ;;
+    *)
+      echo "error: unknown flag $1" >&2
+      usage >&2
+      exit 2
+      ;;
+  esac
+  shift
+done
+
+# Load KEY=VALUE from a file without clobbering variables already in the environment.
+load_env_file() {
+  local file="$1" line key val
+  [[ -f "$file" ]] || return 0
+  while IFS= read -r line || [[ -n "$line" ]]; do
+    line="${line%$'\r'}"
+    [[ "$line" =~ ^[[:space:]]*# ]] && continue
+    [[ -z "${line//[[:space:]]/}" ]] && continue
+    line="${line#export }"
+    key="${line%%=*}"
+    key="${key//[[:space:]]/}"
+    val="${line#*=}"
+    val="${val#\"}"
+    val="${val%\"}"
+    val="${val#\'}"
+    val="${val%\'}"
+    if [[ -z "${!key:-}" ]]; then
+      export "${key}=${val}"
+    fi
+  done <"$file"
+}
+
+load_env_file "${ROOT}/hack/demo-preprod.env.example"
+load_env_file "${ROOT}/hack/demo-preprod.local.env"
+
+KUBE_CONTEXT="${KUBE_CONTEXT:-clusterbot}"
+NAMESPACE="${NAMESPACE:-cost-byoi}"
+CR_NAME="${CR_NAME:-cost-management}"
+INFRA_NAMESPACE="${INFRA_NAMESPACE:-cost-byoi-infra}"
+KAFKA_NAMESPACE="${KAFKA_NAMESPACE:-kafka}"
+KEYCLOAK_NAMESPACE="${KEYCLOAK_NAMESPACE:-keycloak}"
+KAFKA_CLUSTER_NAME="${KAFKA_CLUSTER_NAME:-cost-onprem-kafka}"
+OPEN_BROWSER="${OPEN_BROWSER:-1}"
+BUILD_MODE="${BUILD_MODE:-auto}"
+IMAGE_TAG="${IMAGE_TAG:-preprod}"
+TMUX_SESSION="${TMUX_SESSION:-koku-demo-preprod}"
+WATCHER="${WATCHER:-klock}"
+LOG_LEVEL="${LOG_LEVEL:-INFO}"
+KUBECTL="${KUBECTL:-oc}"
+
+GIT_COMMON=""
+if git -C "$ROOT" rev-parse --git-common-dir >/dev/null 2>&1; then
+  GIT_COMMON="$(git -C "$ROOT" rev-parse --git-common-dir)"
+  if [[ "$GIT_COMMON" != /* ]]; then
+    GIT_COMMON="$(cd "$ROOT/${GIT_COMMON}" && pwd)"
+  fi
+fi
+if [[ -z "${CHART_ROOT:-}" ]]; then
+  CHART_ROOT="$(default_chart_root "$ROOT" "$GIT_COMMON")"
+fi
+export CHART_ROOT NAMESPACE CR_NAME INFRA_NAMESPACE KAFKA_NAMESPACE KEYCLOAK_NAMESPACE LOG_LEVEL
+
+IMG="${IMG:-image-registry.openshift-image-registry.svc:5000/${NAMESPACE}/koku-service-operator:${IMAGE_TAG}}"
+export IMG
+
+STEP_N=0
+STEP_TOTAL=8
+
+if [[ -t 1 ]]; then
+  C_BOLD="$(tput bold 2>/dev/null || true)"
+  C_CYAN="$(tput setaf 6 2>/dev/null || true)"
+  C_GREEN="$(tput setaf 2 2>/dev/null || true)"
+  C_YELLOW="$(tput setaf 3 2>/dev/null || true)"
+  C_RESET="$(tput sgr0 2>/dev/null || true)"
+else
+  C_BOLD="" C_CYAN="" C_GREEN="" C_YELLOW="" C_RESET=""
+fi
+
+step() {
+  STEP_N=$((STEP_N + 1))
+  echo ""
+  echo "${C_BOLD}${C_CYAN}================================================================${C_RESET}"
+  echo "${C_BOLD}${C_CYAN}  [${STEP_N}/${STEP_TOTAL}] $*${C_RESET}"
+  echo "${C_BOLD}${C_CYAN}================================================================${C_RESET}"
+}
+
+skip() {
+  echo "${C_YELLOW}  -> skip: $*${C_RESET}"
+}
+
+ok() {
+  echo "${C_GREEN}  -> $*${C_RESET}"
+}
+
+need_cmd() {
+  command -v "$1" >/dev/null 2>&1 || {
+    echo "error: required command not found: $1" >&2
+    exit 1
+  }
+}
+
+klock_cmd() {
+  if command -v kubectl-klock >/dev/null 2>&1 || "$KUBECTL" klock -h >/dev/null 2>&1; then
+    echo "$KUBECTL klock"
+    return 0
+  fi
+  return 1
+}
+
+print_plan() {
+  cat <<EOF
+Pre-prod demo plan
+  context:     ${KUBE_CONTEXT}
+  app NS:      ${NAMESPACE}  (CR ${CR_NAME})
+  infra NS:    ${INFRA_NAMESPACE}
+  kafka NS:    ${KAFKA_NAMESPACE}
+  keycloak NS: ${KEYCLOAK_NAMESPACE}
+  CHART_ROOT:  ${CHART_ROOT}
+  IMG:         ${IMG}
+  BUILD_MODE:  ${BUILD_MODE}
+  watcher:     ${WATCHER}
+  tmux:        ${TMUX_SESSION}  (NO_TMUX=${DEMO_NO_TMUX})
+  reset:       ${DEMO_RESET}
+  rebuild:     ${DEMO_REBUILD}
+  open UI:     ${OPEN_BROWSER} (NO_OPEN=${DEMO_NO_OPEN})
+
+  [1/8] Preflight (context, oc, CHART_ROOT, StorageClass)
+  [2/8] --reset: delete ${NAMESPACE}, ${INFRA_NAMESPACE}, ${KAFKA_NAMESPACE}, ${KEYCLOAK_NAMESPACE}
+  [3/8] BYOI (./hack/deploy-byoi.sh) — skip inner stages that are already Ready
+  [4/8] Operator image (${BUILD_MODE}: docker or OpenShift binary build)
+  [5/8] In-cluster operator (./hack/deploy-incluster.sh)
+  [6/8] Apply CR (clusterDomain + Keycloak issuerURL + insecureSkipVerify, ROS off)
+  [7/8] Wait until UI Deployment is Ready
+  [8/8] open the UI Route
+EOF
+}
+
+if [[ "$DEMO_DRY_RUN" == "1" ]]; then
+  print_plan
+  exit 0
+fi
+
+# --- tmux layout (outer process) ---------------------------------------------
+start_tmux() {
+  need_cmd tmux
+  local klock inner
+  klock="$(klock_cmd || true)"
+  if [[ "$WATCHER" == "klock" && -z "$klock" ]]; then
+    echo "warning: kubectl klock not found; watcher panes will use oc get -w" >&2
+    klock=""
+  fi
+
+  tmux has-session -t "$TMUX_SESSION" 2>/dev/null && tmux kill-session -t "$TMUX_SESSION"
+  tmux new-session -d -s "$TMUX_SESSION" -n demo
+  tmux set-option -t "$TMUX_SESSION" pane-border-status top
+  tmux set-option -t "$TMUX_SESSION" mouse on
+  tmux split-window -h -t "${TMUX_SESSION}:demo"
+  tmux split-window -v -t "${TMUX_SESSION}:demo.1"
+
+  tmux select-pane -t "${TMUX_SESSION}:demo.0" -T "steps"
+  tmux select-pane -t "${TMUX_SESSION}:demo.1" -T "klock pods ${NAMESPACE}"
+  tmux select-pane -t "${TMUX_SESSION}:demo.2" -T "klock pods ${KAFKA_NAMESPACE}"
+
+  local watch1 watch2
+  klock_watch() {
+    local ns="$1"
+    if [[ -n "$klock" ]]; then
+      echo "${klock} pods -n $(printf %q "$ns") --context $(printf %q "$KUBE_CONTEXT")"
+    else
+      echo "$KUBECTL get pods -n $(printf %q "$ns") --context $(printf %q "$KUBE_CONTEXT") -w"
+    fi
+  }
+  if [[ "$WATCHER" == "k9s" ]] && command -v k9s >/dev/null 2>&1; then
+    watch1="k9s --context $(printf %q "$KUBE_CONTEXT") -n $(printf %q "$NAMESPACE")"
+  else
+    watch1="$(klock_watch "$NAMESPACE")"
+  fi
+  watch2="$(klock_watch "$KAFKA_NAMESPACE")"
+
+  tmux send-keys -t "${TMUX_SESSION}:demo.1" "until ${watch1}; do echo 'watcher retry in 3s…'; sleep 3; done" C-m
+  tmux send-keys -t "${TMUX_SESSION}:demo.2" "until ${watch2}; do echo 'watcher retry in 3s…'; sleep 3; done" C-m
+
+  inner="cd $(printf %q "$ROOT") && DEMO_INNER=1 DEMO_RESET=$(printf %q "$DEMO_RESET") DEMO_REBUILD=$(printf %q "$DEMO_REBUILD") DEMO_NO_OPEN=$(printf %q "$DEMO_NO_OPEN") $(printf %q "$ROOT/hack/demo-preprod.sh")"
+  tmux send-keys -t "${TMUX_SESSION}:demo.0" "$inner" C-m
+  tmux select-pane -t "${TMUX_SESSION}:demo.0"
+
+  if [[ -n "${TMUX:-}" ]]; then
+    tmux switch-client -t "$TMUX_SESSION"
+  else
+    tmux attach-session -t "$TMUX_SESSION"
+  fi
+}
+
+if [[ -z "${DEMO_INNER:-}" && "$DEMO_NO_TMUX" != "1" ]] && command -v tmux >/dev/null 2>&1; then
+  start_tmux
+  exit 0
+fi
+
+# --- inner / no-tmux path ----------------------------------------------------
+need_cmd "$KUBECTL"
+need_cmd python3
+need_cmd openssl
+
+step "Preflight"
+echo "Cluster context: ${KUBE_CONTEXT}"
+if ! "$KUBECTL" config get-contexts "$KUBE_CONTEXT" >/dev/null 2>&1; then
+  echo "error: kube context '${KUBE_CONTEXT}' not found" >&2
+  "$KUBECTL" config get-contexts >&2 || true
+  exit 1
+fi
+"$KUBECTL" config use-context "$KUBE_CONTEXT" >/dev/null
+require_reachable_cluster "$KUBECTL" || exit 1
+ok "using $($KUBECTL config current-context) — $($KUBECTL whoami --show-server)"
+
+if [[ ! -x "${CHART_ROOT}/scripts/deploy-rhbk.sh" ]]; then
+  echo "error: CHART_ROOT has no scripts/deploy-rhbk.sh: ${CHART_ROOT}" >&2
+  echo "  copy hack/demo-preprod.env.example → hack/demo-preprod.local.env and set CHART_ROOT" >&2
+  exit 1
+fi
+ok "CHART_ROOT=${CHART_ROOT}"
+
+DOMAIN="$(read_apps_domain "$KUBECTL")" || exit 1
+ok "apps domain=${DOMAIN}"
+KEYCLOAK_ISSUER="https://keycloak-${KEYCLOAK_NAMESPACE}.${DOMAIN}"
+UI_URL="https://${CR_NAME}-ui-${NAMESPACE}.${DOMAIN}"
+
+# Helpers used by --reset and later skip-if-ready checks. Defined before reset
+# because deleting the app namespace kills the operator; we must delete the CR
+# first while it can still clear its finalizer.
+need_ns() {
+  local ns="$1"
+  if ! "$KUBECTL" get ns "$ns" >/dev/null 2>&1; then
+    "$KUBECTL" create ns "$ns"
+  fi
+}
+operator_ready() {
+  [[ "$("$KUBECTL" -n "$NAMESPACE" get deploy koku-service-operator -o jsonpath='{.status.availableReplicas}' 2>/dev/null || echo 0)" != "0" ]]
+}
+clear_finalizers() {
+  local ns="$1" kind="$2"
+  local obj
+  while read -r obj; do
+    [[ -z "$obj" ]] && continue
+    echo "    strip finalizers: ${ns}/${obj}"
+    "$KUBECTL" patch "$obj" -n "$ns" --type=merge -p '{"metadata":{"finalizers":[]}}' >/dev/null || true
+  done < <("$KUBECTL" get "$kind" -n "$ns" -o name 2>/dev/null || true)
+}
+wait_ns_gone() {
+  local ns="$1" timeout="${2:-180}"
+  local end=$((SECONDS + timeout))
+  while (( SECONDS < end )); do
+    "$KUBECTL" get ns "$ns" >/dev/null 2>&1 || return 0
+    sleep 2
+  done
+  return 1
+}
+delete_cr_or_strip() {
+  local ns="$1" kind="$2" name="${3:-}"
+  local sel
+  if [[ -n "$name" ]]; then
+    "$KUBECTL" get "$kind" "$name" -n "$ns" >/dev/null 2>&1 || return 0
+    sel=("$kind" "$name")
+  else
+    "$KUBECTL" get "$kind" -n "$ns" -o name 2>/dev/null | grep -q . || return 0
+    sel=("$kind" --all)
+  fi
+  echo "  deleting ${kind}${name:+/}${name} in ${ns}…"
+  if ! "$KUBECTL" -n "$ns" delete "${sel[@]}" --timeout=120s >/dev/null 2>&1; then
+    echo "  ${kind} delete timed out — stripping finalizers"
+    if [[ -n "$name" ]]; then
+      "$KUBECTL" patch "$kind" "$name" -n "$ns" --type=merge -p '{"metadata":{"finalizers":[]}}' >/dev/null || true
+    else
+      clear_finalizers "$ns" "$kind"
+    fi
+  fi
+}
+delete_ns() {
+  local ns="$1"
+  if ! "$KUBECTL" get ns "$ns" >/dev/null 2>&1; then
+    skip "namespace ${ns} already gone"
+    return 0
+  fi
+  local phase
+  phase="$("$KUBECTL" get ns "$ns" -o jsonpath='{.status.phase}' 2>/dev/null || true)"
+  if [[ "$phase" != "Terminating" ]]; then
+    echo "  deleting namespace ${ns}…"
+    "$KUBECTL" delete ns "$ns" --wait=false >/dev/null
+  else
+    echo "  namespace ${ns} already Terminating"
+  fi
+  if wait_ns_gone "$ns" 90; then
+    ok "namespace ${ns} gone"
+    return 0
+  fi
+  echo "  ${ns} still terminating — stripping leftover finalizers (operator likely already gone)"
+  local kind
+  for kind in \
+    costmanagementserviceconfigs.service.costmanagement.openshift.io \
+    kafka kafkanodepool kafkatopic \
+    keycloak keycloakrealmimport \
+    persistentvolumeclaims; do
+    clear_finalizers "$ns" "$kind"
+  done
+  if wait_ns_gone "$ns" 90; then
+    ok "namespace ${ns} gone"
+    return 0
+  fi
+  echo "error: namespace ${ns} still stuck in Terminating" >&2
+  "$KUBECTL" get ns "$ns" -o jsonpath='{range .status.conditions[*]}{.type}={.status} {.reason} {.message}{"\n"}{end}' >&2 || true
+  return 1
+}
+
+step "Reset namespaces (optional)"
+if [[ "$DEMO_RESET" == "1" ]]; then
+  # CMSC finalizer requires the operator pod. Deleting the namespace first
+  # kills the operator and leaves the CR (and NS) stuck in Terminating.
+  if "$KUBECTL" -n "$NAMESPACE" get cmsc "$CR_NAME" >/dev/null 2>&1; then
+    if operator_ready; then
+      echo "  deleting CMSC ${NAMESPACE}/${CR_NAME} so the operator can clear its finalizer…"
+      "$KUBECTL" -n "$NAMESPACE" delete cmsc "$CR_NAME" --timeout=180s || true
+    fi
+    if "$KUBECTL" -n "$NAMESPACE" get cmsc "$CR_NAME" >/dev/null 2>&1; then
+      echo "  operator not running or CMSC still present — stripping finalizer"
+      "$KUBECTL" -n "$NAMESPACE" patch cmsc "$CR_NAME" --type=merge -p '{"metadata":{"finalizers":[]}}' >/dev/null || true
+    fi
+  fi
+  "$KUBECTL" delete consolelink "${CR_NAME}-cost-management" --ignore-not-found=true >/dev/null || true
+  "$KUBECTL" delete clusterrole,clusterrolebinding -l "app.kubernetes.io/instance=${CR_NAME}" --ignore-not-found=true >/dev/null || true
+
+  delete_cr_or_strip "$KEYCLOAK_NAMESPACE" keycloakrealmimport
+  delete_cr_or_strip "$KEYCLOAK_NAMESPACE" keycloak keycloak
+  delete_cr_or_strip "$KAFKA_NAMESPACE" kafkatopic
+  delete_cr_or_strip "$KAFKA_NAMESPACE" kafka "$KAFKA_CLUSTER_NAME"
+  delete_cr_or_strip "$KAFKA_NAMESPACE" kafkanodepool
+
+  delete_ns "$NAMESPACE"
+  delete_ns "$INFRA_NAMESPACE"
+  delete_ns "$KEYCLOAK_NAMESPACE"
+  delete_ns "$KAFKA_NAMESPACE"
+  ok "namespaces removed"
+else
+  skip "pass --reset to delete ${NAMESPACE}, ${INFRA_NAMESPACE}, ${KAFKA_NAMESPACE}, ${KEYCLOAK_NAMESPACE}"
+fi
+
+# Pre-create so klock panes have a namespace from the start (empty table, not
+# NotFound). deploy-kafka.sh / deploy-rhbk.sh will then warn that the NS
+# already exists — that is expected and harmless.
+need_ns "$NAMESPACE"
+need_ns "$INFRA_NAMESPACE"
+need_ns "$KAFKA_NAMESPACE"
+need_ns "$KEYCLOAK_NAMESPACE"
+
+kafka_ready() {
+  [[ "$("$KUBECTL" -n "$KAFKA_NAMESPACE" get kafka "$KAFKA_CLUSTER_NAME" -o jsonpath='{.status.conditions[?(@.type=="Ready")].status}' 2>/dev/null || true)" == "True" ]]
+}
+infra_ready() {
+  "$KUBECTL" -n "$INFRA_NAMESPACE" get deploy postgresql >/dev/null 2>&1 \
+    && [[ "$("$KUBECTL" -n "$INFRA_NAMESPACE" get deploy postgresql -o jsonpath='{.status.availableReplicas}' 2>/dev/null || echo 0)" != "0" ]]
+}
+keycloak_ready() {
+  [[ "$("$KUBECTL" -n "$KEYCLOAK_NAMESPACE" get keycloak keycloak -o jsonpath='{.status.conditions[?(@.type=="Ready")].status}' 2>/dev/null || true)" == "True" ]]
+}
+oauth_secret_ready() {
+  "$KUBECTL" -n "$NAMESPACE" get secret "${CR_NAME}-ui-oauth-client" >/dev/null 2>&1
+}
+image_present() {
+  "$KUBECTL" -n "$NAMESPACE" get imagestreamtag "koku-service-operator:${IMAGE_TAG}" >/dev/null 2>&1
+}
+ui_deploy_ready() {
+  [[ "$("$KUBECTL" -n "$NAMESPACE" get deploy "${CR_NAME}-ui" -o jsonpath='{.status.availableReplicas}' 2>/dev/null || echo 0)" != "0" ]]
+}
+
+step "BYOI dependencies (Kafka, Postgres, Valkey, MinIO, Keycloak)"
+SKIP_KAFKA=0 SKIP_INFRA=0 SKIP_KEYCLOAK=0 SKIP_OAUTH_MIRROR=0
+kafka_ready && SKIP_KAFKA=1 && skip "Kafka ${KAFKA_CLUSTER_NAME} already Ready"
+infra_ready && SKIP_INFRA=1 && skip "infra in ${INFRA_NAMESPACE} already rolled out"
+keycloak_ready && SKIP_KEYCLOAK=1 && skip "Keycloak already Ready"
+oauth_secret_ready && SKIP_OAUTH_MIRROR=1 && skip "OAuth client Secret already present"
+if [[ "${SKIP_KAFKA}${SKIP_INFRA}${SKIP_KEYCLOAK}${SKIP_OAUTH_MIRROR}" == "1111" ]]; then
+  skip "all BYOI stages healthy"
+else
+  export SKIP_KAFKA SKIP_INFRA SKIP_KEYCLOAK SKIP_OAUTH_MIRROR
+  ./hack/deploy-byoi.sh
+fi
+ok "BYOI ready"
+
+step "Operator image"
+BUILT_IMAGE=0
+docker_up() {
+  command -v docker >/dev/null 2>&1 && docker info >/dev/null 2>&1
+}
+build_openshift() {
+  echo "  OpenShift binary docker build -> ${NAMESPACE}/koku-service-operator:${IMAGE_TAG}"
+  if ! "$KUBECTL" -n "$NAMESPACE" get buildconfig koku-service-operator >/dev/null 2>&1; then
+    oc -n "$NAMESPACE" new-build --name=koku-service-operator --binary --strategy=docker \
+      --to="koku-service-operator:${IMAGE_TAG}"
+  fi
+  local tmp
+  tmp="$(mktemp -d)"
+  tar -C "$ROOT" -cf - \
+    --exclude .git --exclude .serena --exclude bin --exclude .worktrees \
+    --exclude docs/superpowers --exclude '*.out' \
+    . | tar -C "$tmp" -xf -
+  patch_operator_dockerfile "${tmp}/Dockerfile"
+  oc -n "$NAMESPACE" start-build koku-service-operator --from-dir="$tmp" --follow
+  rm -rf "$tmp"
+}
+build_docker() {
+  echo "  docker buildx --platform linux/amd64 -t ${IMG}"
+  docker buildx build --platform linux/amd64 -t "$IMG" --push "$ROOT"
+}
+
+if [[ "$DEMO_REBUILD" != "1" ]] && image_present && operator_ready; then
+  skip "ImageStream tag and operator Deployment already present (--rebuild to force)"
+else
+  mode="$BUILD_MODE"
+  if [[ "$mode" == "auto" ]]; then
+    case "$IMG" in
+      image-registry.openshift-image-registry.svc:*)
+        mode=openshift
+        ;;
+      *)
+        if docker_up; then
+          mode=docker
+        else
+          mode=openshift
+        fi
+        ;;
+    esac
+  fi
+  case "$mode" in
+    docker)
+      build_docker
+      BUILT_IMAGE=1
+      ;;
+    openshift)
+      build_openshift
+      BUILT_IMAGE=1
+      ;;
+    *)
+      echo "error: BUILD_MODE must be auto|docker|openshift (got ${mode})" >&2
+      exit 1
+      ;;
+  esac
+  ok "image ${IMG}"
+fi
+
+step "In-cluster operator"
+if [[ "$DEMO_REBUILD" != "1" && "$BUILT_IMAGE" != "1" ]] && operator_ready; then
+  skip "koku-service-operator Deployment already Available"
+else
+  IMG="$IMG" ./hack/deploy-incluster.sh "$NAMESPACE"
+fi
+ok "operator running"
+
+step "Apply CostManagementServiceConfig"
+CR_TMP="$(mktemp)"
+render_preprod_cr \
+  "${ROOT}/config/samples/byoi/app/costmanagementserviceconfig.yaml" \
+  "$CR_TMP" \
+  "$DOMAIN" \
+  "$KEYCLOAK_ISSUER"
+"$KUBECTL" apply -f "$CR_TMP"
+rm -f "$CR_TMP"
+ok "CR ${NAMESPACE}/${CR_NAME} applied (issuer ${KEYCLOAK_ISSUER})"
+
+step "Wait for UI Deployment"
+echo "  watching ${NAMESPACE}/${CR_NAME} (UIReady is the OAuth Secret; we wait for the UI rollout)…"
+deadline=$((SECONDS + 900))
+while (( SECONDS < deadline )); do
+  "$KUBECTL" -n "$NAMESPACE" get cmsc "$CR_NAME" -o jsonpath='phase={.status.phase}{"\n"}{range .status.conditions[*]}{.type}={.status} ({.reason}){"\n"}{end}' 2>/dev/null || true
+  if ui_deploy_ready; then
+    "$KUBECTL" -n "$NAMESPACE" rollout status "deploy/${CR_NAME}-ui" --timeout=120s
+    break
+  fi
+  sleep 15
+done
+if ! ui_deploy_ready; then
+  echo "error: UI Deployment ${CR_NAME}-ui did not become Available within 15m" >&2
+  "$KUBECTL" -n "$NAMESPACE" get cmsc "$CR_NAME" -o yaml | tail -80 >&2 || true
+  exit 1
+fi
+ok "UI Deployment Ready"
+
+step "Open the UI"
+echo "  ${UI_URL}"
+echo "  Keycloak realm user: admin / admin"
+if [[ "$DEMO_NO_OPEN" == "1" || "$OPEN_BROWSER" == "0" ]]; then
+  skip "browser launch disabled"
+elif command -v open >/dev/null 2>&1; then
+  open "$UI_URL" || true
+  ok "opened in default browser (cluster TLS may need a click-through)"
+else
+  skip "no 'open' command; visit the URL above"
+fi
+
+echo ""
+echo "${C_BOLD}${C_GREEN}Demo complete.${C_RESET} UI: ${UI_URL}"
+echo "Login: admin / admin"

--- a/hack/demo-preprod_test.sh
+++ b/hack/demo-preprod_test.sh
@@ -64,7 +64,7 @@ assert_contains "$cr" 'clusterDomain: "apps.example.test"' "clusterDomain patche
 assert_not_contains "$cr" "apps.cluster.example.com" "placeholder domain gone"
 assert_contains "$cr" 'issuerURL: "https://keycloak-keycloak.apps.example.test"' "issuerURL set"
 assert_contains "$cr" "insecureSkipVerify: true" "skip-verify for lab router CA"
-assert_contains "$cr" "enabled: false" "ROS stays off"
+assert_contains "$cr" $'  ros:\n    enabled: false' "ROS stays off (sample CR, not a demo env var)"
 rm -f "$tmp"
 
 # --- Chart root: worktree ROOT is not the sibling of cost-onprem-chart ---

--- a/hack/demo-preprod_test.sh
+++ b/hack/demo-preprod_test.sh
@@ -1,0 +1,129 @@
+#!/usr/bin/env bash
+# Unit tests for hack/lib/demo-preprod.bash (no cluster required).
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+# shellcheck disable=SC1091
+source "${ROOT}/hack/lib/demo-preprod.bash"
+
+fail=0
+assert_eq() {
+  local got="$1" want="$2" msg="$3"
+  if [[ "$got" != "$want" ]]; then
+    echo "FAIL: ${msg}" >&2
+    echo "  got:  ${got}" >&2
+    echo "  want: ${want}" >&2
+    fail=1
+  fi
+}
+
+assert_contains() {
+  local haystack="$1" needle="$2" msg="$3"
+  if [[ "$haystack" != *"$needle"* ]]; then
+    echo "FAIL: ${msg}" >&2
+    echo "  missing: ${needle}" >&2
+    fail=1
+  fi
+}
+
+assert_not_contains() {
+  local haystack="$1" needle="$2" msg="$3"
+  if [[ "$haystack" == *"$needle"* ]]; then
+    echo "FAIL: ${msg}" >&2
+    echo "  unexpectedly present: ${needle}" >&2
+    fail=1
+  fi
+}
+
+# --- Dockerfile: OpenShift non-root UID cannot write WORKDIR /workspace ---
+tmp="$(mktemp)"
+cat >"$tmp" <<'EOF'
+RUN CGO_ENABLED=0 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH} go build -a -o manager cmd/main.go
+RUN CGO_ENABLED=0 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH} go build -a -o wait-for ./cmd/wait-for/
+COPY --from=builder /workspace/manager .
+COPY --from=builder /workspace/wait-for .
+EOF
+patch_operator_dockerfile "$tmp"
+patched="$(cat "$tmp")"
+assert_contains "$patched" "go build -a -o /tmp/manager cmd/main.go" "build manager to /tmp"
+assert_contains "$patched" "go build -a -o /tmp/wait-for ./cmd/wait-for/" "build wait-for to /tmp"
+assert_contains "$patched" "COPY --from=builder /tmp/manager ." "copy manager from /tmp"
+assert_contains "$patched" "COPY --from=builder /tmp/wait-for ." "copy wait-for from /tmp"
+assert_not_contains "$patched" "-o manager cmd/main.go" "no WORKDIR-relative manager output"
+rm -f "$tmp"
+
+# --- CR: replace placeholder domain, set public issuer + skip-verify ---
+tmp="$(mktemp)"
+render_preprod_cr \
+  "${ROOT}/config/samples/byoi/app/costmanagementserviceconfig.yaml" \
+  "$tmp" \
+  "apps.example.test" \
+  "https://keycloak-keycloak.apps.example.test"
+cr="$(cat "$tmp")"
+assert_contains "$cr" 'clusterDomain: "apps.example.test"' "clusterDomain patched"
+assert_not_contains "$cr" "apps.cluster.example.com" "placeholder domain gone"
+assert_contains "$cr" 'issuerURL: "https://keycloak-keycloak.apps.example.test"' "issuerURL set"
+assert_contains "$cr" "insecureSkipVerify: true" "skip-verify for lab router CA"
+assert_contains "$cr" "enabled: false" "ROS stays off"
+rm -f "$tmp"
+
+# --- Chart root: worktree ROOT is not the sibling of cost-onprem-chart ---
+got="$(default_chart_root "/tmp/koku-service-operator/.worktrees/cost-7688-gaps" "/tmp/koku-service-operator/.git")"
+assert_eq "$got" "/tmp/cost-onprem-chart" "chart sits next to the main git dir, not the worktree"
+
+# --- Preflight must surface the real API error (expired Cluster Bot, etc.) ---
+stub_dir="$(mktemp -d)"
+cat >"${stub_dir}/kubectl-dead" <<'EOF'
+#!/bin/bash
+echo "Unable to connect to the server: dial tcp: lookup api.expired.example: no such host" >&2
+exit 1
+EOF
+cat >"${stub_dir}/kubectl-empty-domain" <<'EOF'
+#!/bin/bash
+exit 0
+EOF
+cat >"${stub_dir}/kubectl-ok" <<'EOF'
+#!/bin/bash
+if [[ "$1" == "whoami" ]]; then
+  echo "kube:admin"
+  exit 0
+fi
+echo "apps.chat-bot.example.com"
+exit 0
+EOF
+chmod +x "${stub_dir}"/kubectl-*
+
+dead_out="$(require_reachable_cluster "${stub_dir}/kubectl-dead" 2>&1)" && dead_rc=0 || dead_rc=$?
+assert_eq "$dead_rc" "1" "dead cluster: require_reachable_cluster fails"
+assert_contains "$dead_out" "kube API is not reachable" "dead cluster: high-level message"
+assert_contains "$dead_out" "no such host" "dead cluster: original oc/kubectl error"
+
+dead_dom="$(read_apps_domain "${stub_dir}/kubectl-dead" 2>&1)" && dead_dom_rc=0 || dead_dom_rc=$?
+assert_eq "$dead_dom_rc" "1" "dead cluster: read_apps_domain fails"
+assert_contains "$dead_dom" "failed to get ingress.config.openshift.io/cluster" "domain fetch: high-level message"
+assert_contains "$dead_dom" "no such host" "domain fetch: original error, not swallowed"
+assert_not_contains "$dead_dom" "could not read OpenShift apps domain" "no generic swallowed-domain message"
+
+empty_out="$(read_apps_domain "${stub_dir}/kubectl-empty-domain" 2>&1)" && empty_rc=0 || empty_rc=$?
+assert_eq "$empty_rc" "1" "empty spec.domain fails"
+assert_contains "$empty_out" "empty spec.domain" "empty domain is explicit"
+
+ok_dom="$(read_apps_domain "${stub_dir}/kubectl-ok" 2>&1)" && ok_rc=0 || ok_rc=$?
+assert_eq "$ok_rc" "0" "live cluster: read_apps_domain succeeds"
+assert_eq "$ok_dom" "apps.chat-bot.example.com" "live cluster: domain value"
+rm -rf "$stub_dir"
+
+# --help must work when invoked from hack/ (relative $0 after cd to repo root)
+help_out="$(cd "${ROOT}/hack" && ./demo-preprod.sh --help 2>&1)" || {
+  echo "FAIL: --help from hack/ exited $? " >&2
+  echo "$help_out" >&2
+  fail=1
+}
+assert_contains "$help_out" "./hack/demo-preprod.sh --dry-run" "--help from hack/ prints usage"
+assert_not_contains "$help_out" "No such file or directory" "--help from hack/ must not sed a relative \$0"
+
+if [[ "$fail" -ne 0 ]]; then
+  echo "demo-preprod tests FAILED" >&2
+  exit 1
+fi
+echo "demo-preprod tests OK"

--- a/hack/lib/demo-preprod.bash
+++ b/hack/lib/demo-preprod.bash
@@ -1,0 +1,96 @@
+#!/usr/bin/env bash
+# Helpers for hack/demo-preprod.sh. Sourced; do not execute.
+# OpenShift's UBI go-toolset image runs as a random UID. Writing the Go binary
+# into WORKDIR /workspace fails with "open manager: permission denied".
+patch_operator_dockerfile() {
+  local file="${1:?Dockerfile path required}"
+  # Portable in-place edit (macOS/Linux).
+  local tmp
+  tmp="$(mktemp)"
+  sed \
+    -e 's|go build -a -o manager cmd/main.go|go build -a -o /tmp/manager cmd/main.go|' \
+    -e 's|go build -a -o wait-for ./cmd/wait-for/|go build -a -o /tmp/wait-for ./cmd/wait-for/|' \
+    -e 's|COPY --from=builder /workspace/manager .|COPY --from=builder /tmp/manager .|' \
+    -e 's|COPY --from=builder /workspace/wait-for .|COPY --from=builder /tmp/wait-for .|' \
+    "$file" >"$tmp"
+  mv "$tmp" "$file"
+}
+
+# Fill the BYOI sample CR: apps domain, public Keycloak issuer, lab TLS skip-verify.
+render_preprod_cr() {
+  local src="${1:?sample CR path}"
+  local dest="${2:?output path}"
+  local domain="${3:?cluster apps domain}"
+  local issuer="${4:?Keycloak issuer base URL}"
+  python3 - "$src" "$dest" "$domain" "$issuer" <<'PY'
+import sys
+from pathlib import Path
+
+src, dest, domain, issuer = sys.argv[1:5]
+text = Path(src).read_text()
+text = text.replace('clusterDomain: "apps.cluster.example.com"', f'clusterDomain: "{domain}"')
+old_url = '      url: "http://keycloak-service.keycloak.svc.cluster.local:8080"'
+new_block = (
+    old_url
+    + f'\n      issuerURL: "{issuer}"'
+    + "\n      tls:\n        insecureSkipVerify: true"
+)
+if old_url not in text:
+    raise SystemExit("render_preprod_cr: keycloak url line not found in sample CR")
+text = text.replace(old_url, new_block, 1)
+# Drop the commented placeholders so the live values are the only ones.
+text = text.replace('      # issuerURL: "https://keycloak-keycloak.apps.example.com"\n', "")
+text = text.replace("      # tls:\n", "")
+text = text.replace("      #   insecureSkipVerify: true   # dev only when issuer uses a private CA\n", "")
+Path(dest).write_text(text)
+PY
+}
+
+# cost-onprem-chart is a sibling of the main checkout, not of a git worktree dir.
+# Paths are string-computed so this works in tests without the dirs existing.
+default_chart_root() {
+  local repo_root="${1:?}"
+  local git_common_dir="${2:-}"
+  local main_root parent
+  if [[ -n "$git_common_dir" ]]; then
+    main_root="$(dirname "$git_common_dir")"
+  else
+    main_root="$repo_root"
+  fi
+  parent="$(dirname "$main_root")"
+  echo "${parent}/cost-onprem-chart"
+}
+
+# Fail with the real oc/kubectl error when the API is down (expired Cluster Bot).
+require_reachable_cluster() {
+  local kubectl="${1:?kubectl/oc binary}"
+  local err
+  err="$(mktemp)"
+  if ! "$kubectl" whoami >/dev/null 2>"$err"; then
+    echo "error: kube API is not reachable (context may point at an expired Cluster Bot)" >&2
+    sed 's/^/  /' "$err" >&2
+    rm -f "$err"
+    return 1
+  fi
+  rm -f "$err"
+}
+
+# Print spec.domain from ingress.config.openshift.io/cluster. Do not swallow stderr.
+read_apps_domain() {
+  local kubectl="${1:?kubectl/oc binary}"
+  local err out
+  err="$(mktemp)"
+  if ! out="$("$kubectl" get ingress.config.openshift.io cluster -o jsonpath='{.spec.domain}' 2>"$err")"; then
+    echo "error: failed to get ingress.config.openshift.io/cluster (need a live OpenShift API)" >&2
+    sed 's/^/  /' "$err" >&2
+    rm -f "$err"
+    return 1
+  fi
+  rm -f "$err"
+  out="${out//[$'\t\r\n ']/}"
+  if [[ -z "$out" ]]; then
+    echo "error: ingress.config.openshift.io/cluster has an empty spec.domain" >&2
+    return 1
+  fi
+  printf '%s\n' "$out"
+}


### PR DESCRIPTION
## Summary
- Recreates closed [#72](https://github.com/project-koku/koku-service-operator/pull/72) with **only** the demo driver (one commit on `main`). COST-7688 already landed via [#92](https://github.com/project-koku/koku-service-operator/pull/92).
- `hack/demo-preprod.sh` runs the full pre-prod path (AMQ Streams + Keycloak + in-cluster operator + CR, ROS off) with tmux panes and `kubectl klock` watching `cost-byoi` / `kafka` pods.
- Idempotent re-runs; `--reset` deletes the CMSC **first** (while the operator is up) so the cleanup finalizer does not stick the namespace in Terminating.
- Preflight prints the real API error when Cluster Bot is gone, instead of a generic empty `ingress.config.openshift.io` message.

## Test plan
- [x] `./hack/demo-preprod_test.sh` (no cluster)
- [x] `./hack/demo-preprod.sh --dry-run`
- [x] `./hack/demo-preprod.sh --help` from `hack/`
- [x] GitHub compare vs `project-koku/main`: 1 commit, 5 files (gitignore + demo scripts)
- [x] Live Cluster Bot: `./hack/demo-preprod.sh` through UI `open` (on the previous stacked branch)
- [x] `--reset` on a cluster that already has a CMSC: CR deleted before namespaces; no stuck Terminating NS