### PR TITLE
feat: SSA for bundled PostgreSQL StatefulSet (COST-7681)

### DIFF
--- a/internal/controller/apply_statefulset_test.go
+++ b/internal/controller/apply_statefulset_test.go
@@ -418,9 +418,9 @@ func TestVolumeClaimTemplatesEqual(t *testing.T) {
 			expected: false,
 		},
 		{
-			name: "nil vs empty labels",
-			a:    []corev1.PersistentVolumeClaim{{ObjectMeta: metav1.ObjectMeta{Name: "test"}}},
-			b:    []corev1.PersistentVolumeClaim{{ObjectMeta: metav1.ObjectMeta{Name: "test", Labels: map[string]string{}}}},
+			name:     "nil vs empty labels",
+			a:        []corev1.PersistentVolumeClaim{{ObjectMeta: metav1.ObjectMeta{Name: "test"}}},
+			b:        []corev1.PersistentVolumeClaim{{ObjectMeta: metav1.ObjectMeta{Name: "test", Labels: map[string]string{}}}},
 			expected: true,
 		},
 		{
@@ -434,9 +434,9 @@ func TestVolumeClaimTemplatesEqual(t *testing.T) {
 			expected: false,
 		},
 		{
-			name: "nil vs empty annotations",
-			a:    []corev1.PersistentVolumeClaim{{ObjectMeta: metav1.ObjectMeta{Name: "test"}}},
-			b:    []corev1.PersistentVolumeClaim{{ObjectMeta: metav1.ObjectMeta{Name: "test", Annotations: map[string]string{}}}},
+			name:     "nil vs empty annotations",
+			a:        []corev1.PersistentVolumeClaim{{ObjectMeta: metav1.ObjectMeta{Name: "test"}}},
+			b:        []corev1.PersistentVolumeClaim{{ObjectMeta: metav1.ObjectMeta{Name: "test", Annotations: map[string]string{}}}},
 			expected: true,
 		},
 		{

--- a/internal/controller/apply_statefulset_test.go
+++ b/internal/controller/apply_statefulset_test.go
@@ -44,6 +44,42 @@ func TestReconcileInfrastructure_ApplyStatefulSetCreate(t *testing.T) {
 	}
 }
 
+func TestReconcileInfrastructure_WaitsForStatefulSetRollout(t *testing.T) {
+	scheme := ownershipScheme(t)
+	cfg := minimalCR(testCRName, testNamespace)
+	cfg.Spec.Cache.Deploy = boolPtr(false)
+
+	existing := resources.DatabaseStatefulSet(cfg)
+	existing.Generation = 2
+	replicas := int32(1)
+	existing.Spec.Replicas = &replicas
+	existing.Status.ObservedGeneration = 2
+	existing.Status.ReadyReplicas = 1
+	existing.Status.Replicas = 1
+	existing.Status.UpdatedReplicas = 0
+	existing.Status.CurrentRevision = "rev-old"
+	existing.Status.UpdateRevision = "rev-new"
+
+	c := fakeClientPreservingStatus(scheme, existing)
+	r := &CostManagementServiceConfigReconciler{
+		Client:   c,
+		Scheme:   scheme,
+		Recorder: &noopRecorder{},
+	}
+
+	result, err := r.reconcileInfrastructure(context.Background(), cfg)
+	if err != nil {
+		t.Fatalf("reconcileInfrastructure: %v", err)
+	}
+	if result.RequeueAfter == 0 {
+		t.Fatal("expected requeue while the new StatefulSet revision is rolling out")
+	}
+	cond := findCondition(cfg.Status.Conditions, costv1alpha1.ConditionDatabaseReady)
+	if cond == nil || cond.Status != metav1.ConditionFalse || cond.Reason != "WaitingForDatabase" {
+		t.Fatalf("expected DatabaseReady=False WaitingForDatabase during rollout, got %+v", cond)
+	}
+}
+
 func TestApplyStatefulSet_UpdatePreservesVolumeClaimTemplates(t *testing.T) {
 	scheme := ownershipScheme(t)
 	cfg := minimalCR(testCRName, testNamespace)

--- a/internal/controller/apply_statefulset_test.go
+++ b/internal/controller/apply_statefulset_test.go
@@ -2,6 +2,7 @@ package controller
 
 import (
 	"context"
+	"strings"
 	"testing"
 
 	appsv1 "k8s.io/api/apps/v1"
@@ -10,6 +11,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/tools/record"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
@@ -99,10 +101,11 @@ func TestApplyStatefulSet_UpdatePreservesVolumeClaimTemplates(t *testing.T) {
 	replicas := int32(1)
 	existing.Spec.Replicas = &replicas
 
+	rec := record.NewFakeRecorder(10)
 	r := &CostManagementServiceConfigReconciler{
 		Client:   fakeClientWithApplySupport(scheme, existing),
 		Scheme:   scheme,
-		Recorder: &noopRecorder{},
+		Recorder: rec,
 	}
 
 	desired := resources.DatabaseStatefulSet(cfg)
@@ -121,6 +124,13 @@ func TestApplyStatefulSet_UpdatePreservesVolumeClaimTemplates(t *testing.T) {
 	if cond == nil || cond.Status != metav1.ConditionFalse || cond.Reason != "StorageConfigChanged" {
 		t.Fatalf("expected DatabaseReady=False StorageConfigChanged, got %+v", cond)
 	}
+	if !strings.Contains(cond.Message, "10Gi") || !strings.Contains(cond.Message, "99Gi") {
+		t.Errorf("condition message should include size diff 10Gi -> 99Gi, got %q", cond.Message)
+	}
+	if !strings.Contains(cond.Message, "revert") || !strings.Contains(cond.Message, "delete") {
+		t.Errorf("condition message should say revert the CR field vs delete STS/PVC, got %q", cond.Message)
+	}
+	assertEvent(t, rec, "StorageConfigChanged")
 	avail := findCondition(cfg.Status.Conditions, costv1alpha1.ConditionAvailable)
 	if avail == nil || avail.Status != metav1.ConditionFalse || avail.Reason != "StorageConfigChanged" {
 		t.Fatalf("expected Available=False StorageConfigChanged, got %+v", avail)
@@ -738,6 +748,66 @@ func TestVolumeAttributesClassNameEqual(t *testing.T) {
 	}
 }
 
+func TestVolumeClaimTemplateDiff(t *testing.T) {
+	stringPtr := func(s string) *string { return &s }
+	tests := []struct {
+		name string
+		live []corev1.PersistentVolumeClaim
+		want []corev1.PersistentVolumeClaim
+		sub  string
+	}{
+		{
+			name: "size change",
+			live: []corev1.PersistentVolumeClaim{{
+				ObjectMeta: metav1.ObjectMeta{Name: "postgres-storage"},
+				Spec: corev1.PersistentVolumeClaimSpec{
+					Resources: corev1.VolumeResourceRequirements{
+						Requests: corev1.ResourceList{corev1.ResourceStorage: resource.MustParse("10Gi")},
+					},
+				},
+			}},
+			want: []corev1.PersistentVolumeClaim{{
+				ObjectMeta: metav1.ObjectMeta{Name: "postgres-storage"},
+				Spec: corev1.PersistentVolumeClaimSpec{
+					Resources: corev1.VolumeResourceRequirements{
+						Requests: corev1.ResourceList{corev1.ResourceStorage: resource.MustParse("20Gi")},
+					},
+				},
+			}},
+			sub: "postgres-storage size 10Gi -> 20Gi",
+		},
+		{
+			name: "storage class change",
+			live: []corev1.PersistentVolumeClaim{{
+				ObjectMeta: metav1.ObjectMeta{Name: "postgres-storage"},
+				Spec:       corev1.PersistentVolumeClaimSpec{StorageClassName: stringPtr("gp2")},
+			}},
+			want: []corev1.PersistentVolumeClaim{{
+				ObjectMeta: metav1.ObjectMeta{Name: "postgres-storage"},
+				Spec:       corev1.PersistentVolumeClaimSpec{StorageClassName: stringPtr("gp3")},
+			}},
+			sub: "postgres-storage storageClass gp2 -> gp3",
+		},
+		{
+			name: "count change",
+			live: []corev1.PersistentVolumeClaim{{ObjectMeta: metav1.ObjectMeta{Name: "a"}}},
+			want: []corev1.PersistentVolumeClaim{
+				{ObjectMeta: metav1.ObjectMeta{Name: "a"}},
+				{ObjectMeta: metav1.ObjectMeta{Name: "b"}},
+			},
+			sub: "count 1 -> 2",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := volumeClaimTemplateDiff(tt.live, tt.want)
+			if !strings.Contains(got, tt.sub) {
+				t.Errorf("volumeClaimTemplateDiff() = %q, want substring %q", got, tt.sub)
+			}
+		})
+	}
+}
+
 func TestPtrEqual(t *testing.T) {
 	tests := []struct {
 		name     string
@@ -884,6 +954,13 @@ func TestReconcile_VCTMismatchPersistsStatus(t *testing.T) {
 	}
 	if updated.Status.Phase != costv1alpha1.PhaseDegraded {
 		t.Errorf("phase = %q, want %q", updated.Status.Phase, costv1alpha1.PhaseDegraded)
+	}
+	if !strings.Contains(cond.Message, "10Gi") || !strings.Contains(cond.Message, "20Gi") {
+		t.Errorf("persisted message should include size diff, got %q", cond.Message)
+	}
+	prog := findCondition(updated.Status.Conditions, costv1alpha1.ConditionProgressing)
+	if prog == nil || prog.Status != metav1.ConditionFalse || prog.Reason != "StorageConfigChanged" {
+		t.Fatalf("expected Progressing=False StorageConfigChanged, got %+v", prog)
 	}
 }
 

--- a/internal/controller/apply_statefulset_test.go
+++ b/internal/controller/apply_statefulset_test.go
@@ -76,6 +76,14 @@ func TestApplyStatefulSet_UpdatePreservesVolumeClaimTemplates(t *testing.T) {
 	if cond == nil || cond.Status != metav1.ConditionFalse || cond.Reason != "StorageConfigChanged" {
 		t.Fatalf("expected DatabaseReady=False StorageConfigChanged, got %+v", cond)
 	}
+	avail := findCondition(cfg.Status.Conditions, costv1alpha1.ConditionAvailable)
+	if avail == nil || avail.Status != metav1.ConditionFalse || avail.Reason != "StorageConfigChanged" {
+		t.Fatalf("expected Available=False StorageConfigChanged, got %+v", avail)
+	}
+	deg := findCondition(cfg.Status.Conditions, costv1alpha1.ConditionDegraded)
+	if deg == nil || deg.Status != metav1.ConditionTrue || deg.Reason != "StorageConfigChanged" {
+		t.Fatalf("expected Degraded=True StorageConfigChanged, got %+v", deg)
+	}
 
 	// Verify no changes were applied.
 	got := &appsv1.StatefulSet{}
@@ -662,6 +670,56 @@ func TestReconcileInfrastructure_VCTMismatchOnReadyDB(t *testing.T) {
 	cond := findCondition(cfg.Status.Conditions, costv1alpha1.ConditionDatabaseReady)
 	if cond == nil || cond.Status != metav1.ConditionFalse || cond.Reason != "StorageConfigChanged" {
 		t.Fatalf("expected DatabaseReady=False StorageConfigChanged, got %+v", cond)
+	}
+	avail := findCondition(cfg.Status.Conditions, costv1alpha1.ConditionAvailable)
+	if avail == nil || avail.Status != metav1.ConditionFalse || avail.Reason != "StorageConfigChanged" {
+		t.Fatalf("expected Available=False StorageConfigChanged, got %+v", avail)
+	}
+	deg := findCondition(cfg.Status.Conditions, costv1alpha1.ConditionDegraded)
+	if deg == nil || deg.Status != metav1.ConditionTrue || deg.Reason != "StorageConfigChanged" {
+		t.Fatalf("expected Degraded=True StorageConfigChanged, got %+v", deg)
+	}
+}
+
+func TestApplyStatefulSet_SSACopiesLiveVCTBeforeApply(t *testing.T) {
+	scheme := ownershipScheme(t)
+	cfg := minimalCR(testCRName, testNamespace)
+
+	fs := corev1.PersistentVolumeFilesystem
+	existing := resources.DatabaseStatefulSet(cfg)
+	existing.Spec.VolumeClaimTemplates[0].Spec.Resources.Requests[corev1.ResourceStorage] = resource.MustParse("10Gi")
+	existing.Spec.VolumeClaimTemplates[0].Spec.VolumeMode = &fs
+	replicas := int32(1)
+	existing.Spec.Replicas = &replicas
+
+	r := &CostManagementServiceConfigReconciler{
+		Client:   fakeClientWithApplySupport(scheme, existing),
+		Scheme:   scheme,
+		Recorder: &noopRecorder{},
+	}
+
+	desired := resources.DatabaseStatefulSet(cfg)
+	desired.Spec.Template.Spec.Containers[0].Image = "postgres:new"
+	desired.Spec.VolumeClaimTemplates[0].Spec.Resources.Requests[corev1.ResourceStorage] = resource.MustParse("10Gi")
+	desired.Spec.VolumeClaimTemplates[0].Spec.VolumeMode = nil
+
+	if err := r.applyStatefulSet(context.Background(), cfg, desired); err != nil {
+		t.Fatalf("applyStatefulSet: %v", err)
+	}
+
+	got := &appsv1.StatefulSet{}
+	if err := r.Get(context.Background(), types.NamespacedName{
+		Namespace: testNamespace,
+		Name:      resources.NameDatabase(cfg),
+	}, got); err != nil {
+		t.Fatalf("Get StatefulSet: %v", err)
+	}
+	if got.Spec.Template.Spec.Containers[0].Image != "postgres:new" {
+		t.Errorf("image not updated: got %q", got.Spec.Template.Spec.Containers[0].Image)
+	}
+	mode := got.Spec.VolumeClaimTemplates[0].Spec.VolumeMode
+	if mode == nil || *mode != corev1.PersistentVolumeFilesystem {
+		t.Errorf("live VolumeMode should be preserved across SSA: got %+v", mode)
 	}
 }
 

--- a/internal/controller/apply_statefulset_test.go
+++ b/internal/controller/apply_statefulset_test.go
@@ -6,9 +6,15 @@ import (
 
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	costv1alpha1 "github.com/project-koku/koku-service-operator/api/v1alpha1"
 	"github.com/project-koku/koku-service-operator/internal/resources"
@@ -37,6 +43,9 @@ func TestReconcileInfrastructure_ApplyStatefulSetCreate(t *testing.T) {
 	mustExist(t, r.Client, testNamespace, resources.NameDatabase(cfg), &corev1.Service{})
 	sts := &appsv1.StatefulSet{}
 	mustExist(t, r.Client, testNamespace, resources.NameDatabase(cfg), sts)
+	if len(sts.OwnerReferences) != 1 {
+		t.Fatalf("apply() should set ownerRef on the StatefulSet, got %d", len(sts.OwnerReferences))
+	}
 
 	cond := findCondition(cfg.Status.Conditions, costv1alpha1.ConditionDatabaseReady)
 	if cond == nil || cond.Status != metav1.ConditionFalse || cond.Reason != "WaitingForDatabase" {
@@ -398,6 +407,64 @@ func TestVolumeClaimTemplatesEqual(t *testing.T) {
 			b:        []corev1.PersistentVolumeClaim{{ObjectMeta: metav1.ObjectMeta{Name: "test2"}}},
 			expected: false,
 		},
+		{
+			name: "different labels",
+			a: []corev1.PersistentVolumeClaim{{
+				ObjectMeta: metav1.ObjectMeta{Name: "test", Labels: map[string]string{"app": "db"}},
+			}},
+			b: []corev1.PersistentVolumeClaim{{
+				ObjectMeta: metav1.ObjectMeta{Name: "test", Labels: map[string]string{"app": "other"}},
+			}},
+			expected: false,
+		},
+		{
+			name: "nil vs empty labels",
+			a:    []corev1.PersistentVolumeClaim{{ObjectMeta: metav1.ObjectMeta{Name: "test"}}},
+			b:    []corev1.PersistentVolumeClaim{{ObjectMeta: metav1.ObjectMeta{Name: "test", Labels: map[string]string{}}}},
+			expected: true,
+		},
+		{
+			name: "different annotations",
+			a: []corev1.PersistentVolumeClaim{{
+				ObjectMeta: metav1.ObjectMeta{Name: "test", Annotations: map[string]string{"pv.kubernetes.io/bind-completed": "yes"}},
+			}},
+			b: []corev1.PersistentVolumeClaim{{
+				ObjectMeta: metav1.ObjectMeta{Name: "test"},
+			}},
+			expected: false,
+		},
+		{
+			name: "nil vs empty annotations",
+			a:    []corev1.PersistentVolumeClaim{{ObjectMeta: metav1.ObjectMeta{Name: "test"}}},
+			b:    []corev1.PersistentVolumeClaim{{ObjectMeta: metav1.ObjectMeta{Name: "test", Annotations: map[string]string{}}}},
+			expected: true,
+		},
+		{
+			name: "different DataSourceRef namespace",
+			a: []corev1.PersistentVolumeClaim{{
+				ObjectMeta: metav1.ObjectMeta{Name: "test"},
+				Spec: corev1.PersistentVolumeClaimSpec{
+					DataSourceRef: &corev1.TypedObjectReference{
+						APIGroup:  stringPtr("snapshot.storage.k8s.io"),
+						Kind:      "VolumeSnapshot",
+						Name:      "snap-1",
+						Namespace: stringPtr("ns-a"),
+					},
+				},
+			}},
+			b: []corev1.PersistentVolumeClaim{{
+				ObjectMeta: metav1.ObjectMeta{Name: "test"},
+				Spec: corev1.PersistentVolumeClaimSpec{
+					DataSourceRef: &corev1.TypedObjectReference{
+						APIGroup:  stringPtr("snapshot.storage.k8s.io"),
+						Kind:      "VolumeSnapshot",
+						Name:      "snap-1",
+						Namespace: stringPtr("ns-b"),
+					},
+				},
+			}},
+			expected: false,
+		},
 	}
 
 	for _, tt := range tests {
@@ -636,6 +703,8 @@ func TestDataSourceRefEqual(t *testing.T) {
 		{name: "one nil", a: nil, b: &corev1.TypedObjectReference{}, expected: false},
 		{name: "equal", a: &corev1.TypedObjectReference{APIGroup: ptr(""), Kind: "VolumeSnapshot", Name: "snap-1"}, b: &corev1.TypedObjectReference{APIGroup: ptr(""), Kind: "VolumeSnapshot", Name: "snap-1"}, expected: true},
 		{name: "different kind", a: &corev1.TypedObjectReference{APIGroup: ptr(""), Kind: "VolumeSnapshot", Name: "snap-1"}, b: &corev1.TypedObjectReference{APIGroup: ptr(""), Kind: "PVC", Name: "snap-1"}, expected: false},
+		{name: "different namespace", a: &corev1.TypedObjectReference{APIGroup: ptr(""), Kind: "VolumeSnapshot", Name: "snap-1", Namespace: ptr("ns-a")}, b: &corev1.TypedObjectReference{APIGroup: ptr(""), Kind: "VolumeSnapshot", Name: "snap-1", Namespace: ptr("ns-b")}, expected: false},
+		{name: "equal including namespace", a: &corev1.TypedObjectReference{APIGroup: ptr(""), Kind: "VolumeSnapshot", Name: "snap-1", Namespace: ptr("ns-a")}, b: &corev1.TypedObjectReference{APIGroup: ptr(""), Kind: "VolumeSnapshot", Name: "snap-1", Namespace: ptr("ns-a")}, expected: true},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -664,6 +733,28 @@ func TestVolumeAttributesClassNameEqual(t *testing.T) {
 			result := volumeAttributesClassNameEqual(tt.a, tt.b)
 			if result != tt.expected {
 				t.Errorf("volumeAttributesClassNameEqual() = %v, want %v", result, tt.expected)
+			}
+		})
+	}
+}
+
+func TestPtrEqual(t *testing.T) {
+	tests := []struct {
+		name     string
+		a, b     *string
+		expected bool
+	}{
+		{name: "both nil", expected: true},
+		{name: "one nil", b: ptr("gp3"), expected: false},
+		{name: "equal", a: ptr("gp3"), b: ptr("gp3"), expected: true},
+		{name: "different", a: ptr("gp3"), b: ptr("gp2"), expected: false},
+		{name: "nil vs empty string", a: nil, b: ptr(""), expected: false},
+		{name: "both empty string", a: ptr(""), b: ptr(""), expected: true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := ptrEqual(tt.a, tt.b); got != tt.expected {
+				t.Errorf("ptrEqual() = %v, want %v", got, tt.expected)
 			}
 		})
 	}
@@ -714,6 +805,85 @@ func TestReconcileInfrastructure_VCTMismatchOnReadyDB(t *testing.T) {
 	deg := findCondition(cfg.Status.Conditions, costv1alpha1.ConditionDegraded)
 	if deg == nil || deg.Status != metav1.ConditionTrue || deg.Reason != "StorageConfigChanged" {
 		t.Fatalf("expected Degraded=True StorageConfigChanged, got %+v", deg)
+	}
+}
+
+// TestReconcile_VCTMismatchPersistsStatus goes through Reconcile (not just
+// reconcileInfrastructure) and reads the CR back from the client. Reconcile
+// patchStatus runs after runPhases even when the result is RequeueAfter/nil.
+func TestReconcile_VCTMismatchPersistsStatus(t *testing.T) {
+	scheme := ownershipScheme(t)
+	cfg := minimalCR(testCRName, testNamespace)
+	cfg.Spec.Cache.Deploy = boolPtr(false)
+	cfg.Spec.Global.ClusterDomain = "apps.example.com"
+	cfg.Spec.Global.StorageClass = "gp3"
+	cfg.Spec.ObjectStorage.SecretName = "s3-creds"
+	controllerutil.AddFinalizer(cfg, finalizerName)
+
+	existing := resources.DatabaseStatefulSet(cfg)
+	existing.Spec.VolumeClaimTemplates[0].Spec.Resources.Requests[corev1.ResourceStorage] = resource.MustParse("10Gi")
+	replicas := int32(1)
+	existing.Spec.Replicas = &replicas
+
+	cfg.Spec.Database.Storage.Size = resource.MustParse("20Gi")
+
+	c := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(cfg, existing).
+		WithStatusSubresource(cfg, &appsv1.StatefulSet{}).
+		WithInterceptorFuncs(interceptor.Funcs{
+			Patch: func(ctx context.Context, inner client.WithWatch, obj client.Object, patch client.Patch, opts ...client.PatchOption) error {
+				if patch.Type() != types.ApplyPatchType {
+					return inner.Patch(ctx, obj, patch, opts...)
+				}
+				key := client.ObjectKeyFromObject(obj)
+				got := obj.DeepCopyObject().(client.Object)
+				err := inner.Get(ctx, key, got)
+				if apierrors.IsNotFound(err) {
+					return inner.Create(ctx, obj)
+				}
+				if err != nil {
+					return err
+				}
+				obj.SetResourceVersion(got.GetResourceVersion())
+				return inner.Update(ctx, obj)
+			},
+		}).Build()
+
+	r := &CostManagementServiceConfigReconciler{
+		Client:   c,
+		Scheme:   scheme,
+		Recorder: &noopRecorder{},
+	}
+
+	result, err := r.Reconcile(context.Background(), reconcile.Request{
+		NamespacedName: types.NamespacedName{Name: testCRName, Namespace: testNamespace},
+	})
+	if err != nil {
+		t.Fatalf("Reconcile: %v", err)
+	}
+	if result.RequeueAfter == 0 {
+		t.Fatal("expected requeue on VCT mismatch")
+	}
+
+	updated := &costv1alpha1.CostManagementServiceConfig{}
+	if err := c.Get(context.Background(), types.NamespacedName{Name: testCRName, Namespace: testNamespace}, updated); err != nil {
+		t.Fatalf("Get CR: %v", err)
+	}
+	cond := findCondition(updated.Status.Conditions, costv1alpha1.ConditionDatabaseReady)
+	if cond == nil || cond.Status != metav1.ConditionFalse || cond.Reason != "StorageConfigChanged" {
+		t.Fatalf("status not persisted: DatabaseReady=%+v", cond)
+	}
+	avail := findCondition(updated.Status.Conditions, costv1alpha1.ConditionAvailable)
+	if avail == nil || avail.Status != metav1.ConditionFalse || avail.Reason != "StorageConfigChanged" {
+		t.Fatalf("status not persisted: Available=%+v", avail)
+	}
+	deg := findCondition(updated.Status.Conditions, costv1alpha1.ConditionDegraded)
+	if deg == nil || deg.Status != metav1.ConditionTrue || deg.Reason != "StorageConfigChanged" {
+		t.Fatalf("status not persisted: Degraded=%+v", deg)
+	}
+	if updated.Status.Phase != costv1alpha1.PhaseDegraded {
+		t.Errorf("phase = %q, want %q", updated.Status.Phase, costv1alpha1.PhaseDegraded)
 	}
 }
 

--- a/internal/controller/apply_statefulset_test.go
+++ b/internal/controller/apply_statefulset_test.go
@@ -64,13 +64,75 @@ func TestApplyStatefulSet_UpdatePreservesVolumeClaimTemplates(t *testing.T) {
 	desired.Spec.Template.Spec.Containers[0].Image = "postgres:new"
 	wantReplicas := int32(2)
 	desired.Spec.Replicas = &wantReplicas
-	// Attempt to change VCT size — applyStatefulSet must ignore this.
+	// Attempt to change VCT size — applyStatefulSet must detect this and set condition.
 	desired.Spec.VolumeClaimTemplates[0].Spec.Resources.Requests[corev1.ResourceStorage] = resource.MustParse("99Gi")
+
+	if err := r.applyStatefulSet(context.Background(), cfg, desired); err != nil && err != ErrStorageConfigChanged {
+		t.Fatalf("applyStatefulSet: %v", err)
+	}
+
+	// VCT mismatch should set condition and NOT apply changes.
+	cond := findCondition(cfg.Status.Conditions, costv1alpha1.ConditionDatabaseReady)
+	if cond == nil || cond.Status != metav1.ConditionFalse || cond.Reason != "StorageConfigChanged" {
+		t.Fatalf("expected DatabaseReady=False StorageConfigChanged, got %+v", cond)
+	}
+
+	// Verify no changes were applied.
+	got := &appsv1.StatefulSet{}
+	if err := r.Get(context.Background(), types.NamespacedName{
+		Namespace: testNamespace,
+		Name:      resources.NameDatabase(cfg),
+	}, got); err != nil {
+		t.Fatalf("Get StatefulSet: %v", err)
+	}
+
+	if got.Spec.Template.Spec.Containers[0].Image != "postgres:old" {
+		t.Errorf("image should not be updated when VCT differs: got %q", got.Spec.Template.Spec.Containers[0].Image)
+	}
+	if got.Spec.Replicas == nil || *got.Spec.Replicas != 1 {
+		t.Errorf("replicas should not be updated when VCT differs: got %v", got.Spec.Replicas)
+	}
+	size := got.Spec.VolumeClaimTemplates[0].Spec.Resources.Requests[corev1.ResourceStorage]
+	if !size.Equal(resource.MustParse("10Gi")) {
+		t.Errorf("VolumeClaimTemplates must be immutable; got size %s want 10Gi", size.String())
+	}
+}
+
+func TestApplyStatefulSet_SSAUpdatesMutableFields(t *testing.T) {
+	scheme := ownershipScheme(t)
+	cfg := minimalCR(testCRName, testNamespace)
+
+	existing := resources.DatabaseStatefulSet(cfg)
+	existing.Spec.Template.Spec.Containers[0].Image = "postgres:old"
+	existing.Spec.VolumeClaimTemplates[0].Spec.Resources.Requests[corev1.ResourceStorage] = resource.MustParse("10Gi")
+	replicas := int32(1)
+	existing.Spec.Replicas = &replicas
+
+	r := &CostManagementServiceConfigReconciler{
+		Client:   fakeClientWithApplySupport(scheme, existing),
+		Scheme:   scheme,
+		Recorder: &noopRecorder{},
+	}
+
+	// Desired has SAME VCT but different mutable fields.
+	desired := resources.DatabaseStatefulSet(cfg)
+	desired.Spec.Template.Spec.Containers[0].Image = "postgres:new"
+	wantReplicas := int32(2)
+	desired.Spec.Replicas = &wantReplicas
+	// VCT matches existing (10Gi)
+	desired.Spec.VolumeClaimTemplates[0].Spec.Resources.Requests[corev1.ResourceStorage] = resource.MustParse("10Gi")
 
 	if err := r.applyStatefulSet(context.Background(), cfg, desired); err != nil {
 		t.Fatalf("applyStatefulSet: %v", err)
 	}
 
+	// No condition should be set for VCT mismatch.
+	cond := findCondition(cfg.Status.Conditions, costv1alpha1.ConditionDatabaseReady)
+	if cond != nil && cond.Reason == "StorageConfigChanged" {
+		t.Fatalf("unexpected StorageConfigChanged condition: %+v", cond)
+	}
+
+	// Verify SSA applied the mutable fields.
 	got := &appsv1.StatefulSet{}
 	if err := r.Get(context.Background(), types.NamespacedName{
 		Namespace: testNamespace,
@@ -80,13 +142,529 @@ func TestApplyStatefulSet_UpdatePreservesVolumeClaimTemplates(t *testing.T) {
 	}
 
 	if got.Spec.Template.Spec.Containers[0].Image != "postgres:new" {
-		t.Errorf("image not updated: got %q", got.Spec.Template.Spec.Containers[0].Image)
+		t.Errorf("image not updated via SSA: got %q", got.Spec.Template.Spec.Containers[0].Image)
 	}
 	if got.Spec.Replicas == nil || *got.Spec.Replicas != 2 {
-		t.Errorf("replicas not updated: got %v", got.Spec.Replicas)
+		t.Errorf("replicas not updated via SSA: got %v", got.Spec.Replicas)
 	}
 	size := got.Spec.VolumeClaimTemplates[0].Spec.Resources.Requests[corev1.ResourceStorage]
 	if !size.Equal(resource.MustParse("10Gi")) {
 		t.Errorf("VolumeClaimTemplates must be immutable; got size %s want 10Gi", size.String())
 	}
+}
+
+func TestApplyStatefulSet_SSADriftCorrection(t *testing.T) {
+	scheme := ownershipScheme(t)
+	cfg := minimalCR(testCRName, testNamespace)
+
+	// Start with desired state applied via SSA.
+	desired := resources.DatabaseStatefulSet(cfg)
+	desired.Spec.VolumeClaimTemplates[0].Spec.Resources.Requests[corev1.ResourceStorage] = resource.MustParse("10Gi")
+
+	r := &CostManagementServiceConfigReconciler{
+		Client:   fakeClientWithApplySupport(scheme, desired),
+		Scheme:   scheme,
+		Recorder: &noopRecorder{},
+	}
+
+	// First reconcile applies the desired state.
+	if err := r.applyStatefulSet(context.Background(), cfg, desired); err != nil {
+		t.Fatalf("first applyStatefulSet: %v", err)
+	}
+
+	// Simulate manual edit: change a managed field (livenessProbe) to something different.
+	// We need to directly modify the object in the fake client.
+	manualEdited := &appsv1.StatefulSet{}
+	if err := r.Get(context.Background(), types.NamespacedName{
+		Namespace: testNamespace,
+		Name:      resources.NameDatabase(cfg),
+	}, manualEdited); err != nil {
+		t.Fatalf("Get for manual edit: %v", err)
+	}
+	// Modify livenessProbe - this is a field managed by SSA
+	if len(manualEdited.Spec.Template.Spec.Containers) > 0 {
+		manualEdited.Spec.Template.Spec.Containers[0].LivenessProbe = &corev1.Probe{
+			ProbeHandler: corev1.ProbeHandler{
+				Exec: &corev1.ExecAction{Command: []string{"/bin/false"}},
+			},
+			InitialDelaySeconds: 999,
+		}
+	}
+	if err := r.Update(context.Background(), manualEdited); err != nil {
+		t.Fatalf("Update for manual edit: %v", err)
+	}
+
+	// Second reconcile (drift correction) - should revert the manual edit via SSA.
+	if err := r.applyStatefulSet(context.Background(), cfg, desired); err != nil {
+		t.Fatalf("second applyStatefulSet (drift): %v", err)
+	}
+
+	// Verify the manual edit was reverted.
+	got := &appsv1.StatefulSet{}
+	if err := r.Get(context.Background(), types.NamespacedName{
+		Namespace: testNamespace,
+		Name:      resources.NameDatabase(cfg),
+	}, got); err != nil {
+		t.Fatalf("Get after drift correction: %v", err)
+	}
+
+	// The livenessProbe should be back to the desired state (pg_isready)
+	if len(got.Spec.Template.Spec.Containers) == 0 {
+		t.Fatal("no containers in StatefulSet")
+	}
+	probe := got.Spec.Template.Spec.Containers[0].LivenessProbe
+	if probe == nil {
+		t.Fatal("livenessProbe is nil after drift correction")
+		return
+	}
+	if probe.Exec == nil || len(probe.Exec.Command) == 0 || probe.Exec.Command[0] != "/bin/sh" {
+		t.Errorf("livenessProbe not reverted to desired state: got %+v", probe)
+	}
+	if probe.InitialDelaySeconds != 30 {
+		t.Errorf("livenessProbe InitialDelaySeconds not reverted: got %d want 30", probe.InitialDelaySeconds)
+	}
+}
+
+func TestVolumeClaimTemplatesEqual(t *testing.T) {
+	stringPtr := func(s string) *string { return &s }
+	tests := []struct {
+		name     string
+		a        []corev1.PersistentVolumeClaim
+		b        []corev1.PersistentVolumeClaim
+		expected bool
+	}{
+		{
+			name: "equal VCTs",
+			a: []corev1.PersistentVolumeClaim{
+				{
+					ObjectMeta: metav1.ObjectMeta{Name: "test"},
+					Spec: corev1.PersistentVolumeClaimSpec{
+						StorageClassName: stringPtr("fast"),
+						Resources: corev1.VolumeResourceRequirements{
+							Requests: corev1.ResourceList{corev1.ResourceStorage: resource.MustParse("10Gi")},
+						},
+						AccessModes: []corev1.PersistentVolumeAccessMode{corev1.ReadWriteOnce},
+					},
+				},
+			},
+			b: []corev1.PersistentVolumeClaim{
+				{
+					ObjectMeta: metav1.ObjectMeta{Name: "test"},
+					Spec: corev1.PersistentVolumeClaimSpec{
+						StorageClassName: stringPtr("fast"),
+						Resources: corev1.VolumeResourceRequirements{
+							Requests: corev1.ResourceList{corev1.ResourceStorage: resource.MustParse("10Gi")},
+						},
+						AccessModes: []corev1.PersistentVolumeAccessMode{corev1.ReadWriteOnce},
+					},
+				},
+			},
+			expected: true,
+		},
+		{
+			name: "different storage size",
+			a: []corev1.PersistentVolumeClaim{{
+				ObjectMeta: metav1.ObjectMeta{Name: "test"},
+				Spec: corev1.PersistentVolumeClaimSpec{
+					Resources:   corev1.VolumeResourceRequirements{Requests: corev1.ResourceList{corev1.ResourceStorage: resource.MustParse("10Gi")}},
+					AccessModes: []corev1.PersistentVolumeAccessMode{corev1.ReadWriteOnce},
+				},
+			}},
+			b: []corev1.PersistentVolumeClaim{{
+				ObjectMeta: metav1.ObjectMeta{Name: "test"},
+				Spec: corev1.PersistentVolumeClaimSpec{
+					Resources:   corev1.VolumeResourceRequirements{Requests: corev1.ResourceList{corev1.ResourceStorage: resource.MustParse("20Gi")}},
+					AccessModes: []corev1.PersistentVolumeAccessMode{corev1.ReadWriteOnce},
+				},
+			}},
+			expected: false,
+		},
+		{
+			name: "different storage class",
+			a: []corev1.PersistentVolumeClaim{{
+				ObjectMeta: metav1.ObjectMeta{Name: "test"},
+				Spec: corev1.PersistentVolumeClaimSpec{
+					StorageClassName: stringPtr("fast"),
+					Resources:        corev1.VolumeResourceRequirements{Requests: corev1.ResourceList{corev1.ResourceStorage: resource.MustParse("10Gi")}},
+					AccessModes:      []corev1.PersistentVolumeAccessMode{corev1.ReadWriteOnce},
+				},
+			}},
+			b: []corev1.PersistentVolumeClaim{{
+				ObjectMeta: metav1.ObjectMeta{Name: "test"},
+				Spec: corev1.PersistentVolumeClaimSpec{
+					StorageClassName: stringPtr("slow"),
+					Resources:        corev1.VolumeResourceRequirements{Requests: corev1.ResourceList{corev1.ResourceStorage: resource.MustParse("10Gi")}},
+					AccessModes:      []corev1.PersistentVolumeAccessMode{corev1.ReadWriteOnce},
+				},
+			}},
+			expected: false,
+		},
+		{
+			name: "nil vs empty storage class",
+			a: []corev1.PersistentVolumeClaim{{
+				ObjectMeta: metav1.ObjectMeta{Name: "test"},
+				Spec: corev1.PersistentVolumeClaimSpec{
+					StorageClassName: nil,
+					Resources:        corev1.VolumeResourceRequirements{Requests: corev1.ResourceList{corev1.ResourceStorage: resource.MustParse("10Gi")}},
+					AccessModes:      []corev1.PersistentVolumeAccessMode{corev1.ReadWriteOnce},
+				},
+			}},
+			b: []corev1.PersistentVolumeClaim{{
+				ObjectMeta: metav1.ObjectMeta{Name: "test"},
+				Spec: corev1.PersistentVolumeClaimSpec{
+					StorageClassName: stringPtr(""),
+					Resources:        corev1.VolumeResourceRequirements{Requests: corev1.ResourceList{corev1.ResourceStorage: resource.MustParse("10Gi")}},
+					AccessModes:      []corev1.PersistentVolumeAccessMode{corev1.ReadWriteOnce},
+				},
+			}},
+			expected: false,
+		},
+		{
+			name: "different access modes",
+			a: []corev1.PersistentVolumeClaim{{
+				ObjectMeta: metav1.ObjectMeta{Name: "test"},
+				Spec: corev1.PersistentVolumeClaimSpec{
+					Resources:   corev1.VolumeResourceRequirements{Requests: corev1.ResourceList{corev1.ResourceStorage: resource.MustParse("10Gi")}},
+					AccessModes: []corev1.PersistentVolumeAccessMode{corev1.ReadWriteOnce},
+				},
+			}},
+			b: []corev1.PersistentVolumeClaim{{
+				ObjectMeta: metav1.ObjectMeta{Name: "test"},
+				Spec: corev1.PersistentVolumeClaimSpec{
+					Resources:   corev1.VolumeResourceRequirements{Requests: corev1.ResourceList{corev1.ResourceStorage: resource.MustParse("10Gi")}},
+					AccessModes: []corev1.PersistentVolumeAccessMode{corev1.ReadWriteMany},
+				},
+			}},
+			expected: false,
+		},
+		{
+			name: "different length",
+			a: []corev1.PersistentVolumeClaim{
+				{ObjectMeta: metav1.ObjectMeta{Name: "test1"}},
+				{ObjectMeta: metav1.ObjectMeta{Name: "test2"}},
+			},
+			b: []corev1.PersistentVolumeClaim{
+				{ObjectMeta: metav1.ObjectMeta{Name: "test1"}},
+			},
+			expected: false,
+		},
+		{
+			name:     "different names",
+			a:        []corev1.PersistentVolumeClaim{{ObjectMeta: metav1.ObjectMeta{Name: "test1"}}},
+			b:        []corev1.PersistentVolumeClaim{{ObjectMeta: metav1.ObjectMeta{Name: "test2"}}},
+			expected: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := volumeClaimTemplatesEqual(tt.a, tt.b)
+			if result != tt.expected {
+				t.Errorf("volumeClaimTemplatesEqual() = %v, want %v", result, tt.expected)
+			}
+		})
+	}
+}
+
+func TestResourceRequirementsEqual(t *testing.T) {
+	tests := []struct {
+		name     string
+		a        corev1.VolumeResourceRequirements
+		b        corev1.VolumeResourceRequirements
+		expected bool
+	}{
+		{
+			name:     "both nil",
+			a:        corev1.VolumeResourceRequirements{},
+			b:        corev1.VolumeResourceRequirements{},
+			expected: true,
+		},
+		{
+			name:     "both empty",
+			a:        corev1.VolumeResourceRequirements{Requests: corev1.ResourceList{}},
+			b:        corev1.VolumeResourceRequirements{Requests: corev1.ResourceList{}},
+			expected: true,
+		},
+		{
+			name: "equal resources",
+			a: corev1.VolumeResourceRequirements{
+				Requests: corev1.ResourceList{corev1.ResourceStorage: resource.MustParse("10Gi")},
+			},
+			b: corev1.VolumeResourceRequirements{
+				Requests: corev1.ResourceList{corev1.ResourceStorage: resource.MustParse("10Gi")},
+			},
+			expected: true,
+		},
+		{
+			name: "different resources",
+			a: corev1.VolumeResourceRequirements{
+				Requests: corev1.ResourceList{corev1.ResourceStorage: resource.MustParse("10Gi")},
+			},
+			b: corev1.VolumeResourceRequirements{
+				Requests: corev1.ResourceList{corev1.ResourceStorage: resource.MustParse("20Gi")},
+			},
+			expected: false,
+		},
+		{
+			name: "a nil b not",
+			a:    corev1.VolumeResourceRequirements{},
+			b: corev1.VolumeResourceRequirements{
+				Requests: corev1.ResourceList{corev1.ResourceStorage: resource.MustParse("10Gi")},
+			},
+			expected: false,
+		},
+		{
+			name: "extra resource in b",
+			a: corev1.VolumeResourceRequirements{
+				Requests: corev1.ResourceList{corev1.ResourceStorage: resource.MustParse("10Gi")},
+			},
+			b: corev1.VolumeResourceRequirements{
+				Requests: corev1.ResourceList{
+					corev1.ResourceStorage: resource.MustParse("10Gi"),
+					corev1.ResourceCPU:     resource.MustParse("100m"),
+				},
+			},
+			expected: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := resourceRequirementsEqual(tt.a, tt.b)
+			if result != tt.expected {
+				t.Errorf("resourceRequirementsEqual() = %v, want %v", result, tt.expected)
+			}
+		})
+	}
+}
+
+func TestAccessModesEqual(t *testing.T) {
+	tests := []struct {
+		name     string
+		a        []corev1.PersistentVolumeAccessMode
+		b        []corev1.PersistentVolumeAccessMode
+		expected bool
+	}{
+		{
+			name:     "both nil",
+			a:        nil,
+			b:        nil,
+			expected: true,
+		},
+		{
+			name:     "both empty",
+			a:        []corev1.PersistentVolumeAccessMode{},
+			b:        []corev1.PersistentVolumeAccessMode{},
+			expected: true,
+		},
+		{
+			name:     "equal",
+			a:        []corev1.PersistentVolumeAccessMode{corev1.ReadWriteOnce},
+			b:        []corev1.PersistentVolumeAccessMode{corev1.ReadWriteOnce},
+			expected: true,
+		},
+		{
+			name:     "different",
+			a:        []corev1.PersistentVolumeAccessMode{corev1.ReadWriteOnce},
+			b:        []corev1.PersistentVolumeAccessMode{corev1.ReadWriteMany},
+			expected: false,
+		},
+		{
+			name:     "different length",
+			a:        []corev1.PersistentVolumeAccessMode{corev1.ReadWriteOnce},
+			b:        []corev1.PersistentVolumeAccessMode{corev1.ReadWriteOnce, corev1.ReadOnlyMany},
+			expected: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := accessModesEqual(tt.a, tt.b)
+			if result != tt.expected {
+				t.Errorf("accessModesEqual() = %v, want %v", result, tt.expected)
+			}
+		})
+	}
+}
+
+func TestVolumeModeEqual(t *testing.T) {
+	tests := []struct {
+		name     string
+		a        *corev1.PersistentVolumeMode
+		b        *corev1.PersistentVolumeMode
+		expected bool
+	}{
+		{name: "both nil", a: nil, b: nil, expected: true},
+		{name: "nil vs Filesystem", a: nil, b: ptr(corev1.PersistentVolumeFilesystem), expected: true},
+		{name: "Filesystem vs nil", a: ptr(corev1.PersistentVolumeFilesystem), b: nil, expected: true},
+		{name: "both Filesystem", a: ptr(corev1.PersistentVolumeFilesystem), b: ptr(corev1.PersistentVolumeFilesystem), expected: true},
+		{name: "Block vs Filesystem", a: ptr(corev1.PersistentVolumeBlock), b: ptr(corev1.PersistentVolumeFilesystem), expected: false},
+		{name: "Filesystem vs Block", a: ptr(corev1.PersistentVolumeFilesystem), b: ptr(corev1.PersistentVolumeBlock), expected: false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := volumeModeEqual(tt.a, tt.b)
+			if result != tt.expected {
+				t.Errorf("volumeModeEqual() = %v, want %v", result, tt.expected)
+			}
+		})
+	}
+}
+
+func TestLabelSelectorEqual(t *testing.T) {
+	tests := []struct {
+		name     string
+		a        *metav1.LabelSelector
+		b        *metav1.LabelSelector
+		expected bool
+	}{
+		{name: "both nil", a: nil, b: nil, expected: true},
+		{name: "one nil", a: nil, b: &metav1.LabelSelector{}, expected: false},
+		{name: "empty vs empty", a: &metav1.LabelSelector{}, b: &metav1.LabelSelector{}, expected: true},
+		{name: "equal matchLabels", a: &metav1.LabelSelector{MatchLabels: map[string]string{"app": "test"}}, b: &metav1.LabelSelector{MatchLabels: map[string]string{"app": "test"}}, expected: true},
+		{name: "different matchLabels", a: &metav1.LabelSelector{MatchLabels: map[string]string{"app": "test"}}, b: &metav1.LabelSelector{MatchLabels: map[string]string{"app": "other"}}, expected: false},
+		{name: "equal matchExpressions", a: &metav1.LabelSelector{MatchExpressions: []metav1.LabelSelectorRequirement{{Key: "env", Operator: metav1.LabelSelectorOpIn, Values: []string{"prod"}}}}, b: &metav1.LabelSelector{MatchExpressions: []metav1.LabelSelectorRequirement{{Key: "env", Operator: metav1.LabelSelectorOpIn, Values: []string{"prod"}}}}, expected: true},
+		{name: "different matchExpressions", a: &metav1.LabelSelector{MatchExpressions: []metav1.LabelSelectorRequirement{{Key: "env", Operator: metav1.LabelSelectorOpIn, Values: []string{"prod"}}}}, b: &metav1.LabelSelector{MatchExpressions: []metav1.LabelSelectorRequirement{{Key: "env", Operator: metav1.LabelSelectorOpIn, Values: []string{"dev"}}}}, expected: false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := labelSelectorEqual(tt.a, tt.b)
+			if result != tt.expected {
+				t.Errorf("labelSelectorEqual() = %v, want %v", result, tt.expected)
+			}
+		})
+	}
+}
+
+func TestVolumeNameEqual(t *testing.T) {
+	tests := []struct {
+		name     string
+		a        string
+		b        string
+		expected bool
+	}{
+		{name: "both empty", a: "", b: "", expected: true},
+		{name: "equal", a: "pvc-123", b: "pvc-123", expected: true},
+		{name: "different", a: "pvc-123", b: "pvc-456", expected: false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := volumeNameEqual(tt.a, tt.b)
+			if result != tt.expected {
+				t.Errorf("volumeNameEqual() = %v, want %v", result, tt.expected)
+			}
+		})
+	}
+}
+
+// nolint:dupl
+func TestDataSourceEqual(t *testing.T) {
+	tests := []struct {
+		name     string
+		a        *corev1.TypedLocalObjectReference
+		b        *corev1.TypedLocalObjectReference
+		expected bool
+	}{
+		{name: "both nil", a: nil, b: nil, expected: true},
+		{name: "one nil", a: nil, b: &corev1.TypedLocalObjectReference{}, expected: false},
+		{name: "equal", a: &corev1.TypedLocalObjectReference{APIGroup: ptr(""), Kind: "VolumeSnapshot", Name: "snap-1"}, b: &corev1.TypedLocalObjectReference{APIGroup: ptr(""), Kind: "VolumeSnapshot", Name: "snap-1"}, expected: true},
+		{name: "different name", a: &corev1.TypedLocalObjectReference{APIGroup: ptr(""), Kind: "VolumeSnapshot", Name: "snap-1"}, b: &corev1.TypedLocalObjectReference{APIGroup: ptr(""), Kind: "VolumeSnapshot", Name: "snap-2"}, expected: false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := dataSourceEqual(tt.a, tt.b)
+			if result != tt.expected {
+				t.Errorf("dataSourceEqual() = %v, want %v", result, tt.expected)
+			}
+		})
+	}
+}
+
+// nolint:dupl
+func TestDataSourceRefEqual(t *testing.T) {
+	tests := []struct {
+		name     string
+		a        *corev1.TypedObjectReference
+		b        *corev1.TypedObjectReference
+		expected bool
+	}{
+		{name: "both nil", a: nil, b: nil, expected: true},
+		{name: "one nil", a: nil, b: &corev1.TypedObjectReference{}, expected: false},
+		{name: "equal", a: &corev1.TypedObjectReference{APIGroup: ptr(""), Kind: "VolumeSnapshot", Name: "snap-1"}, b: &corev1.TypedObjectReference{APIGroup: ptr(""), Kind: "VolumeSnapshot", Name: "snap-1"}, expected: true},
+		{name: "different kind", a: &corev1.TypedObjectReference{APIGroup: ptr(""), Kind: "VolumeSnapshot", Name: "snap-1"}, b: &corev1.TypedObjectReference{APIGroup: ptr(""), Kind: "PVC", Name: "snap-1"}, expected: false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := dataSourceRefEqual(tt.a, tt.b)
+			if result != tt.expected {
+				t.Errorf("dataSourceRefEqual() = %v, want %v", result, tt.expected)
+			}
+		})
+	}
+}
+
+func TestVolumeAttributesClassNameEqual(t *testing.T) {
+	tests := []struct {
+		name     string
+		a        *string
+		b        *string
+		expected bool
+	}{
+		{name: "both nil", a: nil, b: nil, expected: true},
+		{name: "one nil", a: nil, b: ptr("class-1"), expected: false},
+		{name: "equal", a: ptr("class-1"), b: ptr("class-1"), expected: true},
+		{name: "different", a: ptr("class-1"), b: ptr("class-2"), expected: false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := volumeAttributesClassNameEqual(tt.a, tt.b)
+			if result != tt.expected {
+				t.Errorf("volumeAttributesClassNameEqual() = %v, want %v", result, tt.expected)
+			}
+		})
+	}
+}
+
+func TestReconcileInfrastructure_VCTMismatchOnReadyDB(t *testing.T) {
+	scheme := ownershipScheme(t)
+	cfg := minimalCR(testCRName, testNamespace)
+	cfg.Spec.Cache.Deploy = boolPtr(false)
+
+	// Pre-create a ready StatefulSet with 10Gi storage
+	existing := resources.DatabaseStatefulSet(cfg)
+	existing.Spec.VolumeClaimTemplates[0].Spec.Resources.Requests[corev1.ResourceStorage] = resource.MustParse("10Gi")
+	replicas := int32(1)
+	existing.Spec.Replicas = &replicas
+
+	// Mark the DB as ready in status so reconcileInfrastructure would normally set DatabaseAvailable
+	c := fakeClientPreservingStatus(scheme, existing)
+	markStatefulSetReady(t, c, testNamespace, resources.NameDatabase(cfg))
+
+	r := &CostManagementServiceConfigReconciler{
+		Client:   c,
+		Scheme:   scheme,
+		Recorder: &noopRecorder{},
+	}
+
+	// Simulate user changing storage size to 20Gi in spec
+	cfg.Spec.Database.Storage.Size = resource.MustParse("20Gi")
+
+	result, err := r.reconcileInfrastructure(context.Background(), cfg)
+	if err != nil {
+		t.Fatalf("reconcileInfrastructure: %v", err)
+	}
+
+	// Should requeue and NOT overwrite StorageConfigChanged condition
+	if result.RequeueAfter == 0 {
+		t.Fatal("expected requeue on VCT mismatch")
+	}
+
+	cond := findCondition(cfg.Status.Conditions, costv1alpha1.ConditionDatabaseReady)
+	if cond == nil || cond.Status != metav1.ConditionFalse || cond.Reason != "StorageConfigChanged" {
+		t.Fatalf("expected DatabaseReady=False StorageConfigChanged, got %+v", cond)
+	}
+}
+
+func ptr[T any](v T) *T {
+	return &v
 }

