### PR TITLE
[COST-7692] fix degrade available status on dependency failure and APIDown absence

### DIFF
--- a/internal/controller/rbac_manifest_test.go
+++ b/internal/controller/rbac_manifest_test.go
@@ -31,15 +31,18 @@ func decodeYAMLFile(t *testing.T, path string, into any) {
 	}
 }
 
-// olmCSVClusterPermissions is the CSV fragment we round-trip. Avoids adding
-// operator-framework/api just to inspect install.spec.clusterPermissions.
-type olmCSVClusterPermissions struct {
+// olmCSVInstallPermissions is the CSV fragment we round-trip. Avoids adding
+// operator-framework/api just to inspect install.spec.{clusterPermissions,permissions}.
+type olmCSVInstallPermissions struct {
 	Spec struct {
 		Install struct {
 			Spec struct {
 				ClusterPermissions []struct {
 					Rules []rbacv1.PolicyRule `json:"rules"`
 				} `json:"clusterPermissions"`
+				Permissions []struct {
+					Rules []rbacv1.PolicyRule `json:"rules"`
+				} `json:"permissions"`
 			} `json:"spec"`
 		} `json:"install"`
 	} `json:"spec"`
@@ -159,17 +162,19 @@ func TestManagerRole_GrantsObjectBucketClaimGetList(t *testing.T) {
 	}
 
 	// OLM installs from the CSV, not role.yaml. CI does not regenerate the
-	// bundle, so lock clusterPermissions to the same get+list grant.
-	var csv olmCSVClusterPermissions
+	// bundle, so lock namespaced permissions (manager-role) to the same
+	// get+list grant. objectbucketclaims are namespaced; they must not live
+	// only under clusterPermissions.
+	var csv olmCSVInstallPermissions
 	decodeYAMLFile(t, bundleCSVPath(t), &csv)
 	var csvRules []rbacv1.PolicyRule
-	for _, p := range csv.Spec.Install.Spec.ClusterPermissions {
+	for _, p := range csv.Spec.Install.Spec.Permissions {
 		csvRules = append(csvRules, p.Rules...)
 	}
-	if len(csv.Spec.Install.Spec.ClusterPermissions) == 0 {
-		t.Fatal("CSV spec.install.spec.clusterPermissions is empty (unmarshal failed or field moved)")
+	if len(csv.Spec.Install.Spec.Permissions) == 0 {
+		t.Fatal("CSV spec.install.spec.permissions is empty (unmarshal failed or field moved)")
 	}
-	assertObjectBucketClaimGetList(t, "CSV clusterPermissions", csvRules)
+	assertObjectBucketClaimGetList(t, "CSV permissions", csvRules)
 }
 
 func TestManagerRole_StillGrantsNamespacedSecrets(t *testing.T) {

--- a/internal/controller/validation.go
+++ b/internal/controller/validation.go
@@ -13,6 +13,7 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
+	apimeta "k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 
@@ -151,9 +152,32 @@ func (r *CostManagementServiceConfigReconciler) reconcileValidation(ctx context.
 	}
 
 	if !allReady {
+		// Blocking DB/Cache failures must not leave stale Available=True /
+		// Degraded=False from a prior Ready pass (COST-8107).
+		msg := blockingDependencyMessage(cfg)
+		r.setCondition(cfg, costv1alpha1.ConditionAvailable, metav1.ConditionFalse,
+			"DependencyNotReady", msg)
+		r.setCondition(cfg, costv1alpha1.ConditionDegraded, metav1.ConditionTrue,
+			"DependencyUnreachable", msg)
+		cfg.Status.Phase = costv1alpha1.PhaseDegraded
 		return Result{RequeueAfter: requeueSlow}, nil
 	}
 	return Result{}, nil
+}
+
+// blockingDependencyMessage summarizes why DB/Cache validation blocked reconcile.
+func blockingDependencyMessage(cfg *costv1alpha1.CostManagementServiceConfig) string {
+	var parts []string
+	for _, typ := range []string{costv1alpha1.ConditionDatabaseReady, costv1alpha1.ConditionCacheReady} {
+		c := apimeta.FindStatusCondition(cfg.Status.Conditions, typ)
+		if c != nil && c.Status == metav1.ConditionFalse {
+			parts = append(parts, fmt.Sprintf("%s: %s", typ, c.Message))
+		}
+	}
+	if len(parts) == 0 {
+		return "blocking dependency validation failed"
+	}
+	return strings.Join(parts, "; ")
 }
 
 // tcpProbe opens and immediately closes a TCP connection to addr.

--- a/internal/controller/validation_test.go
+++ b/internal/controller/validation_test.go
@@ -285,6 +285,62 @@ func TestReconcileValidation_ExternalDBUnreachable(t *testing.T) {
 	if dbCond != nil && dbCond.Reason != "DatabaseUnreachable" {
 		t.Errorf("unexpected reason %q", dbCond.Reason)
 	}
+	avail := findCondition(cfg.Status.Conditions, costv1alpha1.ConditionAvailable)
+	if avail == nil || avail.Status != metav1.ConditionFalse || avail.Reason != "DependencyNotReady" {
+		t.Errorf("expected Available=False reason=DependencyNotReady, got %+v", avail)
+	}
+	deg := findCondition(cfg.Status.Conditions, costv1alpha1.ConditionDegraded)
+	if deg == nil || deg.Status != metav1.ConditionTrue || deg.Reason != "DependencyUnreachable" {
+		t.Errorf("expected Degraded=True reason=DependencyUnreachable, got %+v", deg)
+	}
+	if cfg.Status.Phase != costv1alpha1.PhaseDegraded {
+		t.Errorf("expected phase %q, got %q", costv1alpha1.PhaseDegraded, cfg.Status.Phase)
+	}
+}
+
+func TestReconcileValidation_ExternalCacheUnreachable_SetsAvailableDegraded(t *testing.T) {
+	cfg := &costv1alpha1.CostManagementServiceConfig{
+		ObjectMeta: metav1.ObjectMeta{Name: testCRName, Namespace: testNamespace},
+		Spec: costv1alpha1.CostManagementServiceConfigSpec{
+			Database: costv1alpha1.DatabaseConfig{Deploy: truePtr()},
+			Cache: costv1alpha1.CacheConfig{
+				Deploy: falsePtr(),
+				Host:   localHost,
+				Port:   1,
+			},
+			Kafka: costv1alpha1.KafkaConfig{BootstrapServers: ""},
+		},
+	}
+	// Stale Ready-era conditions that must be cleared on blocking failure.
+	cfg.Status.Conditions = []metav1.Condition{
+		{Type: costv1alpha1.ConditionAvailable, Status: metav1.ConditionTrue, Reason: "AllComponentsReady"},
+		{Type: costv1alpha1.ConditionDegraded, Status: metav1.ConditionFalse, Reason: "ReconcileComplete"},
+	}
+	cfg.Status.Phase = costv1alpha1.PhaseReady
+
+	r := newValidationReconciler(t)
+	result, err := r.reconcileValidation(context.Background(), cfg)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.RequeueAfter == 0 {
+		t.Error("expected non-zero requeue (unreachable external cache blocks pipeline)")
+	}
+	cacheCond := findCondition(cfg.Status.Conditions, costv1alpha1.ConditionCacheReady)
+	if cacheCond == nil || cacheCond.Status != metav1.ConditionFalse || cacheCond.Reason != "CacheUnreachable" {
+		t.Errorf("expected CacheReady=False CacheUnreachable, got %+v", cacheCond)
+	}
+	avail := findCondition(cfg.Status.Conditions, costv1alpha1.ConditionAvailable)
+	if avail == nil || avail.Status != metav1.ConditionFalse {
+		t.Errorf("expected Available=False, got %+v", avail)
+	}
+	deg := findCondition(cfg.Status.Conditions, costv1alpha1.ConditionDegraded)
+	if deg == nil || deg.Status != metav1.ConditionTrue {
+		t.Errorf("expected Degraded=True, got %+v", deg)
+	}
+	if cfg.Status.Phase != costv1alpha1.PhaseDegraded {
+		t.Errorf("expected phase %q, got %q", costv1alpha1.PhaseDegraded, cfg.Status.Phase)
+	}
 }
 
 func TestReconcileValidation_KafkaReachable(t *testing.T) {

--- a/internal/resources/monitoring.go
+++ b/internal/resources/monitoring.go
@@ -150,18 +150,19 @@ func PrometheusRules(cfg *costv1alpha1.CostManagementServiceConfig) *unstructure
 				"description": "Database schema is not up to date for {{ $labels.customresource_name }}. Migrations may be stuck.",
 			},
 		},
-		// 4 — koku API unavailable
+		// 4 — koku API unavailable (scrape fail or target gone)
 		map[string]any{
 			"alert": "CostManagementAPIDown",
-			"expr":  `up{job="` + instance + `-koku-api",namespace="` + ns + `"} == 0`,
-			"for":   "5m",
+			"expr": `(up{job="` + instance + `-koku-api",namespace="` + ns + `"} == 0)` +
+				` or (absent(up{job="` + instance + `-koku-api",namespace="` + ns + `"}) == 1)`,
+			"for": "5m",
 			"labels": map[string]any{
 				"severity": "critical",
 				"instance": instance,
 			},
 			"annotations": map[string]any{
 				"summary":     "Cost Management API is unreachable",
-				"description": "The koku-api metrics endpoint has been unreachable for 5 minutes.",
+				"description": "The koku-api metrics endpoint has been down or absent for 5 minutes.",
 			},
 		},
 		// 5 — operator not progressing (stuck reconcile)

--- a/internal/resources/monitoring_test.go
+++ b/internal/resources/monitoring_test.go
@@ -1,0 +1,56 @@
+package resources
+
+import (
+	"strings"
+	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+
+	costv1alpha1 "github.com/project-koku/koku-service-operator/api/v1alpha1"
+)
+
+func TestPrometheusRules_APIDownTreatsAbsentUp(t *testing.T) {
+	cfg := &costv1alpha1.CostManagementServiceConfig{
+		ObjectMeta: metav1.ObjectMeta{Name: "cost-management", Namespace: "cost-onprem"},
+	}
+	pr := PrometheusRules(cfg)
+	expr := prometheusRuleExpr(t, pr, "CostManagementAPIDown")
+	if !strings.Contains(expr, `up{job="cost-management-koku-api",namespace="cost-onprem"} == 0`) {
+		t.Fatalf("APIDown missing up==0 clause: %s", expr)
+	}
+	if !strings.Contains(expr, `absent(up{job="cost-management-koku-api",namespace="cost-onprem"}) == 1`) {
+		t.Fatalf("APIDown missing absent(up) clause (COST-8109): %s", expr)
+	}
+	if !strings.Contains(expr, " or ") {
+		t.Fatalf("APIDown expected or of up==0 and absent(up): %s", expr)
+	}
+}
+
+func prometheusRuleExpr(t *testing.T, pr *unstructured.Unstructured, alert string) string {
+	t.Helper()
+	groups, found, err := unstructured.NestedSlice(pr.Object, "spec", "groups")
+	if err != nil || !found || len(groups) == 0 {
+		t.Fatalf("expected PrometheusRule groups, found=%v err=%v", found, err)
+	}
+	g0, ok := groups[0].(map[string]any)
+	if !ok {
+		t.Fatalf("group[0] type %T", groups[0])
+	}
+	rules, ok := g0["rules"].([]any)
+	if !ok {
+		t.Fatalf("rules type %T", g0["rules"])
+	}
+	for _, raw := range rules {
+		rule, ok := raw.(map[string]any)
+		if !ok {
+			continue
+		}
+		if rule["alert"] == alert {
+			expr, _ := rule["expr"].(string)
+			return expr
+		}
+	}
+	t.Fatalf("alert %q not found", alert)
+	return ""
+}


### PR DESCRIPTION
- address COST-8107 & COST-8109

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved status reporting when required dependencies like database, cache are unavailable.
  * Reconciliation now clearly marks the service as unavailable and degraded, includes dependency details, and retries when appropriate.
  * Updated monitoring alerts to detect both unavailable and missing metrics endpoints.

* **Tests**
  * Added coverage for degraded dependency states and missing monitoring metrics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->