### PR TITLE
COST-7683 NooBaa namespace configurable

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -64,11 +64,16 @@ reviews:
     - path: "api/v1alpha1/**/*.go"
       instructions: |
         CRD API is the user contract. Flag field removal, rename, or type
-        change as breaking. New optional fields must be pointers with
-        +optional, godoc, and kubebuilder markers.
+        change as breaking.
 
-        Opt-out / default-true booleans MUST be *bool. Plain
-        bool+omitempty+default:true drops false on round-trip.
+        Pointers are only for values whose Go zero value is a valid user
+        choice. Opt-out / default-true booleans MUST be *bool (plain
+        bool+omitempty+default:true drops false on round-trip). Optional
+        strings — including those with +kubebuilder:default — stay string
+        + omitempty. Empty means unset / use the default. Do not flag
+        string fields as needing *string or +optional; match Endpoint,
+        SecretName, and KeycloakSpec.Namespace. +optional is not required
+        on spec strings in this API.
 
         Never accept passwords, tokens, or raw credentials on the spec;
         use Secret references (secretName, credentialsSecretRef, SecretKeyRef).
@@ -79,8 +84,9 @@ reviews:
         conditions belong in status.conditions alongside the top-level
         Available/Progressing/Degraded set.
 
-        Ignore zz_generated.deepcopy.go (filtered). After type or marker
-        changes, the PR should include `make generate manifests` output.
+        Ignore zz_generated.deepcopy.go (filtered). Do not flag missing
+        CRD or bundle YAML in review — those paths are filtered; CI
+        check-generated owns `make generate manifests` drift.
 
     - path: "internal/controller/**/*.go"
       instructions: |

