### PR TITLE
COST-7683 bucket creation docs

### DIFF
--- a/api/v1alpha1/costmanagementserviceconfig_types.go
+++ b/api/v1alpha1/costmanagementserviceconfig_types.go
@@ -375,6 +375,7 @@ type IngressConfig struct {
 	// When empty, the operator uses the same bucket as Koku REQUESTED_BUCKET
 	// (status.discoveredConfig.s3.bucket, else spec.costManagement.storage.bucketName),
 	// then "koku-bucket".
+	// The bucket must already exist; the operator will not create it.
 	StagingBucket string                      `json:"stagingBucket,omitempty"`
 	Resources     corev1.ResourceRequirements `json:"resources,omitempty"`
 }
@@ -488,8 +489,12 @@ type CostManagementConfig struct {
 }
 
 type CostManagementStorageSpec struct {
+	// Bucket name for Cost Management object storage (Koku REQUESTED_BUCKET).
+	// The bucket must already exist; the operator will not create it.
 	// +kubebuilder:default:="koku-bucket"
 	BucketName string `json:"bucketName,omitempty"`
+	// ROS object-storage bucket. Required when ros.enabled is true.
+	// The bucket must already exist; the operator will not create it.
 	// +kubebuilder:default:="ros-data"
 	ROSBucketName string `json:"rosBucketName,omitempty"`
 }

--- a/config/crd/bases/service.costmanagement.openshift.io_costmanagementserviceconfigs.yaml
+++ b/config/crd/bases/service.costmanagement.openshift.io_costmanagementserviceconfigs.yaml
@@ -1342,9 +1342,15 @@ spec:
                     properties:
                       bucketName:
                         default: koku-bucket
+                        description: |-
+                          Bucket name for Cost Management object storage (Koku REQUESTED_BUCKET).
+                          The bucket must already exist; the operator will not create it.
                         type: string
                       rosBucketName:
                         default: ros-data
+                        description: |-
+                          ROS object-storage bucket. Required when ros.enabled is true.
+                          The bucket must already exist; the operator will not create it.
                         type: string
                     type: object
                 type: object
@@ -1628,6 +1634,7 @@ spec:
                       When empty, the operator uses the same bucket as Koku REQUESTED_BUCKET
                       (status.discoveredConfig.s3.bucket, else spec.costManagement.storage.bucketName),
                       then "koku-bucket".
+                      The bucket must already exist; the operator will not create it.
                     type: string
                   validTypes:
                     default: hccm

--- a/config/samples/byoi/README.md
+++ b/config/samples/byoi/README.md
@@ -32,6 +32,22 @@ is present.
 
 **Credentials in these YAMLs are fixed test values — not for production.**
 
+## Object storage buckets
+
+The operator does **not** create S3/MinIO/NooBaa/ODF buckets. It only stores
+connection details and env vars (`REQUESTED_BUCKET`, `INGRESS_STAGEBUCKET`, …).
+
+This fixture's MinIO init Job (`job/minio-init`) creates `koku-bucket` and
+`ros-data`. In production, create the Cost bucket
+(`spec.costManagement.storage.bucketName`, default `koku-bucket`) in
+MinIO/ODF/NooBaa **before** uploads.
+
+The Ingress staging bucket uses the same name as the Cost bucket unless
+`spec.ingress.stagingBucket` is set; that bucket must exist too.
+
+When `ros.enabled: true`, also create
+`spec.costManagement.storage.rosBucketName` (default `ros-data`).
+
 ## Prerequisites
 
 - Operator installed and running on the cluster

--- a/config/samples/byoi/infra/minio.yaml
+++ b/config/samples/byoi/infra/minio.yaml
@@ -102,7 +102,7 @@ spec:
           persistentVolumeClaim:
             claimName: minio-data
 ---
-# Create the buckets the operator / Koku expect by default.
+# Fixture-only (not operator behavior): create the buckets Koku expects by default.
 apiVersion: batch/v1
 kind: Job
 metadata:
@@ -154,6 +154,7 @@ spec:
                 echo "waiting for minio..."
                 sleep 3
               done
+              # Fixture-only: the operator does not create buckets.
               mc mb --ignore-existing local/koku-bucket
               mc mb --ignore-existing local/ros-data
               mc ls local

--- a/docs/development/clusterbot.md
+++ b/docs/development/clusterbot.md
@@ -103,6 +103,8 @@ If you already have AMQ Streams Kafka, point
 | **Auth / UI** | `AuthenticationReady`, `UIReady` | **Yes** False without Keycloak + OAuth mirror — needed for `Phase=Ready` / UI login |
 | **ROS** | `ROSEnabled=False` (CRD default / sample `ros.enabled: false`) | Expected for beta — no ROS/Kruize objects |
 
+The BYOI MinIO init Job creates `koku-bucket`; a customer S3 must have that bucket or uploads return 500.
+
 Reading conditions:
 
 ```bash

--- a/docs/development/clusterbot.md
+++ b/docs/development/clusterbot.md
@@ -103,7 +103,7 @@ If you already have AMQ Streams Kafka, point
 | **Auth / UI** | `AuthenticationReady`, `UIReady` | **Yes** False without Keycloak + OAuth mirror — needed for `Phase=Ready` / UI login |
 | **ROS** | `ROSEnabled=False` (CRD default / sample `ros.enabled: false`) | Expected for beta — no ROS/Kruize objects |
 
-The BYOI MinIO init Job creates `koku-bucket`; a customer S3 must have that bucket or uploads return 500.
+The BYOI MinIO init Job creates the default Cost bucket (`koku-bucket`); a customer S3 must already have `spec.costManagement.storage.bucketName` (default `koku-bucket`) or uploads return 500.
 
 Reading conditions:
 


### PR DESCRIPTION
## Summary
- Documents COST-7683 item 8: the operator never creates S3/MinIO/NooBaa/ODF buckets; the customer (or the BYOI MinIO init Job) must, before uploads.
- Installer-facing contract in the BYOI README, CR godoc/CRD (`bucketName`, `stagingBucket`, `rosBucketName`), clusterbot (`koku-bucket` or uploads 500), and a fixture-only note on the MinIO Job.
- No reconciler, RBAC, or `CreateBucket` changes. Ingress staging still follows the Cost bucket unless `spec.ingress.stagingBucket` is set.

## Test plan
- [ ] From `config/samples/byoi/README.md` alone, a new installer can answer “who creates `koku-bucket`?”
- [ ] CRD/godoc on `bucketName` and `stagingBucket` say the bucket must already exist
- [ ] `oc explain` (or CRD YAML) shows the new field descriptions after `make generate manifests`
- [ ] No Go / unit-test changes expected

Jira: [COST-7683](https://redhat.atlassian.net/browse/COST-7683) Item 8
