### PR TITLE
(COST-7683) Default omitted Ingress stagingBucket to Cost storage bucketName

### DIFF
--- a/api/v1alpha1/costmanagementserviceconfig_types.go
+++ b/api/v1alpha1/costmanagementserviceconfig_types.go
@@ -368,7 +368,8 @@ type IngressConfig struct {
 	// +kubebuilder:default:="hccm"
 	ValidTypes string `json:"validTypes,omitempty"`
 	// Staging bucket name for uploads.
-	// +kubebuilder:default:="insights-upload-perma"
+	// When empty, the operator uses spec.costManagement.storage.bucketName,
+	// then "koku-bucket".
 	StagingBucket string                      `json:"stagingBucket,omitempty"`
 	Resources     corev1.ResourceRequirements `json:"resources,omitempty"`
 }

--- a/api/v1alpha1/costmanagementserviceconfig_types.go
+++ b/api/v1alpha1/costmanagementserviceconfig_types.go
@@ -368,7 +368,8 @@ type IngressConfig struct {
 	// +kubebuilder:default:="hccm"
 	ValidTypes string `json:"validTypes,omitempty"`
 	// Staging bucket name for uploads.
-	// When empty, the operator uses spec.costManagement.storage.bucketName,
+	// When empty, the operator uses the same bucket as Koku REQUESTED_BUCKET
+	// (status.discoveredConfig.s3.bucket, else spec.costManagement.storage.bucketName),
 	// then "koku-bucket".
 	StagingBucket string                      `json:"stagingBucket,omitempty"`
 	Resources     corev1.ResourceRequirements `json:"resources,omitempty"`

--- a/bundle/manifests/service.costmanagement.openshift.io_costmanagementserviceconfigs.yaml
+++ b/bundle/manifests/service.costmanagement.openshift.io_costmanagementserviceconfigs.yaml
@@ -1623,8 +1623,10 @@ spec:
                         type: object
                     type: object
                   stagingBucket:
-                    default: insights-upload-perma
-                    description: Staging bucket name for uploads.
+                    description: |-
+                      Staging bucket name for uploads.
+                      When empty, the operator uses spec.costManagement.storage.bucketName,
+                      then "koku-bucket".
                     type: string
                   validTypes:
                     default: hccm

--- a/bundle/manifests/service.costmanagement.openshift.io_costmanagementserviceconfigs.yaml
+++ b/bundle/manifests/service.costmanagement.openshift.io_costmanagementserviceconfigs.yaml
@@ -1625,7 +1625,8 @@ spec:
                   stagingBucket:
                     description: |-
                       Staging bucket name for uploads.
-                      When empty, the operator uses spec.costManagement.storage.bucketName,
+                      When empty, the operator uses the same bucket as Koku REQUESTED_BUCKET
+                      (status.discoveredConfig.s3.bucket, else spec.costManagement.storage.bucketName),
                       then "koku-bucket".
                     type: string
                   validTypes:

--- a/config/crd/bases/service.costmanagement.openshift.io_costmanagementserviceconfigs.yaml
+++ b/config/crd/bases/service.costmanagement.openshift.io_costmanagementserviceconfigs.yaml
@@ -1623,8 +1623,10 @@ spec:
                         type: object
                     type: object
                   stagingBucket:
-                    default: insights-upload-perma
-                    description: Staging bucket name for uploads.
+                    description: |-
+                      Staging bucket name for uploads.
+                      When empty, the operator uses spec.costManagement.storage.bucketName,
+                      then "koku-bucket".
                     type: string
                   validTypes:
                     default: hccm

--- a/config/crd/bases/service.costmanagement.openshift.io_costmanagementserviceconfigs.yaml
+++ b/config/crd/bases/service.costmanagement.openshift.io_costmanagementserviceconfigs.yaml
@@ -1625,7 +1625,8 @@ spec:
                   stagingBucket:
                     description: |-
                       Staging bucket name for uploads.
-                      When empty, the operator uses spec.costManagement.storage.bucketName,
+                      When empty, the operator uses the same bucket as Koku REQUESTED_BUCKET
+                      (status.discoveredConfig.s3.bucket, else spec.costManagement.storage.bucketName),
                       then "koku-bucket".
                     type: string
                   validTypes:

--- a/internal/resources/ingress.go
+++ b/internal/resources/ingress.go
@@ -76,7 +76,8 @@ func IngressDeployment(cfg *costv1alpha1.CostManagementServiceConfig) *appsv1.De
 	}
 	stagingBucket := spec.StagingBucket
 	if stagingBucket == "" {
-		stagingBucket = cfg.Spec.CostManagement.Storage.BucketName
+		// Same resolution as Koku REQUESTED_BUCKET: discovered S3 bucket, then spec.
+		stagingBucket = S3Bucket(cfg)
 	}
 	if stagingBucket == "" {
 		stagingBucket = "koku-bucket"

--- a/internal/resources/ingress.go
+++ b/internal/resources/ingress.go
@@ -76,7 +76,10 @@ func IngressDeployment(cfg *costv1alpha1.CostManagementServiceConfig) *appsv1.De
 	}
 	stagingBucket := spec.StagingBucket
 	if stagingBucket == "" {
-		stagingBucket = "insights-upload-perma"
+		stagingBucket = cfg.Spec.CostManagement.Storage.BucketName
+	}
+	if stagingBucket == "" {
+		stagingBucket = "koku-bucket"
 	}
 
 	env := []corev1.EnvVar{

--- a/internal/resources/ingress_test.go
+++ b/internal/resources/ingress_test.go
@@ -80,6 +80,7 @@ func TestIngressDeployment(t *testing.T) {
 		"INGRESS_WEBPORT":              "8080",
 		"INGRESS_METRICSPORT":          "9000",
 		"INGRESS_MINIOENDPOINT":        "minio.cost-byoi-infra.svc:9000",
+		"INGRESS_STAGEBUCKET":          "koku-bucket",
 		"INGRESS_USESSL":               "false",
 		"INGRESS_VALID_UPLOAD_TYPES":   "hccm",
 		"INGRESS_STAGERIMPLEMENTATION": "s3",
@@ -105,6 +106,42 @@ func TestIngressDeployment(t *testing.T) {
 	}
 	if len(d.Spec.Template.Spec.InitContainers) == 0 {
 		t.Error("expected CA combine init container")
+	}
+}
+
+func TestIngressDeploymentStageBucket(t *testing.T) {
+	tests := []struct {
+		name          string
+		stagingBucket string
+		bucketName    string
+		want          string
+	}{
+		{
+			name: "omitted staging and bucketName falls back to koku-bucket",
+			want: "koku-bucket",
+		},
+		{
+			name:       "omitted staging uses costManagement.storage.bucketName",
+			bucketName: "my-data",
+			want:       "my-data",
+		},
+		{
+			name:          "explicit stagingBucket is honored over bucketName",
+			stagingBucket: "insights-upload-perma",
+			bucketName:    "koku-bucket",
+			want:          "insights-upload-perma",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := ingressCfg()
+			cfg.Spec.Ingress.StagingBucket = tt.stagingBucket
+			cfg.Spec.CostManagement.Storage.BucketName = tt.bucketName
+			env := envValues(IngressDeployment(cfg).Spec.Template.Spec.Containers[0])
+			if got := env["INGRESS_STAGEBUCKET"]; got != tt.want {
+				t.Errorf("INGRESS_STAGEBUCKET = %q, want %q", got, tt.want)
+			}
+		})
 	}
 }
 