--- a/internal/controller/costmanagementserviceconfig_controller.go
+++ b/internal/controller/costmanagementserviceconfig_controller.go
@@ -3,6 +3,7 @@ package controller
 import (
 	"context"
 	"fmt"
+	"maps"
 	"strings"
 	"time"
 
@@ -929,9 +930,9 @@ var ErrStorageConfigChanged = fmt.Errorf("storage config changed: VolumeClaimTem
 // volumeClaimTemplatesEqual compares two VolumeClaimTemplate slices for equality
 // of the immutable fields. It normalizes defaulted values per Kubernetes API
 // conventions before comparison to avoid false mismatches.
-// Compared fields: Name, StorageClassName, Resources (Requests & Limits),
-// AccessModes, VolumeMode, Selector, VolumeName, DataSource, DataSourceRef,
-// VolumeAttributesClassName.
+// Compared fields: Name, Labels, Annotations, StorageClassName, Resources
+// (Requests & Limits), AccessModes, VolumeMode, Selector, VolumeName,
+// DataSource, DataSourceRef (including Namespace), VolumeAttributesClassName.
 func volumeClaimTemplatesEqual(a, b []corev1.PersistentVolumeClaim) bool {
 	if len(a) != len(b) {
 		return false
@@ -940,11 +941,13 @@ func volumeClaimTemplatesEqual(a, b []corev1.PersistentVolumeClaim) bool {
 		if a[i].Name != b[i].Name {
 			return false
 		}
-		if a[i].Spec.StorageClassName != nil && b[i].Spec.StorageClassName != nil {
-			if *a[i].Spec.StorageClassName != *b[i].Spec.StorageClassName {
-				return false
-			}
-		} else if (a[i].Spec.StorageClassName == nil) != (b[i].Spec.StorageClassName == nil) {
+		if !maps.Equal(a[i].Labels, b[i].Labels) {
+			return false
+		}
+		if !maps.Equal(a[i].Annotations, b[i].Annotations) {
+			return false
+		}
+		if !ptrEqual(a[i].Spec.StorageClassName, b[i].Spec.StorageClassName) {
 			return false
 		}
 		if !resourceRequirementsEqual(a[i].Spec.Resources, b[i].Spec.Resources) {
@@ -1012,7 +1015,9 @@ func accessModesEqual(a, b []corev1.PersistentVolumeAccessMode) bool {
 }
 
 func volumeModeEqual(a, b *corev1.PersistentVolumeMode) bool {
-	// nil and Filesystem are equivalent per Kubernetes defaulting
+	// PersistentVolumeClaimSpec.VolumeMode defaults to Filesystem when unset
+	// (Kubernetes API defaulting). Treat nil and Filesystem as equal so live
+	// vs desired comparisons do not false-mismatch after defaulting.
 	if a == nil && b == nil {
 		return true
 	}
@@ -1085,7 +1090,7 @@ func dataSourceRefEqual(a, b *corev1.TypedObjectReference) bool {
 	if a == nil || b == nil {
 		return false
 	}
-	return ptrEqual(a.APIGroup, b.APIGroup) && a.Kind == b.Kind && a.Name == b.Name
+	return ptrEqual(a.APIGroup, b.APIGroup) && a.Kind == b.Kind && a.Name == b.Name && ptrEqual(a.Namespace, b.Namespace)
 }
 
 func volumeAttributesClassNameEqual(a, b *string) bool {

--- a/internal/controller/costmanagementserviceconfig_controller.go
+++ b/internal/controller/costmanagementserviceconfig_controller.go
@@ -1174,7 +1174,25 @@ func (r *CostManagementServiceConfigReconciler) isStatefulSetReady(ctx context.C
 	if ss.Spec.Replicas == nil || *ss.Spec.Replicas == 0 {
 		return true, nil
 	}
-	return ss.Status.ReadyReplicas >= *ss.Spec.Replicas, nil
+	want := *ss.Spec.Replicas
+	// ObservedGeneration lags metadata.generation until the controller has
+	// seen the SSA-applied spec. ReadyReplicas alone can still be the old
+	// revision's pods.
+	if ss.Status.ObservedGeneration < ss.Generation {
+		return false, nil
+	}
+	if ss.Status.ReadyReplicas < want {
+		return false, nil
+	}
+	if ss.Status.UpdateRevision != "" && ss.Status.CurrentRevision != ss.Status.UpdateRevision {
+		return false, nil
+	}
+	// UpdatedReplicas is 0 on first create until an update revision exists;
+	// once the controller reports any updated pods, all replicas must match.
+	if ss.Status.UpdatedReplicas > 0 && ss.Status.UpdatedReplicas < want {
+		return false, nil
+	}
+	return true, nil
 }
 
 func isJobComplete(j *batchv1.Job) bool {

--- a/internal/controller/costmanagementserviceconfig_controller.go
+++ b/internal/controller/costmanagementserviceconfig_controller.go
@@ -892,9 +892,11 @@ func (r *CostManagementServiceConfigReconciler) ensureServiceAccount(
 
 // applyStatefulSet applies a StatefulSet using Server-Side Apply (SSA).
 // VolumeClaimTemplates are immutable; if they differ from the existing
-// StatefulSet, we set a DatabaseReady=False condition with StorageConfigChanged
-// reason and skip the SSA apply, returning ErrStorageConfigChanged to signal
-// the caller to stop reconciliation before overwriting the condition.
+// StatefulSet, we set DatabaseReady/Available=False and Degraded=True with
+// StorageConfigChanged and skip the SSA apply, returning ErrStorageConfigChanged
+// so the caller stops before later phases overwrite those conditions.
+// When VCT matches, the live templates are copied onto desired so SSA never
+// proposes a VCT update (API defaulting / managedFields must not 403).
 func (r *CostManagementServiceConfigReconciler) applyStatefulSet(ctx context.Context, cfg *costv1alpha1.CostManagementServiceConfig, desired *appsv1.StatefulSet) error {
 	existing := &appsv1.StatefulSet{}
 	err := r.Get(ctx, types.NamespacedName{Namespace: desired.Namespace, Name: desired.Name}, existing)
@@ -907,13 +909,16 @@ func (r *CostManagementServiceConfigReconciler) applyStatefulSet(ctx context.Con
 
 	// Check if VolumeClaimTemplates differ (immutable field).
 	if !volumeClaimTemplatesEqual(existing.Spec.VolumeClaimTemplates, desired.Spec.VolumeClaimTemplates) {
-		r.setCondition(cfg, costv1alpha1.ConditionDatabaseReady, metav1.ConditionFalse,
-			"StorageConfigChanged",
-			"PVC size or storageClass change detected in VolumeClaimTemplates; manual intervention required")
+		msg := "immutable VolumeClaimTemplates change detected; manual intervention required"
+		r.setCondition(cfg, costv1alpha1.ConditionDatabaseReady, metav1.ConditionFalse, "StorageConfigChanged", msg)
+		r.setCondition(cfg, costv1alpha1.ConditionAvailable, metav1.ConditionFalse, "StorageConfigChanged", msg)
+		r.setCondition(cfg, costv1alpha1.ConditionDegraded, metav1.ConditionTrue, "StorageConfigChanged", msg)
+		cfg.Status.Phase = costv1alpha1.PhaseDegraded
 		return ErrStorageConfigChanged
 	}
 
-	// Use SSA for all other mutable fields.
+	// Stamp live VCT onto desired so SSA only updates mutable fields.
+	desired.Spec.VolumeClaimTemplates = append([]corev1.PersistentVolumeClaim(nil), existing.Spec.VolumeClaimTemplates...)
 	return r.apply(ctx, cfg, desired)
 }
 

--- a/internal/controller/costmanagementserviceconfig_controller.go
+++ b/internal/controller/costmanagementserviceconfig_controller.go
@@ -23,6 +23,8 @@ import (
 
 	costv1alpha1 "github.com/project-koku/koku-service-operator/api/v1alpha1"
 	"github.com/project-koku/koku-service-operator/internal/resources"
+
+	stderrors "errors"
 )
 
 const (
@@ -309,6 +311,10 @@ func (r *CostManagementServiceConfigReconciler) reconcileInfrastructure(ctx cont
 			return Result{}, fmt.Errorf("database service: %w", err)
 		}
 		if err := r.applyStatefulSet(ctx, cfg, resources.DatabaseStatefulSet(cfg)); err != nil {
+			if stderrors.Is(err, ErrStorageConfigChanged) {
+				// VCT mismatch: condition already set, stop reconciliation to avoid overwriting it.
+				return Result{RequeueAfter: requeueFast}, nil
+			}
 			return Result{}, fmt.Errorf("database statefulset: %w", err)
 		}
 		// Gate: wait for the DB pod to be ready.
@@ -884,29 +890,217 @@ func (r *CostManagementServiceConfigReconciler) ensureServiceAccount(
 	return r.apply(ctx, cfg, sa)
 }
 
-// applyStatefulSet applies a StatefulSet, handling the VolumeClaimTemplate
-// immutability constraint by creating on first call and only patching spec
-// (not VCT) on subsequent calls.
+// applyStatefulSet applies a StatefulSet using Server-Side Apply (SSA).
+// VolumeClaimTemplates are immutable; if they differ from the existing
+// StatefulSet, we set a DatabaseReady=False condition with StorageConfigChanged
+// reason and skip the SSA apply, returning ErrStorageConfigChanged to signal
+// the caller to stop reconciliation before overwriting the condition.
 func (r *CostManagementServiceConfigReconciler) applyStatefulSet(ctx context.Context, cfg *costv1alpha1.CostManagementServiceConfig, desired *appsv1.StatefulSet) error {
 	existing := &appsv1.StatefulSet{}
 	err := r.Get(ctx, types.NamespacedName{Namespace: desired.Namespace, Name: desired.Name}, existing)
 	if errors.IsNotFound(err) {
-		setOwnerRef(cfg, desired)
-		return r.Create(ctx, desired)
+		return r.apply(ctx, cfg, desired)
 	}
 	if err != nil {
 		return err
 	}
-	// Only update mutable fields (replicas, container image, resources, pull secrets).
-	patch := existing.DeepCopy()
-	patch.Spec.Replicas = desired.Spec.Replicas
-	patch.Spec.Template.Spec.ImagePullSecrets = desired.Spec.Template.Spec.ImagePullSecrets
-	if len(patch.Spec.Template.Spec.Containers) > 0 && len(desired.Spec.Template.Spec.Containers) > 0 {
-		patch.Spec.Template.Spec.Containers[0].Image = desired.Spec.Template.Spec.Containers[0].Image
-		patch.Spec.Template.Spec.Containers[0].Resources = desired.Spec.Template.Spec.Containers[0].Resources
-		patch.Spec.Template.Spec.Containers[0].Env = desired.Spec.Template.Spec.Containers[0].Env
+
+	// Check if VolumeClaimTemplates differ (immutable field).
+	if !volumeClaimTemplatesEqual(existing.Spec.VolumeClaimTemplates, desired.Spec.VolumeClaimTemplates) {
+		r.setCondition(cfg, costv1alpha1.ConditionDatabaseReady, metav1.ConditionFalse,
+			"StorageConfigChanged",
+			"PVC size or storageClass change detected in VolumeClaimTemplates; manual intervention required")
+		return ErrStorageConfigChanged
 	}
-	return r.Update(ctx, patch)
+
+	// Use SSA for all other mutable fields.
+	return r.apply(ctx, cfg, desired)
+}
+
+// ErrStorageConfigChanged signals that VolumeClaimTemplates differ and
+// reconciliation should stop to avoid overwriting the StorageConfigChanged condition.
+var ErrStorageConfigChanged = fmt.Errorf("storage config changed: VolumeClaimTemplates are immutable")
+
+// volumeClaimTemplatesEqual compares two VolumeClaimTemplate slices for equality
+// of the immutable fields. It normalizes defaulted values per Kubernetes API
+// conventions before comparison to avoid false mismatches.
+// Compared fields: Name, StorageClassName, Resources (Requests & Limits),
+// AccessModes, VolumeMode, Selector, VolumeName, DataSource, DataSourceRef,
+// VolumeAttributesClassName.
+func volumeClaimTemplatesEqual(a, b []corev1.PersistentVolumeClaim) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i].Name != b[i].Name {
+			return false
+		}
+		if a[i].Spec.StorageClassName != nil && b[i].Spec.StorageClassName != nil {
+			if *a[i].Spec.StorageClassName != *b[i].Spec.StorageClassName {
+				return false
+			}
+		} else if (a[i].Spec.StorageClassName == nil) != (b[i].Spec.StorageClassName == nil) {
+			return false
+		}
+		if !resourceRequirementsEqual(a[i].Spec.Resources, b[i].Spec.Resources) {
+			return false
+		}
+		if !accessModesEqual(a[i].Spec.AccessModes, b[i].Spec.AccessModes) {
+			return false
+		}
+		if !volumeModeEqual(a[i].Spec.VolumeMode, b[i].Spec.VolumeMode) {
+			return false
+		}
+		if !labelSelectorEqual(a[i].Spec.Selector, b[i].Spec.Selector) {
+			return false
+		}
+		if !volumeNameEqual(a[i].Spec.VolumeName, b[i].Spec.VolumeName) {
+			return false
+		}
+		if !dataSourceEqual(a[i].Spec.DataSource, b[i].Spec.DataSource) {
+			return false
+		}
+		if !dataSourceRefEqual(a[i].Spec.DataSourceRef, b[i].Spec.DataSourceRef) {
+			return false
+		}
+		if !volumeAttributesClassNameEqual(a[i].Spec.VolumeAttributesClassName, b[i].Spec.VolumeAttributesClassName) {
+			return false
+		}
+	}
+	return true
+}
+
+func resourceRequirementsEqual(a, b corev1.VolumeResourceRequirements) bool {
+	// Compare both Requests and Limits, treating nil and empty as equivalent
+	// to handle Kubernetes API defaulting.
+	if !resourceListEqual(a.Requests, b.Requests) {
+		return false
+	}
+	if !resourceListEqual(a.Limits, b.Limits) {
+		return false
+	}
+	return true
+}
+
+func resourceListEqual(a, b corev1.ResourceList) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for k, v := range a {
+		if v2, ok := b[k]; !ok || !v.Equal(v2) {
+			return false
+		}
+	}
+	return true
+}
+
+func accessModesEqual(a, b []corev1.PersistentVolumeAccessMode) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}
+
+func volumeModeEqual(a, b *corev1.PersistentVolumeMode) bool {
+	// nil and Filesystem are equivalent per Kubernetes defaulting
+	if a == nil && b == nil {
+		return true
+	}
+	if a == nil && b != nil && *b == corev1.PersistentVolumeFilesystem {
+		return true
+	}
+	if b == nil && a != nil && *a == corev1.PersistentVolumeFilesystem {
+		return true
+	}
+	if a != nil && b != nil {
+		return *a == *b
+	}
+	return false
+}
+
+func labelSelectorEqual(a, b *metav1.LabelSelector) bool {
+	if a == nil && b == nil {
+		return true
+	}
+	if a == nil || b == nil {
+		return false
+	}
+	if len(a.MatchLabels) != len(b.MatchLabels) {
+		return false
+	}
+	for k, v := range a.MatchLabels {
+		if v2, ok := b.MatchLabels[k]; !ok || v != v2 {
+			return false
+		}
+	}
+	if len(a.MatchExpressions) != len(b.MatchExpressions) {
+		return false
+	}
+	for i := range a.MatchExpressions {
+		if a.MatchExpressions[i].Key != b.MatchExpressions[i].Key ||
+			a.MatchExpressions[i].Operator != b.MatchExpressions[i].Operator {
+			return false
+		}
+		if len(a.MatchExpressions[i].Values) != len(b.MatchExpressions[i].Values) {
+			return false
+		}
+		for j := range a.MatchExpressions[i].Values {
+			if a.MatchExpressions[i].Values[j] != b.MatchExpressions[i].Values[j] {
+				return false
+			}
+		}
+	}
+	return true
+}
+
+func volumeNameEqual(a, b string) bool {
+	// Empty string and nil are equivalent (Kubernetes treats unset as empty)
+	return a == b
+}
+
+func dataSourceEqual(a, b *corev1.TypedLocalObjectReference) bool {
+	if a == nil && b == nil {
+		return true
+	}
+	if a == nil || b == nil {
+		return false
+	}
+	return ptrEqual(a.APIGroup, b.APIGroup) && a.Kind == b.Kind && a.Name == b.Name
+}
+
+func dataSourceRefEqual(a, b *corev1.TypedObjectReference) bool {
+	if a == nil && b == nil {
+		return true
+	}
+	if a == nil || b == nil {
+		return false
+	}
+	return ptrEqual(a.APIGroup, b.APIGroup) && a.Kind == b.Kind && a.Name == b.Name
+}
+
+func volumeAttributesClassNameEqual(a, b *string) bool {
+	if a == nil && b == nil {
+		return true
+	}
+	if a == nil || b == nil {
+		return false
+	}
+	return *a == *b
+}
+
+func ptrEqual(a, b *string) bool {
+	if a == nil && b == nil {
+		return true
+	}
+	if a == nil || b == nil {
+		return false
+	}
+	return *a == *b
 }
 
 // ensureSecret creates the secret only if it does not already exist.

--- a/internal/controller/costmanagementserviceconfig_controller.go
+++ b/internal/controller/costmanagementserviceconfig_controller.go
@@ -910,11 +910,14 @@ func (r *CostManagementServiceConfigReconciler) applyStatefulSet(ctx context.Con
 
 	// Check if VolumeClaimTemplates differ (immutable field).
 	if !volumeClaimTemplatesEqual(existing.Spec.VolumeClaimTemplates, desired.Spec.VolumeClaimTemplates) {
-		msg := "immutable VolumeClaimTemplates change detected; manual intervention required"
+		diff := volumeClaimTemplateDiff(existing.Spec.VolumeClaimTemplates, desired.Spec.VolumeClaimTemplates)
+		msg := fmt.Sprintf("immutable VolumeClaimTemplates change (%s); revert spec.database.storage.size or spec.global.storageClass to match the live volume, or delete the StatefulSet and PVC to recreate", diff)
 		r.setCondition(cfg, costv1alpha1.ConditionDatabaseReady, metav1.ConditionFalse, "StorageConfigChanged", msg)
 		r.setCondition(cfg, costv1alpha1.ConditionAvailable, metav1.ConditionFalse, "StorageConfigChanged", msg)
 		r.setCondition(cfg, costv1alpha1.ConditionDegraded, metav1.ConditionTrue, "StorageConfigChanged", msg)
+		r.setCondition(cfg, costv1alpha1.ConditionProgressing, metav1.ConditionFalse, "StorageConfigChanged", msg)
 		cfg.Status.Phase = costv1alpha1.PhaseDegraded
+		r.Recorder.Eventf(cfg, corev1.EventTypeWarning, "StorageConfigChanged", "%s", msg)
 		return ErrStorageConfigChanged
 	}
 
@@ -926,6 +929,41 @@ func (r *CostManagementServiceConfigReconciler) applyStatefulSet(ctx context.Con
 // ErrStorageConfigChanged signals that VolumeClaimTemplates differ and
 // reconciliation should stop to avoid overwriting the StorageConfigChanged condition.
 var ErrStorageConfigChanged = fmt.Errorf("storage config changed: VolumeClaimTemplates are immutable")
+
+// volumeClaimTemplateDiff summarizes live vs desired VolumeClaimTemplate
+// changes for status messages. Size and storageClass are the CR-driven fields.
+func volumeClaimTemplateDiff(live, desired []corev1.PersistentVolumeClaim) string {
+	if len(live) != len(desired) {
+		return fmt.Sprintf("count %d -> %d", len(live), len(desired))
+	}
+	var parts []string
+	for i := range live {
+		name := live[i].Name
+		if live[i].Name != desired[i].Name {
+			parts = append(parts, fmt.Sprintf("name %q -> %q", live[i].Name, desired[i].Name))
+			name = desired[i].Name
+		}
+		liveSize := live[i].Spec.Resources.Requests[corev1.ResourceStorage]
+		desiredSize := desired[i].Spec.Resources.Requests[corev1.ResourceStorage]
+		if !liveSize.Equal(desiredSize) {
+			parts = append(parts, fmt.Sprintf("%s size %s -> %s", name, liveSize.String(), desiredSize.String()))
+		}
+		if !ptrEqual(live[i].Spec.StorageClassName, desired[i].Spec.StorageClassName) {
+			parts = append(parts, fmt.Sprintf("%s storageClass %s -> %s", name, pvcStorageClass(live[i]), pvcStorageClass(desired[i])))
+		}
+	}
+	if len(parts) == 0 {
+		return "other immutable fields differ"
+	}
+	return strings.Join(parts, "; ")
+}
+
+func pvcStorageClass(pvc corev1.PersistentVolumeClaim) string {
+	if pvc.Spec.StorageClassName == nil || *pvc.Spec.StorageClassName == "" {
+		return "<unset>"
+	}
+	return *pvc.Spec.StorageClassName
+}
 
 // volumeClaimTemplatesEqual compares two VolumeClaimTemplate slices for equality
 // of the immutable fields. It normalizes defaulted values per Kubernetes API

--- a/internal/controller/readiness_test.go
+++ b/internal/controller/readiness_test.go
@@ -86,9 +86,15 @@ func TestIsStatefulSetReady(t *testing.T) {
 		{
 			name: "ready",
 			ss: &appsv1.StatefulSet{
-				ObjectMeta: metav1.ObjectMeta{Name: "db", Namespace: "ns"},
+				ObjectMeta: metav1.ObjectMeta{Name: "db", Namespace: "ns", Generation: 1},
 				Spec:       appsv1.StatefulSetSpec{Replicas: int32Ptr(1)},
-				Status:     appsv1.StatefulSetStatus{ReadyReplicas: 1},
+				Status: appsv1.StatefulSetStatus{
+					ObservedGeneration: 1,
+					ReadyReplicas:      1,
+					UpdatedReplicas:    1,
+					CurrentRevision:    "rev-a",
+					UpdateRevision:     "rev-a",
+				},
 			},
 			want: true,
 		},
@@ -98,6 +104,51 @@ func TestIsStatefulSetReady(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{Name: "db", Namespace: "ns"},
 				Spec:       appsv1.StatefulSetSpec{Replicas: int32Ptr(1)},
 				Status:     appsv1.StatefulSetStatus{ReadyReplicas: 0},
+			},
+			want: false,
+		},
+		{
+			name: "stale observed generation",
+			ss: &appsv1.StatefulSet{
+				ObjectMeta: metav1.ObjectMeta{Name: "db", Namespace: "ns", Generation: 2},
+				Spec:       appsv1.StatefulSetSpec{Replicas: int32Ptr(1)},
+				Status: appsv1.StatefulSetStatus{
+					ObservedGeneration: 1,
+					ReadyReplicas:      1,
+					UpdatedReplicas:    1,
+					CurrentRevision:    "rev-a",
+					UpdateRevision:     "rev-a",
+				},
+			},
+			want: false,
+		},
+		{
+			name: "stale pods during rollout",
+			ss: &appsv1.StatefulSet{
+				ObjectMeta: metav1.ObjectMeta{Name: "db", Namespace: "ns", Generation: 2},
+				Spec:       appsv1.StatefulSetSpec{Replicas: int32Ptr(1)},
+				Status: appsv1.StatefulSetStatus{
+					ObservedGeneration: 2,
+					ReadyReplicas:      1,
+					UpdatedReplicas:    0,
+					CurrentRevision:    "rev-old",
+					UpdateRevision:     "rev-new",
+				},
+			},
+			want: false,
+		},
+		{
+			name: "updated replicas lag desired",
+			ss: &appsv1.StatefulSet{
+				ObjectMeta: metav1.ObjectMeta{Name: "db", Namespace: "ns", Generation: 2},
+				Spec:       appsv1.StatefulSetSpec{Replicas: int32Ptr(2)},
+				Status: appsv1.StatefulSetStatus{
+					ObservedGeneration: 2,
+					ReadyReplicas:      2,
+					UpdatedReplicas:    1,
+					CurrentRevision:    "rev-a",
+					UpdateRevision:     "rev-a",
+				},
 			},
 			want: false,
 		},

--- a/internal/controller/shared_config_test.go
+++ b/internal/controller/shared_config_test.go
@@ -199,6 +199,25 @@ func markDeploymentReady(t *testing.T, c client.Client, ns, name string) {
 	}
 }
 
+// markStatefulSetReady sets ReadyReplicas to Spec.Replicas so isStatefulSetReady
+// returns true. Requires a client built with WithStatusSubresource(&appsv1.StatefulSet{}).
+func markStatefulSetReady(t *testing.T, c client.Client, ns, name string) {
+	t.Helper()
+	sts := &appsv1.StatefulSet{}
+	if err := c.Get(context.Background(), types.NamespacedName{Namespace: ns, Name: name}, sts); err != nil {
+		t.Fatalf("get statefulset %s: %v", name, err)
+	}
+	replicas := int32(1)
+	if sts.Spec.Replicas != nil {
+		replicas = *sts.Spec.Replicas
+	}
+	sts.Status.ReadyReplicas = replicas
+	sts.Status.Replicas = replicas
+	if err := c.Status().Update(context.Background(), sts); err != nil {
+		t.Fatalf("mark statefulset %s ready: %v", name, err)
+	}
+}
+
 func TestReconcileSharedConfig_CreatesStorageCredentialsPlaceholder(t *testing.T) {
 	const ns = "test"
 	cfg := &costv1alpha1.CostManagementServiceConfig{

--- a/internal/controller/shared_config_test.go
+++ b/internal/controller/shared_config_test.go
@@ -199,8 +199,9 @@ func markDeploymentReady(t *testing.T, c client.Client, ns, name string) {
 	}
 }
 
-// markStatefulSetReady sets ReadyReplicas to Spec.Replicas so isStatefulSetReady
-// returns true. Requires a client built with WithStatusSubresource(&appsv1.StatefulSet{}).
+// markStatefulSetReady sets status so isStatefulSetReady returns true: the
+// observed generation matches, replicas are ready, and current==update revision.
+// Requires a client built with WithStatusSubresource(&appsv1.StatefulSet{}).
 func markStatefulSetReady(t *testing.T, c client.Client, ns, name string) {
 	t.Helper()
 	sts := &appsv1.StatefulSet{}
@@ -211,8 +212,12 @@ func markStatefulSetReady(t *testing.T, c client.Client, ns, name string) {
 	if sts.Spec.Replicas != nil {
 		replicas = *sts.Spec.Replicas
 	}
+	sts.Status.ObservedGeneration = sts.Generation
 	sts.Status.ReadyReplicas = replicas
 	sts.Status.Replicas = replicas
+	sts.Status.UpdatedReplicas = replicas
+	sts.Status.CurrentRevision = "rev-current"
+	sts.Status.UpdateRevision = "rev-current"
 	if err := c.Status().Update(context.Background(), sts); err != nil {
 		t.Fatalf("mark statefulset %s ready: %v", name, err)
 	}


### PR DESCRIPTION
## Summary
- Refactors `applyStatefulSet` to Server-Side Apply for mutable StatefulSet fields.
- Detects immutable VolumeClaimTemplate changes, sets `DatabaseReady`/`Available`=`False` and `Degraded`=`True` (`StorageConfigChanged`), and skips the apply.
- Copies live VCT onto desired before SSA so API defaulting cannot 403 an otherwise matching update.

This is the review-fixed follow-up to #97: merge regressions against `main` (CI/Go, conditions, TLS/CA, RBAC/gateway/ingress gates, docs) are restored, so the diff vs `main` is the G1 StatefulSet work only.

## Test plan
- [ ] `go test ./internal/controller/ -run 'TestApplyStatefulSet_|TestReconcileInfrastructure_VCT'`
- [ ] Confirm VCT size change does not update image/replicas and sets `Available=False` + `Degraded=True`
- [ ] Confirm defaulted `volumeMode` on the live STS is preserved across SSA
- [ ] Confirm govulncheck CI is unsuppressed (`go 1.25.13`)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

- Use Server-Side Apply for mutable fields in the bundled PostgreSQL StatefulSet.
- Preserve live `VolumeClaimTemplates` before apply to retain API-defaulted values.
- Detect immutable storage changes and skip the StatefulSet apply.
- Requeue reconciliation when storage changes occur.
- Set `DatabaseReady=False`, `Available=False`, and `Degraded=True` with reason `StorageConfigChanged`.
- Require current generation, ready replicas, revision, and updated replicas before reporting StatefulSet readiness.
- Add tests for SSA updates, drift correction, VCT comparisons, live VCT preservation, rollout readiness, and status conditions.

## Operator impact

- CRD API compatibility is unchanged.
- Mutable StatefulSet drift is corrected during reconciliation.
- Immutable `VolumeClaimTemplate` changes do not modify the StatefulSet.
- Storage changes place the resource in the `Degraded` phase and report explicit status conditions.
- Reconciliation waits for the desired StatefulSet revision before continuing.
- The restored changes include CI, Go, TLS, CA, RBAC, gateway, ingress, Route TLS, and documentation updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->