### PR TITLE
[COST-8060] Add NetworkPolicy for Masu service

### DIFF
--- a/docs/gap_analysis/COST-7691.md
+++ b/docs/gap_analysis/COST-7691.md
@@ -7,7 +7,7 @@
 
 ## Verdict
 
-Substantial edge/TLS/SCC scaffolding exists (gateway + UI Routes, five NetworkPolicies, service-CA combine init, three dedicated SAs, app-pod restricted-v2 alignment, `status.phase → Ready` on pipeline success), but COST-7691 is **not done**. Remaining ticket gaps are incomplete NetworkPolicy coverage, incomplete dedicated ServiceAccounts, user-CA merge into the combined bundle, and Ready not gated on Route admission. ROS workers still on `default` is a real inconsistency but owned by [COST-8054](../jira/COST-8054.md).
+Substantial edge/TLS/SCC scaffolding exists (gateway + UI Routes, six NetworkPolicies including Masu, service-CA combine init, three dedicated SAs, app-pod restricted-v2 alignment, `status.phase → Ready` on pipeline success), but COST-7691 is **not done**. Remaining ticket gaps are incomplete NetworkPolicy coverage (UI, Listener, workers), incomplete dedicated ServiceAccounts, user-CA merge into the combined bundle, and Ready not gated on Route admission. ROS workers still on `default` is a real inconsistency but owned by [COST-8054](../jira/COST-8054.md).
 
 ## Sources
 
@@ -31,7 +31,7 @@ Out of scope per ticket: Monitoring (covered by COST-7692).
 | Deliverable | Status |
 |-------------|--------|
 | OpenShift Routes for gateway and UI with edge TLS termination | Partial — gateway defaults to edge; UI is **passthrough** (intentional) |