--- a/internal/resources/ingress_test.go
+++ b/internal/resources/ingress_test.go
@@ -111,10 +111,11 @@ func TestIngressDeployment(t *testing.T) {
 
 func TestIngressDeploymentStageBucket(t *testing.T) {
 	tests := []struct {
-		name          string
-		stagingBucket string
-		bucketName    string
-		want          string
+		name             string
+		stagingBucket    string
+		bucketName       string
+		discoveredBucket string
+		want             string
 	}{
 		{
 			name: "omitted staging and bucketName falls back to koku-bucket",
@@ -126,10 +127,23 @@ func TestIngressDeploymentStageBucket(t *testing.T) {
 			want:       "my-data",
 		},
 		{
+			name:             "omitted staging prefers discovered S3 bucket over spec",
+			bucketName:       "koku-bucket",
+			discoveredBucket: "obc-provisioned-bucket",
+			want:             "obc-provisioned-bucket",
+		},
+		{
 			name:          "explicit stagingBucket is honored over bucketName",
 			stagingBucket: "insights-upload-perma",
 			bucketName:    "koku-bucket",
 			want:          "insights-upload-perma",
+		},
+		{
+			name:             "explicit stagingBucket is honored over discovered bucket",
+			stagingBucket:    "insights-upload-perma",
+			bucketName:       "koku-bucket",
+			discoveredBucket: "obc-provisioned-bucket",
+			want:             "insights-upload-perma",
 		},
 	}
 	for _, tt := range tests {
@@ -137,6 +151,11 @@ func TestIngressDeploymentStageBucket(t *testing.T) {
 			cfg := ingressCfg()
 			cfg.Spec.Ingress.StagingBucket = tt.stagingBucket
 			cfg.Spec.CostManagement.Storage.BucketName = tt.bucketName
+			if tt.discoveredBucket != "" {
+				cfg.Status.DiscoveredConfig = &costv1alpha1.DiscoveredConfig{
+					S3: &costv1alpha1.DiscoveredS3{Bucket: tt.discoveredBucket},
+				}
+			}
 			env := envValues(IngressDeployment(cfg).Spec.Template.Spec.Containers[0])
 			if got := env["INGRESS_STAGEBUCKET"]; got != tt.want {
 				t.Errorf("INGRESS_STAGEBUCKET = %q, want %q", got, tt.want)


### PR DESCRIPTION
## Summary

[Jira Ticket](https://redhat.atlassian.net/browse/COST-7683) (Item 6)

- Ingress uploads no longer default to `insights-upload-perma`. New CRs that omit `spec.ingress.stagingBucket` use Cost storage (`spec.costManagement.storage.bucketName`, then `koku-bucket`), matching the bucket BYOI MinIO actually creates.
- Removed the CRD `+kubebuilder:default` so the API server leaves the field empty; `IngressDeployment` sets `INGRESS_STAGEBUCKET` with that three-step Go fallback. An explicit `stagingBucket` is still honored.
- Regenerated CRD bases and bundle OpenAPI (no default on `stagingBucket`). Operator still does not create buckets.

Existing CRs that already stored `stagingBucket: insights-upload-perma` from the old CRD default keep that value until the field is cleared.

## Test plan

- [ ] `make generate manifests`
- [ ] `go test ./internal/resources/ -count=1 -run Ingress`
- [ ] `go test ./internal/resources/ ./api/v1alpha1/ -count=1`
- [ ] Confirm CRD YAML has no `default: insights-upload-perma` on `stagingBucket` (`config/crd/bases/` and `bundle/manifests/`)
- [ ] Optional: smoke a CR without `stagingBucket` against MinIO with `koku-bucket` and confirm uploads land there

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- New custom resources use `spec.costManagement.storage.bucketName` for `INGRESS_STAGEBUCKET` when `spec.ingress.stagingBucket` is empty.
- Resources use `koku-bucket` when both values are empty.
- Explicit `spec.ingress.stagingBucket` values remain unchanged.
- Existing resources that stored `insights-upload-perma` retain that value until cleared.
- The CRD default was removed. This preserves API compatibility without changing existing stored values.
- The operator does not create storage buckets.
- No RBAC or user-visible status condition changes are included.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->