### PR TITLE
Add Celery beat resource limits

### DIFF
--- a/docs/helm-vs-operator-comparison.md
+++ b/docs/helm-vs-operator-comparison.md
@@ -1,6 +1,6 @@
 # Helm Chart vs Operator Comparison Report
 
-Updated: 2026-08-20 (validated against `main` + feat/helm_gaps)
+Updated: 2026-08-20 (validated against `main` + feat/helm_gaps: ENHANCED_ORG_ADMIN, Celery beat resources)
 
 Systematic comparison of `cost-onprem-chart/cost-onprem/` (Helm chart) against
 `koku-service-operator` (operator) — identifying deviations, missing pieces,
@@ -31,7 +31,7 @@ a `CostManagementServiceConfig` CR + Go reconciler.
 | Listener Deployment | yes | yes | match |
 | Koku ServiceAccount | yes | yes | match |
 | Koku Migration Job | yes | yes | match |
-| Celery Beat Deployment | yes | yes | **no resources** |
+| Celery Beat Deployment | yes | yes | **fixed** (50m/200Mi req, 100m/400Mi lim) |
 | Celery Workers (10 queues) | yes | yes | match |
 | RBAC API Deployment + Service | yes | yes | match |
 | RBAC Worker Deployment | yes | yes | match |
@@ -86,13 +86,13 @@ a `CostManagementServiceConfig` CR + Go reconciler.
 
 ## 2. Open Issues (Broken / Wrong)
 
-### 2.1 Celery beat has zero resource limits
+### 2.1 Celery beat has zero resource limits **FIXED** (feat/helm_gaps)
 
 **Severity: MEDIUM — unbounded resource consumption**
 
-`CeleryBeatDeployment()` in `koku.go` passes `corev1.ResourceRequirements{}`
+`CeleryBeatDeployment()` in `koku.go` previously passed `corev1.ResourceRequirements{}`
 (empty). The chart sets requests `{cpu: 50m, mem: 200Mi}` and limits
-`{cpu: 100m, mem: 400Mi}`.
+`{cpu: 100m, mem: 400Mi}`. **Now fixed** — operator matches chart defaults.
 
 ### 2.2 Masu Service port mismatch
 
@@ -291,7 +291,7 @@ OpenShift Route annotation default should also be set for consistency.
 ## 7. Remaining Fixes (Priority Order)
 
 1. ~~**Set `ENHANCED_ORG_ADMIN=False`** in `KokuCommonEnv()` — critical for RBAC scoping~~ **DONE** (feat/helm_gaps)
-2. **Add Celery beat resources** (`koku.go`): set `{cpu: 50m, mem: 200Mi}` / `{cpu: 100m, mem: 400Mi}`
+2. ~~**Add Celery beat resources** (`koku.go`): set `{cpu: 50m, mem: 200Mi}` / `{cpu: 100m, mem: 400Mi}`~~ **DONE** (feat/helm_gaps)
 3. **Fix Masu Service port** (`koku.go`): expose port 8000 (http) + 9000 (metrics)
 4. **Add ROS Processor + Poller Services**: needed for Prometheus metrics scraping
 5. **Add ROS metrics-scraping NetworkPolicies**: ros-api-metrics, processor-metrics, poller-metrics (Gateway, Koku API, and Masu now covered)

--- a/internal/resources/koku.go
+++ b/internal/resources/koku.go
@@ -3,6 +3,7 @@ package resources
 import (
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 
@@ -130,8 +131,19 @@ func CeleryBeatDeployment(cfg *costv1alpha1.CostManagementServiceConfig) *appsv1
 	env := KokuCommonEnv(cfg)
 	env = append(env, EnvVal("CELERY_LOG_LEVEL", "info"))
 
+	resources := corev1.ResourceRequirements{
+		Requests: corev1.ResourceList{
+			corev1.ResourceCPU:    resource.MustParse("50m"),
+			corev1.ResourceMemory: resource.MustParse("200Mi"),
+		},
+		Limits: corev1.ResourceList{
+			corev1.ResourceCPU:    resource.MustParse("100m"),
+			corev1.ResourceMemory: resource.MustParse("400Mi"),
+		},
+	}
+
 	return deployment(cfg, NameCeleryBeat(cfg), "cost-scheduler", image, replicas,
-		corev1.ResourceRequirements{}, nil, nil, env,
+		resources, nil, nil, env,
 		[]string{"/bin/sh", "-c", "cd $APP_HOME && PYTHONPATH=$APP_HOME celery -A koku beat -l info"},
 	)
 }

--- a/internal/resources/koku_test.go
+++ b/internal/resources/koku_test.go
@@ -103,3 +103,30 @@ func TestCeleryWorkerDeployments_SaaSQueuesOptIn(t *testing.T) {
 		t.Errorf("subs_extraction replicas = %d, want 1", got)
 	}
 }
+
+func TestCeleryBeatDeployment_ContainerResources(t *testing.T) {
+	cfg := testCfg()
+	cfg.Spec.CostManagement.API.Image.Repository = "quay.io/example/koku"
+	cfg.Spec.CostManagement.API.Image.Tag = "latest"
+
+	dep := CeleryBeatDeployment(cfg)
+	container := dep.Spec.Template.Spec.Containers[0]
+
+	cpuReq := container.Resources.Requests[corev1.ResourceCPU]
+	memReq := container.Resources.Requests[corev1.ResourceMemory]
+	cpuLim := container.Resources.Limits[corev1.ResourceCPU]
+	memLim := container.Resources.Limits[corev1.ResourceMemory]
+
+	if cpuReq.String() != "50m" {
+		t.Errorf("CPU request = %s, want 50m", cpuReq.String())
+	}
+	if memReq.String() != "200Mi" {
+		t.Errorf("Memory request = %s, want 200Mi", memReq.String())
+	}
+	if cpuLim.String() != "100m" {
+		t.Errorf("CPU limit = %s, want 100m", cpuLim.String())
+	}
+	if memLim.String() != "400Mi" {
+		t.Errorf("Memory limit = %s, want 400Mi", memLim.String())
+	}
+}


### PR DESCRIPTION
Add Celery beat resource limits

    Set CPU/memory requests and limits to match Helm chart:
      requests: cpu=50m, memory=200Mi
      limits:   cpu=100m, memory=400Mi
    
    Previously passed empty ResourceRequirements{} causing unbounded
    resource consumption.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Added Celery beat resource requests of `50m` CPU and `200Mi` memory.
- Added limits of `100m` CPU and `400Mi` memory.
- Added unit test coverage for these resources.
- Updated Helm-versus-operator comparison documentation.
- No CRD API, reconcile behavior, RBAC, or status condition changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->