### PR TITLE
Set default Route timeout annotation to 180s on GatewayAPIRoute

### DIFF
--- a/docs/helm-vs-operator-comparison.md
+++ b/docs/helm-vs-operator-comparison.md
@@ -1,6 +1,6 @@
 # Helm Chart vs Operator Comparison Report
 
-Updated: 2026-08-20 (validated against `main` + feat/helm_gaps: ENHANCED_ORG_ADMIN, Celery beat resources, Masu Service ports)
+Updated: 2026-08-20 (validated against `main` + feat/helm_gaps: ENHANCED_ORG_ADMIN, Celery beat resources, Masu Service ports, Gateway Route timeout)
 
 Systematic comparison of `cost-onprem-chart/cost-onprem/` (Helm chart) against
 `koku-service-operator` (operator) — identifying deviations, missing pieces,
@@ -278,12 +278,11 @@ the UI (passthrough TLS to oauth2-proxy). Architecturally sound.
 Operator uses `app.kubernetes.io/{name,instance,component,managed-by}`.
 Chart uses Helm-standard labels. Both are valid.
 
-### 6.5 Gateway Route timeout annotation not set by default
+### 6.5 Gateway Route timeout annotation **FIXED** (feat/helm_gaps)
 
-The operator doesn't set `haproxy.router.openshift.io/timeout` on the
-gateway Route (user can set it via `spec.gatewayRoute.annotations`). The
-chart sets `180s`. The Envoy-side timeout is now correct (180s), but the
-OpenShift Route annotation default should also be set for consistency.
+The operator now sets `haproxy.router.openshift.io/timeout: "180s"` as a
+default annotation on the gateway Route (matches Helm chart and Envoy config).
+User overrides via `spec.gatewayRoute.annotations` still take precedence.
 
 ---
 
@@ -295,6 +294,6 @@ OpenShift Route annotation default should also be set for consistency.
 4. **Add ROS Processor + Poller Services**: needed for Prometheus metrics scraping
 5. **Add ROS metrics-scraping NetworkPolicies**: ros-api-metrics, processor-metrics, poller-metrics (Gateway, Koku API, and Masu now covered)
 6. **Add RBAC + ROS components to ServiceMonitors**: rbac-api, ros-processor, ros-recommendation-poller, gateway still missing
-7. **Set default Route timeout annotation** to 180s in GatewayAPIRoute
+7. ~~**Set default Route timeout annotation** to 180s in GatewayAPIRoute~~ **DONE** (feat/helm_gaps)
 8. **Add remaining env var defaults**: `INITIAL_INGEST_NUM_MONTHS`, logging vars in `KokuCommonEnv()`
 9. **Expose `roleCreateAllowList`** in the RBAC CR section

--- a/internal/resources/route.go
+++ b/internal/resources/route.go
@@ -2,6 +2,7 @@ package resources
 
 import (
 	"fmt"
+	"maps"
 
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -58,9 +59,13 @@ func GatewayAPIRoute(cfg *costv1alpha1.CostManagementServiceConfig) *unstructure
 	route.SetName(NameAPIRoute(cfg))
 	route.SetNamespace(cfg.Namespace)
 	route.SetLabels(Labels(cfg, envoyComponent))
-	if len(cfg.Spec.GatewayRoute.Annotations) > 0 {
-		route.SetAnnotations(cfg.Spec.GatewayRoute.Annotations)
+
+	// Set default timeout annotation (matches Helm chart and Envoy config)
+	annotations := map[string]string{
+		"haproxy.router.openshift.io/timeout": "180s",
 	}
+	maps.Copy(annotations, cfg.Spec.GatewayRoute.Annotations)
+	route.SetAnnotations(annotations)
 
 	_ = unstructured.SetNestedField(route.Object, host, "spec", "host")
 	_ = unstructured.SetNestedField(route.Object, "/api", "spec", "path")

--- a/internal/resources/route_test.go
+++ b/internal/resources/route_test.go
@@ -84,6 +84,20 @@ func TestGatewayAPIRouteSpec(t *testing.T) {
 	}
 }
 
+func TestGatewayAPIRouteDefaultTimeoutAnnotation(t *testing.T) {
+	cfg := testCfg()
+	cfg.Spec.Global.ClusterDomain = "apps.cluster.local"
+
+	route := GatewayAPIRoute(cfg)
+	if route == nil {
+		t.Fatal("expected Route")
+	}
+	timeout := route.GetAnnotations()["haproxy.router.openshift.io/timeout"]
+	if timeout != "180s" {
+		t.Errorf("default timeout annotation = %q, want 180s", timeout)
+	}
+}
+
 func TestGatewayAPIRouteTLSOverrides(t *testing.T) {
 	cfg := testCfg()
 	cfg.Spec.GatewayRoute.Host = "api.example.com"


### PR DESCRIPTION
Adds haproxy.router.openshift.io/timeout: "180s" as default annotation, matching Helm chart and Envoy config. User overrides via spec.gatewayRoute.annotations still take precedence.

Adds TestGatewayAPIRouteDefaultTimeoutAnnotation test.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Operator impact

- `GatewayAPIRoute` now applies `haproxy.router.openshift.io/timeout: "180s"` by default.
- Values in `spec.gatewayRoute.annotations` override the default.
- The change does not modify the CRD API, RBAC, or user-visible status conditions.
- Reconcile behavior now aligns with the Helm chart and Envoy configuration.
- Added a test for the default timeout behavior.
- Updated the Helm-versus-operator comparison to mark the timeout gap as resolved.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->