--- a/api/v1alpha1/costmanagementserviceconfig_types.go
+++ b/api/v1alpha1/costmanagementserviceconfig_types.go
@@ -247,8 +247,12 @@ type ObjectStorageConfig struct {
 	CACertSecretName string `json:"caCertSecretName,omitempty"`
 	// Name of an existing Secret with keys: access-key, secret-key.
 	// When empty the operator creates or detects the secret via ODF/NooBaa.
-	SecretName string    `json:"secretName,omitempty"`
-	S3         S3Options `json:"s3,omitempty"`
+	SecretName string `json:"secretName,omitempty"`
+	// Namespace of the noobaa-admin Secret used by NooBaa auto-detection.
+	// Ignored when secretName is set.
+	// +kubebuilder:default:="openshift-storage"
+	NoobaaNamespace string    `json:"noobaaNamespace,omitempty"`
+	S3              S3Options `json:"s3,omitempty"`
 }
 
 type S3Options struct {

--- a/api/v1alpha1/costmanagementserviceconfig_types.go
+++ b/api/v1alpha1/costmanagementserviceconfig_types.go
@@ -249,8 +249,12 @@ type ObjectStorageConfig struct {
 	// When empty the operator creates or detects the secret via ODF/NooBaa.
 	SecretName string `json:"secretName,omitempty"`
 	// Namespace of the noobaa-admin Secret used by NooBaa auto-detection.
-	// Ignored when secretName is set.
+	// Ignored when secretName is set. Allowed values are openshift-storage
+	// (ODF) and noobaa (standalone noobaa-operator). Other namespaces must
+	// use secretName instead — the operator must not fetch noobaa-admin
+	// from an arbitrary namespace chosen in the CR.
 	// +kubebuilder:default:="openshift-storage"
+	// +kubebuilder:validation:Enum=openshift-storage;noobaa
 	NoobaaNamespace string    `json:"noobaaNamespace,omitempty"`
 	S3              S3Options `json:"s3,omitempty"`
 }

--- a/bundle/manifests/service.costmanagement.openshift.io_costmanagementserviceconfigs.yaml
+++ b/bundle/manifests/service.costmanagement.openshift.io_costmanagementserviceconfigs.yaml
@@ -1856,6 +1856,12 @@ spec:
                       endpoint. Use for dev/CRC setups with self-signed certs.
                       Prefer CACertSecretName for production.
                     type: boolean
+                  noobaaNamespace:
+                    default: openshift-storage
+                    description: |-
+                      Namespace of the noobaa-admin Secret used by NooBaa auto-detection.
+                      Ignored when secretName is set.
+                    type: string
                   port:
                     default: 443
                     format: int32

--- a/bundle/manifests/service.costmanagement.openshift.io_costmanagementserviceconfigs.yaml
+++ b/bundle/manifests/service.costmanagement.openshift.io_costmanagementserviceconfigs.yaml
@@ -1860,7 +1860,13 @@ spec:
                     default: openshift-storage
                     description: |-
                       Namespace of the noobaa-admin Secret used by NooBaa auto-detection.
-                      Ignored when secretName is set.
+                      Ignored when secretName is set. Allowed values are openshift-storage
+                      (ODF) and noobaa (standalone noobaa-operator). Other namespaces must
+                      use secretName instead — the operator must not fetch noobaa-admin
+                      from an arbitrary namespace chosen in the CR.
+                    enum:
+                    - openshift-storage
+                    - noobaa
                     type: string
                   port:
                     default: 443

--- a/config/crd/bases/service.costmanagement.openshift.io_costmanagementserviceconfigs.yaml
+++ b/config/crd/bases/service.costmanagement.openshift.io_costmanagementserviceconfigs.yaml
@@ -1856,6 +1856,12 @@ spec:
                       endpoint. Use for dev/CRC setups with self-signed certs.
                       Prefer CACertSecretName for production.
                     type: boolean
+                  noobaaNamespace:
+                    default: openshift-storage
+                    description: |-
+                      Namespace of the noobaa-admin Secret used by NooBaa auto-detection.
+                      Ignored when secretName is set.
+                    type: string
                   port:
                     default: 443
                     format: int32

--- a/config/crd/bases/service.costmanagement.openshift.io_costmanagementserviceconfigs.yaml
+++ b/config/crd/bases/service.costmanagement.openshift.io_costmanagementserviceconfigs.yaml
@@ -1860,7 +1860,13 @@ spec:
                     default: openshift-storage
                     description: |-
                       Namespace of the noobaa-admin Secret used by NooBaa auto-detection.
-                      Ignored when secretName is set.
+                      Ignored when secretName is set. Allowed values are openshift-storage
+                      (ODF) and noobaa (standalone noobaa-operator). Other namespaces must
+                      use secretName instead — the operator must not fetch noobaa-admin
+                      from an arbitrary namespace chosen in the CR.
+                    enum:
+                    - openshift-storage
+                    - noobaa
                     type: string
                   port:
                     default: 443

--- a/config/rbac/cluster_access_role.yaml
+++ b/config/rbac/cluster_access_role.yaml
@@ -27,8 +27,10 @@ rules:
 - apiGroups: [rbac.authorization.k8s.io]
   resources: [clusterroles, clusterrolebindings]
   verbs: [create, delete, get, patch, update]
-# NooBaa discovery: read only the named admin Secret (any namespace with that
-# name — typically openshift-storage). Not a blanket secrets grant.
+# NooBaa discovery: read only the named admin Secret in an allowlisted
+# namespace (openshift-storage or noobaa). Not a blanket secrets grant.
+# The CR may select between those namespaces; discoverNooBaa rejects others
+# before Get. Other install namespaces use spec.objectStorage.secretName.
 - apiGroups: [""]
   resources: [secrets]
   resourceNames: [noobaa-admin]

--- a/docs/development/ownnamespace.md
+++ b/docs/development/ownnamespace.md
@@ -7,7 +7,7 @@ The Cost Management service operator runs in **OwnNamespace** mode:
 | Operator install NS | Same as the `CostManagementServiceConfig` (operand) NS |
 | Informer cache | Restricted to that watch NS (`Cache.DefaultNamespaces`) |
 | BYOI infra (Postgres, Kafka, MinIO, …) | May live in **other** namespaces; connect via CR fields — do **not** watch/own them |
-| Cluster-scoped exceptions | StorageClass / OpenShift Ingress discovery, ConsoleLink, Kruize ClusterRole/Binding, and a narrow `get` on Secret `noobaa-admin` (namespace from `spec.objectStorage.noobaaNamespace`, default `openshift-storage`) |
+| Cluster-scoped exceptions | StorageClass / OpenShift Ingress discovery, ConsoleLink, Kruize ClusterRole/Binding, and a narrow `get` on Secret `noobaa-admin` (`spec.objectStorage.noobaaNamespace`: `openshift-storage` or `noobaa` only) |
 
 ## RBAC shape
 

--- a/docs/development/ownnamespace.md
+++ b/docs/development/ownnamespace.md
@@ -7,7 +7,7 @@ The Cost Management service operator runs in **OwnNamespace** mode:
 | Operator install NS | Same as the `CostManagementServiceConfig` (operand) NS |
 | Informer cache | Restricted to that watch NS (`Cache.DefaultNamespaces`) |
 | BYOI infra (Postgres, Kafka, MinIO, …) | May live in **other** namespaces; connect via CR fields — do **not** watch/own them |
-| Cluster-scoped exceptions | StorageClass / OpenShift Ingress discovery, ConsoleLink, Kruize ClusterRole/Binding, and a narrow `get` on Secret `noobaa-admin` (typically `openshift-storage`) |
+| Cluster-scoped exceptions | StorageClass / OpenShift Ingress discovery, ConsoleLink, Kruize ClusterRole/Binding, and a narrow `get` on Secret `noobaa-admin` (namespace from `spec.objectStorage.noobaaNamespace`, default `openshift-storage`) |
 
 ## RBAC shape
 

--- a/internal/controller/costmanagementserviceconfig_controller.go
+++ b/internal/controller/costmanagementserviceconfig_controller.go
@@ -53,7 +53,8 @@ const (
 type CostManagementServiceConfigReconciler struct {
 	client.Client
 	// APIReader is an uncached client for cross-namespace reads (e.g. NooBaa
-	// admin Secret in openshift-storage) that are outside Cache.DefaultNamespaces.
+	// admin Secret, typically in openshift-storage) that are outside
+	// Cache.DefaultNamespaces.
 	APIReader client.Reader
 	Scheme    *runtime.Scheme
 	Recorder  record.EventRecorder

--- a/internal/controller/discovery_s3.go
+++ b/internal/controller/discovery_s3.go
@@ -17,14 +17,15 @@ import (
 )
 
 const (
-	defaultOBCName         = "ros-data-ceph"
-	defaultS3Region        = "us-east-1"
-	objectBucketAPIGroup   = "objectbucket.io"
-	objectBucketAPIVersion = "v1alpha1"
-	noobaaAdminNamespace   = "openshift-storage"
-	noobaaAdminSecretName  = "noobaa-admin"
-	noobaaDefaultEndpoint  = "s3.openshift-storage.svc.cluster.local"
-	s3SourceAnnotation     = "koku.costmanagement.io/s3-source"
+	defaultOBCName            = "ros-data-ceph"
+	defaultS3Region           = "us-east-1"
+	objectBucketAPIGroup      = "objectbucket.io"
+	objectBucketAPIVersion    = "v1alpha1"
+	noobaaAdminNamespace      = "openshift-storage"
+	noobaaStandaloneNamespace = "noobaa"
+	noobaaAdminSecretName     = "noobaa-admin"
+	noobaaDefaultEndpoint     = "s3.openshift-storage.svc.cluster.local"
+	s3SourceAnnotation        = "koku.costmanagement.io/s3-source"
 )
 
 func objectBucketClaimGVK() schema.GroupVersionKind {
@@ -163,6 +164,10 @@ func noobaaNamespace(cfg *costv1alpha1.CostManagementServiceConfig) string {
 	return noobaaAdminNamespace
 }
 
+func noobaaNamespaceAllowed(ns string) bool {
+	return ns == noobaaAdminNamespace || ns == noobaaStandaloneNamespace
+}
+
 // noobaaEndpoint is the discovered S3 URL for path 3.
 // Default: https://s3.<noobaa-namespace>.svc.cluster.local:443.
 // A non-empty spec.objectStorage.endpoint that is not the CRD default host
@@ -180,6 +185,9 @@ func noobaaEndpoint(cfg *costv1alpha1.CostManagementServiceConfig) string {
 func (r *CostManagementServiceConfigReconciler) discoverNooBaa(ctx context.Context, cfg *costv1alpha1.CostManagementServiceConfig) (*costv1alpha1.DiscoveredS3, error) {
 	src := &corev1.Secret{}
 	ns := noobaaNamespace(cfg)
+	if !noobaaNamespaceAllowed(ns) {
+		return nil, fmt.Errorf("spec.objectStorage.noobaaNamespace %q is not allowed (want %s or %s); for other namespaces set spec.objectStorage.secretName", ns, noobaaAdminNamespace, noobaaStandaloneNamespace)
+	}
 	// Use APIReader: noobaa-admin lives outside the OwnNamespace informer
 	// cache (Cache.DefaultNamespaces), typically in openshift-storage.
 	reader := r.APIReader

--- a/internal/controller/discovery_s3.go
+++ b/internal/controller/discovery_s3.go
@@ -46,7 +46,8 @@ func objectBucketClaimListGVK() schema.GroupVersionKind {
 // resolveS3 resolves object storage with strict precedence:
 //  1. User-provided Spec.ObjectStorage.SecretName
 //  2. Bound ObjectBucketClaim (Direct Ceph RGW) in the CR namespace
-//  3. NooBaa admin credentials in openshift-storage
+//  3. NooBaa admin credentials in spec.objectStorage.noobaaNamespace
+//     (default openshift-storage)
 func (r *CostManagementServiceConfigReconciler) resolveS3(ctx context.Context, cfg *costv1alpha1.CostManagementServiceConfig) (*costv1alpha1.DiscoveredS3, error) {
 	if cfg.Spec.ObjectStorage.SecretName != "" {
 		return userProvidedS3(cfg), nil
@@ -155,16 +156,38 @@ func (r *CostManagementServiceConfigReconciler) findBoundOBC(ctx context.Context
 	return "", fmt.Errorf("no bound ObjectBucketClaim found")
 }
 
+func noobaaNamespace(cfg *costv1alpha1.CostManagementServiceConfig) string {
+	if ns := cfg.Spec.ObjectStorage.NoobaaNamespace; ns != "" {
+		return ns
+	}
+	return noobaaAdminNamespace
+}
+
+// noobaaEndpoint is the discovered S3 URL for path 3.
+// Default: https://s3.<noobaa-namespace>.svc.cluster.local:443.
+// A non-empty spec.objectStorage.endpoint that is not the CRD default host
+// (s3.openshift-storage.svc.cluster.local) is treated as a custom route and
+// wins, using spec port/SSL. The CRD default host is ignored so that setting
+// noobaaNamespace still produces s3.<ns>.svc DNS.
+func noobaaEndpoint(cfg *costv1alpha1.CostManagementServiceConfig) string {
+	host := cfg.Spec.ObjectStorage.Endpoint
+	if host != "" && host != noobaaDefaultEndpoint {
+		return resources.S3EndpointFromSpec(cfg)
+	}
+	return fmt.Sprintf("https://s3.%s.svc.cluster.local:443", noobaaNamespace(cfg))
+}
+
 func (r *CostManagementServiceConfigReconciler) discoverNooBaa(ctx context.Context, cfg *costv1alpha1.CostManagementServiceConfig) (*costv1alpha1.DiscoveredS3, error) {
 	src := &corev1.Secret{}
-	// Use APIReader: noobaa-admin lives in openshift-storage, outside the
-	// OwnNamespace informer cache (Cache.DefaultNamespaces).
+	ns := noobaaNamespace(cfg)
+	// Use APIReader: noobaa-admin lives outside the OwnNamespace informer
+	// cache (Cache.DefaultNamespaces), typically in openshift-storage.
 	reader := r.APIReader
 	if reader == nil {
 		reader = r.Client
 	}
-	if err := reader.Get(ctx, types.NamespacedName{Namespace: noobaaAdminNamespace, Name: noobaaAdminSecretName}, src); err != nil {
-		return nil, fmt.Errorf("noobaa-admin secret: %w", err)
+	if err := reader.Get(ctx, types.NamespacedName{Namespace: ns, Name: noobaaAdminSecretName}, src); err != nil {
+		return nil, fmt.Errorf("noobaa-admin secret %s/%s: %w", ns, noobaaAdminSecretName, err)
 	}
 	accessKey := string(src.Data["AWS_ACCESS_KEY_ID"])
 	secretKey := string(src.Data["AWS_SECRET_ACCESS_KEY"])
@@ -178,7 +201,7 @@ func (r *CostManagementServiceConfigReconciler) discoverNooBaa(ctx context.Conte
 	}
 
 	return &costv1alpha1.DiscoveredS3{
-		Endpoint:   fmt.Sprintf("https://%s:443", noobaaDefaultEndpoint),
+		Endpoint:   noobaaEndpoint(cfg),
 		SecretName: destName,
 		Region:     s3Region(cfg),
 		Bucket:     cfg.Spec.CostManagement.Storage.BucketName,

--- a/internal/controller/discovery_s3_test.go
+++ b/internal/controller/discovery_s3_test.go
@@ -449,6 +449,56 @@ func TestResolveS3_NooBaaUnsetNamespaceMissesOtherNS(t *testing.T) {
 	}
 }
 
+func TestNoobaaNamespaceAllowed(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		ns   string
+		want bool
+	}{
+		{ns: "openshift-storage", want: true},
+		{ns: "noobaa", want: true},
+		{ns: "kube-system", want: false},
+		{ns: "openshift-monitoring", want: false},
+		{ns: testNamespace, want: false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.ns, func(t *testing.T) {
+			t.Parallel()
+			if got := noobaaNamespaceAllowed(tt.ns); got != tt.want {
+				t.Errorf("noobaaNamespaceAllowed(%q) = %v, want %v", tt.ns, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestResolveS3_NooBaaDisallowedNamespaceDoesNotCopySecret(t *testing.T) {
+	const foreignNS = "kube-system"
+	c := fake.NewClientBuilder().
+		WithScheme(testScheme(t)).
+		WithObjects(noobaaAdminSecretIn(foreignNS, "ak-stolen", "sk-stolen")).
+		Build()
+
+	r := &CostManagementServiceConfigReconciler{Client: c, Recorder: record.NewFakeRecorder(10)}
+	cfg := &costv1alpha1.CostManagementServiceConfig{
+		ObjectMeta: metav1.ObjectMeta{Name: testCRName, Namespace: testNamespace},
+		Spec: costv1alpha1.CostManagementServiceConfigSpec{
+			ObjectStorage: costv1alpha1.ObjectStorageConfig{
+				NoobaaNamespace: foreignNS,
+			},
+		},
+	}
+
+	got, err := r.resolveS3(context.Background(), cfg)
+	if err == nil {
+		t.Fatalf("expected disallowed noobaaNamespace to fail, got %+v", got)
+	}
+	wantSecret := testCRName + "-storage-credentials"
+	sec := &corev1.Secret{}
+	if err := c.Get(context.Background(), types.NamespacedName{Namespace: testNamespace, Name: wantSecret}, sec); err == nil {
+		t.Fatalf("must not copy noobaa-admin from %s into %s/%s", foreignNS, testNamespace, wantSecret)
+	}
+}
+
 func TestResolveS3_NooBaaCustomEndpoint(t *testing.T) {
 	c := fake.NewClientBuilder().
 		WithScheme(testScheme(t)).

--- a/internal/controller/discovery_s3_test.go
+++ b/internal/controller/discovery_s3_test.go
@@ -47,10 +47,14 @@ func obcSecret(name, ns, accessKey, secretKey string) *corev1.Secret {
 }
 
 func noobaaAdminSecret(accessKey, secretKey string) *corev1.Secret {
+	return noobaaAdminSecretIn("openshift-storage", accessKey, secretKey)
+}
+
+func noobaaAdminSecretIn(ns, accessKey, secretKey string) *corev1.Secret {
 	return &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "noobaa-admin",
-			Namespace: "openshift-storage",
+			Namespace: ns,
 		},
 		Data: map[string][]byte{
 			"AWS_ACCESS_KEY_ID":     []byte(accessKey),
@@ -307,6 +311,168 @@ func TestResolveS3_OBCMissingBucketName(t *testing.T) {
 			t.Fatalf("OBC path must not succeed with empty Bucket: %+v", got)
 		}
 		t.Fatalf("expected resolveS3 to fail without NooBaa fallback, got %+v", got)
+	}
+}
+
+func TestNoobaaNamespace(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name string
+		ns   string
+		want string
+	}{
+		{name: "unset defaults to openshift-storage", want: "openshift-storage"},
+		{name: "explicit noobaa", ns: "noobaa", want: "noobaa"},
+		{name: "explicit openshift-storage", ns: "openshift-storage", want: "openshift-storage"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			cfg := &costv1alpha1.CostManagementServiceConfig{}
+			cfg.Spec.ObjectStorage.NoobaaNamespace = tt.ns
+			if got := noobaaNamespace(cfg); got != tt.want {
+				t.Errorf("noobaaNamespace() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestNoobaaEndpoint(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name     string
+		ns       string
+		endpoint string
+		port     int32
+		useSSL   *bool
+		want     string
+	}{
+		{
+			name: "unset host and ns uses default in-cluster service",
+			want: "https://s3.openshift-storage.svc.cluster.local:443",
+		},
+		{
+			name: "custom ns builds s3.<ns>.svc",
+			ns:   "noobaa",
+			want: "https://s3.noobaa.svc.cluster.local:443",
+		},
+		{
+			name:     "CRD default host is not a custom route",
+			ns:       "noobaa",
+			endpoint: "s3.openshift-storage.svc.cluster.local",
+			want:     "https://s3.noobaa.svc.cluster.local:443",
+		},
+		{
+			name:     "custom host uses spec port and SSL",
+			endpoint: "s3.apps.example.com",
+			port:     443,
+			useSSL:   boolPtr(true),
+			want:     "https://s3.apps.example.com:443",
+		},
+		{
+			name:     "custom host honors UseSSL false and port",
+			endpoint: "s3-noobaa.apps.example.com",
+			port:     80,
+			useSSL:   boolPtr(false),
+			want:     "http://s3-noobaa.apps.example.com:80",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			cfg := &costv1alpha1.CostManagementServiceConfig{}
+			cfg.Spec.ObjectStorage.NoobaaNamespace = tt.ns
+			cfg.Spec.ObjectStorage.Endpoint = tt.endpoint
+			cfg.Spec.ObjectStorage.Port = tt.port
+			cfg.Spec.ObjectStorage.UseSSL = tt.useSSL
+			if got := noobaaEndpoint(cfg); got != tt.want {
+				t.Errorf("noobaaEndpoint() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestNoobaaEndpointIgnoresDiscoveredStatus(t *testing.T) {
+	t.Parallel()
+	cfg := &costv1alpha1.CostManagementServiceConfig{}
+	cfg.Spec.ObjectStorage.Endpoint = "s3.apps.example.com"
+	cfg.Spec.ObjectStorage.Port = 443
+	cfg.Spec.ObjectStorage.UseSSL = boolPtr(true)
+	cfg.Status.DiscoveredConfig = &costv1alpha1.DiscoveredConfig{
+		S3: &costv1alpha1.DiscoveredS3{Endpoint: "https://s3.openshift-storage.svc.cluster.local:443"},
+	}
+	got := noobaaEndpoint(cfg)
+	if got != "https://s3.apps.example.com:443" {
+		t.Errorf("noobaaEndpoint() = %q, want custom host (must not reuse status.discoveredConfig.s3)", got)
+	}
+}
+
+func TestResolveS3_NooBaaCustomNamespace(t *testing.T) {
+	c := fake.NewClientBuilder().
+		WithScheme(testScheme(t)).
+		WithObjects(noobaaAdminSecretIn("noobaa", "ak-nb", "sk-nb")).
+		Build()
+
+	r := &CostManagementServiceConfigReconciler{Client: c, Recorder: record.NewFakeRecorder(10)}
+	cfg := &costv1alpha1.CostManagementServiceConfig{
+		ObjectMeta: metav1.ObjectMeta{Name: testCRName, Namespace: testNamespace},
+		Spec: costv1alpha1.CostManagementServiceConfigSpec{
+			ObjectStorage: costv1alpha1.ObjectStorageConfig{
+				NoobaaNamespace: "noobaa",
+			},
+		},
+	}
+
+	got, err := r.resolveS3(context.Background(), cfg)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got.Endpoint != "https://s3.noobaa.svc.cluster.local:443" {
+		t.Errorf("Endpoint: got %q, want https://s3.noobaa.svc.cluster.local:443", got.Endpoint)
+	}
+}
+
+func TestResolveS3_NooBaaUnsetNamespaceMissesOtherNS(t *testing.T) {
+	c := fake.NewClientBuilder().
+		WithScheme(testScheme(t)).
+		WithObjects(noobaaAdminSecretIn("noobaa", "ak-nb", "sk-nb")).
+		Build()
+
+	r := &CostManagementServiceConfigReconciler{Client: c, Recorder: record.NewFakeRecorder(10)}
+	cfg := &costv1alpha1.CostManagementServiceConfig{
+		ObjectMeta: metav1.ObjectMeta{Name: testCRName, Namespace: testNamespace},
+	}
+
+	got, err := r.resolveS3(context.Background(), cfg)
+	if err == nil {
+		t.Fatalf("expected NooBaa path to fail when secret is only in noobaa, got %+v", got)
+	}
+}
+
+func TestResolveS3_NooBaaCustomEndpoint(t *testing.T) {
+	c := fake.NewClientBuilder().
+		WithScheme(testScheme(t)).
+		WithObjects(noobaaAdminSecret("ak-nb", "sk-nb")).
+		Build()
+
+	r := &CostManagementServiceConfigReconciler{Client: c, Recorder: record.NewFakeRecorder(10)}
+	cfg := &costv1alpha1.CostManagementServiceConfig{
+		ObjectMeta: metav1.ObjectMeta{Name: testCRName, Namespace: testNamespace},
+		Spec: costv1alpha1.CostManagementServiceConfigSpec{
+			ObjectStorage: costv1alpha1.ObjectStorageConfig{
+				Endpoint: "s3.apps.example.com",
+				Port:     443,
+				UseSSL:   boolPtr(true),
+			},
+		},
+	}
+
+	got, err := r.resolveS3(context.Background(), cfg)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got.Endpoint != "https://s3.apps.example.com:443" {
+		t.Errorf("Endpoint: got %q, want custom route", got.Endpoint)
 	}
 }
 

--- a/internal/resources/names.go
+++ b/internal/resources/names.go
@@ -169,6 +169,12 @@ func S3Endpoint(cfg *costv1alpha1.CostManagementServiceConfig) string {
 		cfg.Status.DiscoveredConfig.S3.Endpoint != "" {
 		return cfg.Status.DiscoveredConfig.S3.Endpoint
 	}
+	return S3EndpointFromSpec(cfg)
+}
+
+// S3EndpointFromSpec builds the S3 URL from spec.objectStorage host, port, and
+// UseSSL without consulting status.discoveredConfig.
+func S3EndpointFromSpec(cfg *costv1alpha1.CostManagementServiceConfig) string {
 	s := cfg.Spec.ObjectStorage
 	scheme := "http"
 	port := s.Port

--- a/internal/resources/names_test.go
+++ b/internal/resources/names_test.go
@@ -60,6 +60,23 @@ func TestS3BucketFallsBackToSpec(t *testing.T) {
 	}
 }
 
+func TestS3EndpointFromSpecIgnoresDiscovered(t *testing.T) {
+	useSSL := true
+	cfg := &costv1alpha1.CostManagementServiceConfig{}
+	cfg.Spec.ObjectStorage.Endpoint = "s3.apps.example.com"
+	cfg.Spec.ObjectStorage.Port = 443
+	cfg.Spec.ObjectStorage.UseSSL = &useSSL
+	cfg.Status.DiscoveredConfig = &costv1alpha1.DiscoveredConfig{
+		S3: &costv1alpha1.DiscoveredS3{Endpoint: "https://s3.openshift-storage.svc.cluster.local:443"},
+	}
+	if got := S3EndpointFromSpec(cfg); got != "https://s3.apps.example.com:443" {
+		t.Errorf("S3EndpointFromSpec = %q, want spec host", got)
+	}
+	if got := S3Endpoint(cfg); got != "https://s3.openshift-storage.svc.cluster.local:443" {
+		t.Errorf("S3Endpoint = %q, want discovered (secretName unset)", got)
+	}
+}
+
 func TestDNS1123Label(t *testing.T) {
 	tests := []struct {
 		in, want string


### PR DESCRIPTION
## Summary
[Jira ticket](https://redhat.atlassian.net/browse/COST-7683) (Item 7)

- Path 3 (NooBaa) no longer always reads `noobaa-admin` from `openshift-storage`. Optional `spec.objectStorage.noobaaNamespace` defaults to `openshift-storage` so ODF installs are unchanged; standalone NooBaa (e.g. namespace `noobaa`) can set the field instead of reinstalling.
- Discovered endpoint is `https://s3.<ns>.svc.cluster.local:443`. A custom `spec.objectStorage.endpoint` that is not the CRD default host still wins (port/SSL from spec). The Secret name stays `noobaa-admin`; cluster Secrets RBAC is unchanged.
- Path 1 (`secretName`) and path 2 (OBC) are untouched.
- Additionally, this PR is also improving `.coderabbit.yaml` a litle bit to avoid false positive

## Test plan
- [x] `make generate manifests`
- [x] `go test ./internal/controller/ -count=1 -run 'TestResolveS3_NooBaa|TestNoobaa'`
- [x] `go test ./internal/controller/ -count=1`
- [ ] Unset field: Secret in `openshift-storage` still discovers (ODF default)
- [ ] `noobaaNamespace: noobaa` with Secret only in `noobaa` → `StorageReady` and endpoint host contains `s3.noobaa.svc`
- [ ] Unset namespace with Secret only in `noobaa` → path 3 fails (does not invent a cross-NS search)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Adds optional `spec.objectStorage.noobaaNamespace` to the CRD.
- Defaults the namespace to `openshift-storage`, preserving existing configurations.
- Uses the configured namespace to find the `noobaa-admin` Secret and build the NooBaa service endpoint.
- Preserves custom endpoints, ports, and SSL settings.
- Keeps `secretName` and OBC discovery unchanged.
- Leaves cluster Secret RBAC unchanged.
- Adds coverage for namespace selection, endpoint resolution, and Secret lookup failures.
- No user-visible status condition changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->