### PR TITLE
Set ENHANCED_ORG_ADMIN=False in KokuCommonEnv

### DIFF
--- a/docs/helm-vs-operator-comparison.md
+++ b/docs/helm-vs-operator-comparison.md
@@ -1,6 +1,6 @@
 # Helm Chart vs Operator Comparison Report
 
-Updated: 2026-08-20 (validated against `main`)
+Updated: 2026-08-20 (validated against `main` + feat/helm_gaps)
 
 Systematic comparison of `cost-onprem-chart/cost-onprem/` (Helm chart) against
 `koku-service-operator` (operator) — identifying deviations, missing pieces,
@@ -153,7 +153,7 @@ them (users can provide them via `spec.costManagement.api.env`):
 
 | Env Var | Chart Default | Operator | Impact |
 |---------|---------------|----------|--------|
-| `ENHANCED_ORG_ADMIN` | `"False"` | not set | **critical for RBAC scoping** |
+| `ENHANCED_ORG_ADMIN` | `"False"` | **set** (`"False"`) | **fixed** |
 | `DEVELOPMENT` | `"False"` | not set | koku defaults to "True" in dev? |
 | `KOKU_ENABLE_SENTRY` | `"False"` | not set | Sentry SDK may try to phone home |
 | `INITIAL_INGEST_NUM_MONTHS` | `"2"` | not set | may over-ingest |
@@ -168,10 +168,10 @@ them (users can provide them via `spec.costManagement.api.env`):
 Previously missing `RETAIN_NUM_MONTHS` is now set via a dedicated CR field
 (default `4`; chart was updated from `3` to `4` on 2026-08-10 — now matching).
 
-`ENHANCED_ORG_ADMIN` is particularly important: when True, Koku treats all
-org_admin users as having full access without checking RBAC. The chart's
-keycloakSync template validates this at render time. The operator should
-hardcode this to `"False"`.
+`ENHANCED_ORG_ADMIN` is now set to `"False"` in `KokuCommonEnv()` (fixed
+2026-08-20). When True, Koku treats all org_admin users as having full
+access without checking RBAC. The chart's keycloakSync template validates
+this at render time.
 
 ### 4.2 Logging env vars partially set
 
@@ -290,7 +290,7 @@ OpenShift Route annotation default should also be set for consistency.
 
 ## 7. Remaining Fixes (Priority Order)
 
-1. **Set `ENHANCED_ORG_ADMIN=False`** in `KokuCommonEnv()` — critical for RBAC scoping
+1. ~~**Set `ENHANCED_ORG_ADMIN=False`** in `KokuCommonEnv()` — critical for RBAC scoping~~ **DONE** (feat/helm_gaps)
 2. **Add Celery beat resources** (`koku.go`): set `{cpu: 50m, mem: 200Mi}` / `{cpu: 100m, mem: 400Mi}`
 3. **Fix Masu Service port** (`koku.go`): expose port 8000 (http) + 9000 (metrics)
 4. **Add ROS Processor + Poller Services**: needed for Prometheus metrics scraping

--- a/internal/resources/env.go
+++ b/internal/resources/env.go
@@ -69,6 +69,7 @@ func KokuCommonEnv(cfg *costv1alpha1.CostManagementServiceConfig) []corev1.EnvVa
 		EnvVal("RBAC_SERVICE_PORT", "8080"),
 		EnvVal("RBAC_SERVICE_PATH", "/api/rbac/v1/access/"),
 		EnvVal("RBAC_SERVICE_PROTOCOL", "http"),
+		EnvVal("ENHANCED_ORG_ADMIN", "False"),
 	}
 
 	// Celery result expiry (default 28800 = 8 hours)

--- a/internal/resources/env_test.go
+++ b/internal/resources/env_test.go
@@ -225,3 +225,17 @@ func TestMergeEnvOverrideReplacesBase(t *testing.T) {
 		t.Fatalf("expected 3 env vars, got %d", len(merged))
 	}
 }
+
+func TestKokuCommonEnvEnhancedOrgAdmin(t *testing.T) {
+	cfg := &costv1alpha1.CostManagementServiceConfig{
+		ObjectMeta: metav1.ObjectMeta{Name: "cost-management", Namespace: "cost-onprem"},
+	}
+	env := KokuCommonEnv(cfg)
+	got, ok := envValue(env, "ENHANCED_ORG_ADMIN")
+	if !ok {
+		t.Fatal("missing ENHANCED_ORG_ADMIN")
+	}
+	if got != "False" {
+		t.Errorf("ENHANCED_ORG_ADMIN = %q, want False", got)
+	}
+}


### PR DESCRIPTION
Critical for RBAC scoping - when True, Koku treats all org_admin users as having full access without checking RBAC. The Helm chart defaults this to False and validates it at render time. The operator now hardcodes it to False in the common env shared by all Koku workloads.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Add `ENHANCED_ORG_ADMIN=False` to `KokuCommonEnv`.
- Apply RBAC checks to `org_admin` users across Koku workloads.
- Match the Helm chart default and validation behavior.

## Operator impact

- No CRD API changes.
- Reconcile behavior changes through the shared container environment.
- `org_admin` users receive RBAC enforcement.
- No user-visible status condition changes.

## Tests

- Add coverage for the default `ENHANCED_ORG_ADMIN` value.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->