-| NetworkPolicies restricting traffic for all components | Partial — five ingress policies only |
+| NetworkPolicies restricting traffic for all components | Partial — six ingress policies (Masu added in [COST-8060](https://redhat.atlassian.net/browse/COST-8060)) |
 | CA bundle ConfigMap combining service CA and user-provided CAs | Partial — system + service CA combine ✅; general user-CA merge ❌ |
 | Dedicated ServiceAccounts per component | Partial — koku / ros / kruize only; many pods on `default`. ROS SA wiring → [COST-8054](../jira/COST-8054.md) |
 | All pods compliant with restricted-v2 SCC | Partial — app pods aligned; Django RO-root exception; bundled DB/cache need anyuid |
@@ -75,8 +75,9 @@ Applied in `reconcileEdge`. Tests in [`route_test.go`](../../internal/resources/
 | `KruizeNetworkPolicy` | `ros-optimization` | ROS processor / poller / housekeeper |
 | `RBACAPINetworkPolicy` | `rbac-api` | gateway, koku-api, masu, ros-api |
 | `KokuAPINetworkPolicy` | `cost-management-api` | gateway, masu, ros-housekeeper, monitoring |
+| `MasuNetworkPolicy` | `cost-processor` | monitoring only (port 9000; [COST-8060](https://redhat.atlassian.net/browse/COST-8060)) |
 
-All builders are **ingress-only** (`PolicyTypes: [Ingress]`). Controller `.Owns(&networkingv1.NetworkPolicy{})`; ClusterRole has NetworkPolicy CRUD. No NetworkPolicy unit tests found.
+All builders are **ingress-only** (`PolicyTypes: [Ingress]`). Controller `.Owns(&networkingv1.NetworkPolicy{})`; ClusterRole has NetworkPolicy CRUD. Unit tests in [`networkpolicies_test.go`](../../internal/resources/networkpolicies_test.go) (including Masu).
 
 ### CA combine scaffolding
 
@@ -135,10 +136,10 @@ ClusterRole / kubebuilder markers cover `route.openshift.io/routes` (+ `custom-h
 
 ### G1. NetworkPolicies for all components — partial
 
-Only five ingress policies exist. No policies for:
+Only six ingress policies exist (Masu added in [COST-8060](https://redhat.atlassian.net/browse/COST-8060)). No policies for:
 
 - `ui` — **beta should-have** (secured beta)
-- `cost-processor` (Masu), `listener`, `cost-scheduler`, `cost-worker-*` — Masu/Listener **beta should-have**; Celery workers P2
+- `listener`, `cost-scheduler`, `cost-worker-*` — Listener **beta should-have**; Celery workers P2
 - `rbac-worker` — P2 / with RBAC readiness work
 - `ros-api`, `ros-processor`, `ros-recommendation-poller`, `ros-housekeeper` — **→ [COST-8054](../jira/COST-8054.md)** (ROS)
 - Bundled `database` / `cache` (dev path) — defer

--- a/internal/controller/costmanagementserviceconfig_controller.go
+++ b/internal/controller/costmanagementserviceconfig_controller.go
@@ -729,6 +729,7 @@ func (r *CostManagementServiceConfigReconciler) reconcileEdge(ctx context.Contex
 		resources.IngressNetworkPolicy(cfg),
 		resources.RBACAPINetworkPolicy(cfg),
 		resources.KokuAPINetworkPolicy(cfg),
+		resources.MasuNetworkPolicy(cfg),
 	}
 	if costv1alpha1.ROSEnabled(cfg) {
 		netpols = append(netpols,

--- a/internal/controller/edge_test.go
+++ b/internal/controller/edge_test.go
@@ -130,6 +130,7 @@ func TestReconcileEdge_EnvoyReady_WithDomain_NoOAuth(t *testing.T) {
 	mustExist(t, r.Client, testNamespace, cfg.Name+"-ingress", &networkingv1.NetworkPolicy{})
 	mustExist(t, r.Client, testNamespace, cfg.Name+"-rbac-api", &networkingv1.NetworkPolicy{})
 	mustExist(t, r.Client, testNamespace, cfg.Name+"-koku-api", &networkingv1.NetworkPolicy{})
+	mustExist(t, r.Client, testNamespace, cfg.Name+"-masu", &networkingv1.NetworkPolicy{})
 	// Deploy defaults true → cache/db NetworkPolicies are applied.
 	mustExist(t, r.Client, testNamespace, cfg.Name+"-cache", &networkingv1.NetworkPolicy{})
 	mustExist(t, r.Client, testNamespace, cfg.Name+"-database", &networkingv1.NetworkPolicy{})

--- a/internal/resources/networkpolicies.go
+++ b/internal/resources/networkpolicies.go
@@ -216,6 +216,29 @@ func DatabaseNetworkPolicy(cfg *costv1alpha1.CostManagementServiceConfig) *netwo
 // Koku API
 // -----------------------------------------------------------------------------
 
+// MasuNetworkPolicy restricts ingress to Masu (cost-processor) pods.
+// Masu is ClusterIP-only and is not fronted by the Envoy gateway or a public
+// Route (COST-8060). In normal runtime no other workload calls Masu over HTTP;
+// report processing is driven by Kafka and Celery. This policy blocks casual
+// same-namespace access to admin endpoints on port 9000; app-level auth is
+// tracked under COST-7841. Prometheus may scrape metrics on the same port.
+func MasuNetworkPolicy(cfg *costv1alpha1.CostManagementServiceConfig) *networkingv1.NetworkPolicy {
+	const masuPort = int32(9000)
+	return netpol(cfg, cfg.Name+"-masu", "cost-processor", []networkingv1.NetworkPolicyIngressRule{
+		{
+			From: []networkingv1.NetworkPolicyPeer{
+				{NamespaceSelector: &metav1.LabelSelector{
+					MatchLabels: map[string]string{"network.openshift.io/policy-group": "monitoring"},
+				}},
+				{NamespaceSelector: &metav1.LabelSelector{
+					MatchLabels: map[string]string{"kubernetes.io/metadata.name": "openshift-monitoring"},
+				}},
+			},
+			Ports: []networkingv1.NetworkPolicyPort{tcpPort(masuPort)},
+		},
+	})
+}
+
 // KokuAPINetworkPolicy allows the gateway and internal services to reach the
 // Koku API on its Service port (8000), and Prometheus to scrape the metrics
 // port (9000).

--- a/internal/resources/networkpolicies_test.go
+++ b/internal/resources/networkpolicies_test.go
@@ -99,13 +99,54 @@ func TestMasuNetworkPolicy(t *testing.T) {
 	if len(np.Spec.Ingress) != 1 {
 		t.Fatalf("expected single monitoring rule, got %d", len(np.Spec.Ingress))
 	}
-	if !ruleAllowsPort(np.Spec.Ingress, masuPort) {
-		t.Errorf("missing masu port %d", masuPort)
+	rule := np.Spec.Ingress[0]
+	if len(rule.From) != 2 {
+		t.Fatalf("expected 2 monitoring namespace peers, got %d", len(rule.From))
 	}
-	for _, from := range np.Spec.Ingress[0].From {
+	wantNSLabels := []map[string]string{
+		{"network.openshift.io/policy-group": "monitoring"},
+		{"kubernetes.io/metadata.name": "openshift-monitoring"},
+	}
+	matched := make([]bool, len(wantNSLabels))
+	for _, from := range rule.From {
 		if from.PodSelector != nil {
-			t.Error("masu ingress must not allow arbitrary pod peers")
+			t.Error("masu ingress must not allow pod peers")
 		}
+		if from.IPBlock != nil {
+			t.Error("masu ingress must not allow IPBlock peers")
+		}
+		if from.NamespaceSelector == nil {
+			t.Fatal("masu ingress peer must use NamespaceSelector")
+		}
+		found := false
+		for i, want := range wantNSLabels {
+			if mapsEqual(from.NamespaceSelector.MatchLabels, want) {
+				if matched[i] {
+					t.Errorf("duplicate namespace peer MatchLabels %v", want)
+				}
+				matched[i] = true
+				found = true
+				break
+			}
+		}
+		if !found {
+			t.Errorf("unexpected namespace peer MatchLabels = %v", from.NamespaceSelector.MatchLabels)
+		}
+	}
+	for i, want := range wantNSLabels {
+		if !matched[i] {
+			t.Errorf("missing namespace peer MatchLabels %v", want)
+		}
+	}
+	if len(rule.Ports) != 1 {
+		t.Fatalf("expected single TCP port, got %d", len(rule.Ports))
+	}
+	port := rule.Ports[0]
+	if port.Port == nil || port.Port.IntVal != masuPort {
+		t.Errorf("port = %v, want TCP %d", port.Port, masuPort)
+	}
+	if port.Protocol == nil || *port.Protocol != corev1.ProtocolTCP {
+		t.Errorf("protocol = %v, want TCP", port.Protocol)
 	}
 }
 
@@ -248,6 +289,18 @@ func peerHasComponent(rule networkingv1.NetworkPolicyIngressRule, component stri
 		}
 	}
 	return false
+}
+
+func mapsEqual(a, b map[string]string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for k, v := range a {
+		if b[k] != v {
+			return false
+		}
+	}
+	return true
 }
 
 func ruleAllowsPort(rules []networkingv1.NetworkPolicyIngressRule, port int32) bool {

--- a/internal/resources/networkpolicies_test.go
+++ b/internal/resources/networkpolicies_test.go
@@ -85,6 +85,30 @@ func TestRBACAPINetworkPolicy(t *testing.T) {
 	}
 }
 
+func TestMasuNetworkPolicy(t *testing.T) {
+	const masuPort = int32(9000)
+	cfg := testCfg()
+	np := MasuNetworkPolicy(cfg)
+	if np.Name != cfg.Name+"-masu" {
+		t.Errorf("Name = %q", np.Name)
+	}
+	assertIngressOnly(t, np)
+	if got := np.Spec.PodSelector.MatchLabels[labelComponent]; got != "cost-processor" {
+		t.Errorf("podSelector component = %q, want cost-processor", got)
+	}
+	if len(np.Spec.Ingress) != 1 {
+		t.Fatalf("expected single monitoring rule, got %d", len(np.Spec.Ingress))
+	}
+	if !ruleAllowsPort(np.Spec.Ingress, masuPort) {
+		t.Errorf("missing masu port %d", masuPort)
+	}
+	for _, from := range np.Spec.Ingress[0].From {
+		if from.PodSelector != nil {
+			t.Error("masu ingress must not allow arbitrary pod peers")
+		}
+	}
+}
+
 func TestKokuAPINetworkPolicy(t *testing.T) {
 	const (
 		kokuAPIPort     = int32(8000)


### PR DESCRIPTION
## Jira Ticket
[COST-8060](https://redhat.atlassian.net/browse/COST-8060)

## Summary

- Add `MasuNetworkPolicy` selecting `cost-processor` pods and allowing ingress on port 9000 only from OpenShift monitoring namespaces (metrics scrape).
- Wire the policy in `reconcileEdge` alongside the other core NetworkPolicies.
- Partial close of [COST-7691](https://redhat.atlassian.net/browse/COST-7691) G1 (Masu); no Route or Envoy path added for Masu.

Masu remains ClusterIP-only. In normal runtime no other workload calls Masu over HTTP (processing is Kafka/Celery-driven); this is defense-in-depth with app-level auth ([COST-7841](https://redhat.atlassian.net/browse/COST-7841)).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Adds `MasuNetworkPolicy` for `cost-processor` pods.
- Allows ingress on TCP port 9000 only from OpenShift monitoring namespaces.
- Applies the policy during `reconcileEdge`.
- Adds unit and reconciliation coverage.
- Keeps Masu ClusterIP-only. No Route or Envoy path is added.

## Operator impact

- CRD API compatibility is unchanged.
- Reconciliation now creates the Masu NetworkPolicy with the other core policies.
- RBAC requirements are unchanged.
- User-visible status conditions are unchanged.
- This partially closes COST-7691 G1 for Masu.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->