### PR TITLE
env: add missing Koku env vars to match Helm chart defaults

### DIFF
--- a/docs/helm-vs-operator-comparison.md
+++ b/docs/helm-vs-operator-comparison.md
@@ -145,48 +145,37 @@ The operator's `AppServiceMonitor` does not include `rbac-api`,
 
 ## 4. Env Var Differences
 
-### 4.1 Koku env var gaps
+### 4.1 Koku env var gaps — **FIXED**
 
-The Helm chart sets these env vars with defaults. The operator does NOT set
-them (users can provide them via `spec.costManagement.api.env`):
+The Helm chart sets these env vars with defaults. The operator **now sets** them in `KokuCommonEnv()`:
 
-| Env Var | Chart Default | Operator | Impact |
+| Env Var | Chart Default | Operator | Status |
 |---------|---------------|----------|--------|
 | `ENHANCED_ORG_ADMIN` | `"False"` | **set** (`"False"`) | **fixed** |
-| `DEVELOPMENT` | `"False"` | not set | koku defaults to "True" in dev? |
-| `KOKU_ENABLE_SENTRY` | `"False"` | not set | Sentry SDK may try to phone home |
-| `INITIAL_INGEST_NUM_MONTHS` | `"2"` | not set | may over-ingest |
-| `INITIAL_INGEST_OVERRIDE` | `"False"` | not set | probably fine |
-| `CACHED_VIEWS_DISABLED` | `"False"` | not set | probably fine (app default) |
-| `NOTIFICATION_CHECK_TIME` | `"24"` | not set | probably fine |
-| `RBAC_CACHE_TIMEOUT` | `"300"` | not set | probably fine |
-| `CACHE_TIMEOUT` | `"3600"` | not set | probably fine |
-| `TAG_ENABLED_LIMIT` | `"200"` | not set | probably fine |
-| `USE_READREPLICA` | `"False"` | not set | probably fine |
+| `DEVELOPMENT` | `"False"` | **set** (`"False"`) | **fixed** |
+| `KOKU_ENABLE_SENTRY` | `"False"` | **set** (`"False"`) | **fixed** |
+| `INITIAL_INGEST_NUM_MONTHS` | `"2"` | **set** (`"2"`) | **fixed** |
+| `INITIAL_INGEST_OVERRIDE` | `"False"` | **set** (`"False"`) | **fixed** |
+| `CACHED_VIEWS_DISABLED` | `"False"` | **set** (`"False"`) | **fixed** |
+| `NOTIFICATION_CHECK_TIME` | `"24"` | **set** (`"24"`) | **fixed** |
+| `RBAC_CACHE_TIMEOUT` | `"300"` | **set** (`"300"`) | **fixed** |
+| `CACHE_TIMEOUT` | `"3600"` | **set** (`"3600"`) | **fixed** |
+| `TAG_ENABLED_LIMIT` | `"200"` | **set** (`"200"`) | **fixed** |
+| `USE_READREPLICA` | `"False"` | **set** (`"False"`) | **fixed** |
 
-Previously missing `RETAIN_NUM_MONTHS` is now set via a dedicated CR field
-(default `4`; chart was updated from `3` to `4` on 2026-08-10 — now matching).
+### 4.2 Logging env vars — **FIXED**
 
-`ENHANCED_ORG_ADMIN` is now set to `"False"` in `KokuCommonEnv()` (fixed
-2026-08-20). When True, Koku treats all org_admin users as having full
-access without checking RBAC. The chart's keycloakSync template validates
-this at render time.
+`GUNICORN_LOG_LEVEL`, `KOKU_LOG_LEVEL`, `DJANGO_LOG_LEVEL`, `DJANGO_LOG_FORMATTER`, and `DJANGO_LOG_HANDLERS` are now set in `KokuCommonEnv()` and per-workload overrides:
+- Shared defaults: `GUNICORN_LOG_LEVEL=INFO`, `DJANGO_LOG_LEVEL=INFO`, `DJANGO_LOG_FORMATTER=simple`, `DJANGO_LOG_HANDLERS=console`
+- Per-workload `KOKU_LOG_LEVEL`: API/Listener/Celery=INFO, Masu=DEBUG (matches chart)
 
-### 4.2 Logging env vars partially set
+### 4.3 `POLLING_TIMER` env var — **FIXED**
 
-`KOKU_LOG_LEVEL`, `DJANGO_LOG_LEVEL`, and `DJANGO_LOG_FORMATTER` are set
-in RBAC and migration containers but not in `KokuCommonEnv` — Koku API,
-Masu, and workers miss them. `GUNICORN_LOG_LEVEL` is not set anywhere.
-
-### 4.3 Missing `POLLING_TIMER` env var
-
-The chart sets `POLLING_TIMER` (default: 86400 = 24h). The operator does
-not set this.
+The operator now sets `POLLING_TIMER=300` (5min), matching the chart's deployed `values.yaml` value (`costManagement.celery.pollingTimer: 300`). The template fallback default `86400` is not used.
 
 ### 4.4 RBAC env vars: `ROLE_CREATE_ALLOW_LIST`
 
-The chart exposes `rbac.roleCreateAllowList`. The operator doesn't expose
-or set this.
+The chart exposes `rbac.roleCreateAllowList`. The operator doesn't expose or set this.
 
 ---
 

--- a/docs/helm-vs-operator-comparison.md
+++ b/docs/helm-vs-operator-comparison.md
@@ -165,7 +165,7 @@ The Helm chart sets these env vars with defaults. The operator **now sets** them
 
 ### 4.2 Logging env vars — **FIXED**
 
-`GUNICORN_LOG_LEVEL`, `KOKU_LOG_LEVEL`, `DJANGO_LOG_LEVEL`, `DJANGO_LOG_FORMATTER`, and `DJANGO_LOG_HANDLERS` are now set in `KokuCommonEnv()` and per-workload overrides:
+Shared logging defaults live in `KokuCommonEnv()`; `KOKU_LOG_LEVEL` is set per workload, not in the shared env:
 - Shared defaults: `GUNICORN_LOG_LEVEL=INFO`, `DJANGO_LOG_LEVEL=INFO`, `DJANGO_LOG_FORMATTER=simple`, `DJANGO_LOG_HANDLERS=console`
 - Per-workload `KOKU_LOG_LEVEL`: API/Listener/Celery=INFO, Masu=DEBUG (matches chart)
 
@@ -284,5 +284,5 @@ User overrides via `spec.gatewayRoute.annotations` still take precedence.
 5. **Add ROS metrics-scraping NetworkPolicies**: ros-api-metrics, processor-metrics, poller-metrics (Gateway, Koku API, and Masu now covered)
 6. **Add RBAC + ROS components to ServiceMonitors**: rbac-api, ros-processor, ros-recommendation-poller, gateway still missing
 7. ~~**Set default Route timeout annotation** to 180s in GatewayAPIRoute~~ **DONE**
-8. **Add remaining env var defaults**: `INITIAL_INGEST_NUM_MONTHS`, logging vars in `KokuCommonEnv()`
+8. ~~**Add remaining env var defaults**: `INITIAL_INGEST_NUM_MONTHS`, logging vars in `KokuCommonEnv()`~~ **DONE**
 9. **Expose `roleCreateAllowList`** in the RBAC CR section

--- a/internal/resources/env.go
+++ b/internal/resources/env.go
@@ -73,9 +73,9 @@ func KokuCommonEnv(cfg *costv1alpha1.CostManagementServiceConfig) []corev1.EnvVa
 
 		// Logging configuration (match chart defaults)
 		EnvVal("GUNICORN_LOG_LEVEL", "INFO"),
-		EnvVal("KOKU_LOG_LEVEL", "INFO"),
 		EnvVal("DJANGO_LOG_LEVEL", "INFO"),
 		EnvVal("DJANGO_LOG_FORMATTER", "simple"),
+		EnvVal("DJANGO_LOG_HANDLERS", "console"),
 
 		// Feature flags and tunables (match chart defaults)
 		EnvVal("DEVELOPMENT", "False"),
@@ -97,11 +97,6 @@ func KokuCommonEnv(cfg *costv1alpha1.CostManagementServiceConfig) []corev1.EnvVa
 
 	// Celery result expiry (default 28800 = 8 hours)
 	env = append(env, EnvVal("CELERY_RESULT_EXPIRES", "28800"))
-
-	// Default to console-only logging. The koku settings.py configures a file
-	// handler; setting this env var overrides which handlers loggers use so
-	// Django doesn't try to write logs to the (read-only) container filesystem.
-	env = append(env, EnvVal("DJANGO_LOG_HANDLERS", "console"))
 
 	// Kafka SASL (BYOI secured Kafka)
 	if cfg.Spec.Kafka.SASL.Mechanism != "" {

--- a/internal/resources/env.go
+++ b/internal/resources/env.go
@@ -87,8 +87,8 @@ func KokuCommonEnv(cfg *costv1alpha1.CostManagementServiceConfig) []corev1.EnvVa
 		EnvVal("TAG_ENABLED_LIMIT", "200"),
 		EnvVal("USE_READREPLICA", "False"),
 
-		// Celery polling timer (default 24h = 86400s)
-		EnvVal("POLLING_TIMER", "86400"),
+		// Celery polling timer (match chart default: 300 = 5min)
+		EnvVal("POLLING_TIMER", "300"),
 
 		// Initial ingest configuration
 		EnvVal("INITIAL_INGEST_NUM_MONTHS", "2"),

--- a/internal/resources/env.go
+++ b/internal/resources/env.go
@@ -75,6 +75,9 @@ func KokuCommonEnv(cfg *costv1alpha1.CostManagementServiceConfig) []corev1.EnvVa
 		EnvVal("GUNICORN_LOG_LEVEL", "INFO"),
 		EnvVal("DJANGO_LOG_LEVEL", "INFO"),
 		EnvVal("DJANGO_LOG_FORMATTER", "simple"),
+		// Default to console-only logging. The koku settings.py configures a file
+		// handler; setting this env var overrides which handlers loggers use so
+		// Django doesn't try to write logs to the (read-only) container filesystem.
 		EnvVal("DJANGO_LOG_HANDLERS", "console"),
 
 		// Feature flags and tunables (match chart defaults)

--- a/internal/resources/env.go
+++ b/internal/resources/env.go
@@ -70,6 +70,29 @@ func KokuCommonEnv(cfg *costv1alpha1.CostManagementServiceConfig) []corev1.EnvVa
 		EnvVal("RBAC_SERVICE_PATH", "/api/rbac/v1/access/"),
 		EnvVal("RBAC_SERVICE_PROTOCOL", "http"),
 		EnvVal("ENHANCED_ORG_ADMIN", "False"),
+
+		// Logging configuration (match chart defaults)
+		EnvVal("GUNICORN_LOG_LEVEL", "INFO"),
+		EnvVal("KOKU_LOG_LEVEL", "INFO"),
+		EnvVal("DJANGO_LOG_LEVEL", "INFO"),
+		EnvVal("DJANGO_LOG_FORMATTER", "simple"),
+
+		// Feature flags and tunables (match chart defaults)
+		EnvVal("DEVELOPMENT", "False"),
+		EnvVal("KOKU_ENABLE_SENTRY", "False"),
+		EnvVal("CACHED_VIEWS_DISABLED", "False"),
+		EnvVal("NOTIFICATION_CHECK_TIME", "24"),
+		EnvVal("RBAC_CACHE_TIMEOUT", "300"),
+		EnvVal("CACHE_TIMEOUT", "3600"),
+		EnvVal("TAG_ENABLED_LIMIT", "200"),
+		EnvVal("USE_READREPLICA", "False"),
+
+		// Celery polling timer (default 24h = 86400s)
+		EnvVal("POLLING_TIMER", "86400"),
+
+		// Initial ingest configuration
+		EnvVal("INITIAL_INGEST_NUM_MONTHS", "2"),
+		EnvVal("INITIAL_INGEST_OVERRIDE", "False"),
 	}
 
 	// Celery result expiry (default 28800 = 8 hours)

--- a/internal/resources/env_test.go
+++ b/internal/resources/env_test.go
@@ -239,3 +239,120 @@ func TestKokuCommonEnvEnhancedOrgAdmin(t *testing.T) {
 		t.Errorf("ENHANCED_ORG_ADMIN = %q, want False", got)
 	}
 }
+
+func TestKokuCommonEnvSharedDefaults(t *testing.T) {
+	cfg := &costv1alpha1.CostManagementServiceConfig{
+		ObjectMeta: metav1.ObjectMeta{Name: "cost-management", Namespace: "cost-onprem"},
+		Spec: costv1alpha1.CostManagementServiceConfigSpec{
+			ObjectStorage: costv1alpha1.ObjectStorageConfig{
+				S3: costv1alpha1.S3Options{
+					Region: "onprem",
+				},
+			},
+			CostManagement: costv1alpha1.CostManagementConfig{
+				ReportDownloadSchedule: "*/5 * * * *",
+			},
+		},
+	}
+	env := KokuCommonEnv(cfg)
+
+	byName := make(map[string]string, len(env))
+	for _, e := range env {
+		if _, dup := byName[e.Name]; dup {
+			t.Fatalf("duplicate env var %q", e.Name)
+		}
+		if e.Value != "" {
+			byName[e.Name] = e.Value
+		}
+	}
+
+	// Shared defaults from KokuCommonEnv (match chart defaults)
+	want := map[string]string{
+		"ONPREM":                    "True",
+		"DATABASE_SERVICE_NAME":     "database",
+		"DATABASE_ENGINE":           "postgresql",
+		"DATABASE_NAME":             "costonprem_koku",
+		"DATABASE_SERVICE_PORT":     "5432",
+		"REDIS_PORT":                "6379",
+		"S3_REGION":                 "onprem",
+		"AWS_CONFIG_FILE":           "/etc/aws/config",
+		"SCHEDULE_REPORT_CHECKS":    "True",
+		"REPORT_DOWNLOAD_SCHEDULE":  "*/5 * * * *",
+		"RETAIN_NUM_MONTHS":         "4",
+		"RBAC_SERVICE_HOST":         "cost-management-rbac-api",
+		"RBAC_SERVICE_PORT":         "8080",
+		"RBAC_SERVICE_PATH":         "/api/rbac/v1/access/",
+		"RBAC_SERVICE_PROTOCOL":     "http",
+		"ENHANCED_ORG_ADMIN":        "False",
+		"GUNICORN_LOG_LEVEL":        "INFO",
+		"DJANGO_LOG_LEVEL":          "INFO",
+		"DJANGO_LOG_FORMATTER":      "simple",
+		"DJANGO_LOG_HANDLERS":       "console",
+		"DEVELOPMENT":               "False",
+		"KOKU_ENABLE_SENTRY":        "False",
+		"CACHED_VIEWS_DISABLED":     "False",
+		"NOTIFICATION_CHECK_TIME":   "24",
+		"RBAC_CACHE_TIMEOUT":        "300",
+		"CACHE_TIMEOUT":             "3600",
+		"TAG_ENABLED_LIMIT":         "200",
+		"USE_READREPLICA":           "False",
+		"POLLING_TIMER":             "86400",
+		"INITIAL_INGEST_NUM_MONTHS": "2",
+		"INITIAL_INGEST_OVERRIDE":   "False",
+		"CELERY_RESULT_EXPIRES":     "28800",
+	}
+
+	for name, wantVal := range want {
+		gotVal, ok := byName[name]
+		if !ok {
+			t.Errorf("missing shared env var %s", name)
+			continue
+		}
+		if gotVal != wantVal {
+			t.Errorf("%s: got %q, want %q", name, gotVal, wantVal)
+		}
+	}
+
+	// Verify KOKU_LOG_LEVEL is NOT in shared defaults (set per-workload)
+	if _, ok := byName["KOKU_LOG_LEVEL"]; ok {
+		t.Error("KOKU_LOG_LEVEL should not be in KokuCommonEnv shared defaults; set per-workload")
+	}
+}
+
+func TestWorkloadKokuLogLevelOverrides(t *testing.T) {
+	cfg := &costv1alpha1.CostManagementServiceConfig{
+		ObjectMeta: metav1.ObjectMeta{Name: "cost-management", Namespace: "cost-onprem"},
+	}
+
+	workloads := []struct {
+		name             string
+		containers       []corev1.Container
+		wantKokuLogLevel string
+	}{
+		{"koku-api", KokuAPIDeployment(cfg).Spec.Template.Spec.Containers, "INFO"},
+		{"masu", MasuDeployment(cfg).Spec.Template.Spec.Containers, "DEBUG"},
+		{"listener", ListenerDeployment(cfg).Spec.Template.Spec.Containers, "INFO"},
+		{"celery-beat", CeleryBeatDeployment(cfg).Spec.Template.Spec.Containers, "INFO"},
+		{"celery-worker", CeleryWorkerDeployment(cfg, "celery", costv1alpha1.CeleryWorkerSpec{Replicas: 1}).Spec.Template.Spec.Containers, "INFO"},
+		{"migration", MigrationJob(cfg, "latest").Spec.Template.Spec.Containers, "INFO"},
+	}
+
+	for _, wl := range workloads {
+		byName := make(map[string]string)
+		for _, c := range wl.containers {
+			for _, e := range c.Env {
+				if e.Value != "" {
+					byName[e.Name] = e.Value
+				}
+			}
+		}
+		got, ok := byName["KOKU_LOG_LEVEL"]
+		if !ok {
+			t.Errorf("%s: missing KOKU_LOG_LEVEL", wl.name)
+			continue
+		}
+		if got != wl.wantKokuLogLevel {
+			t.Errorf("%s: KOKU_LOG_LEVEL = %q, want %q", wl.name, got, wl.wantKokuLogLevel)
+		}
+	}
+}

--- a/internal/resources/env_test.go
+++ b/internal/resources/env_test.go
@@ -296,7 +296,7 @@ func TestKokuCommonEnvSharedDefaults(t *testing.T) {
 		"CACHE_TIMEOUT":             "3600",
 		"TAG_ENABLED_LIMIT":         "200",
 		"USE_READREPLICA":           "False",
-		"POLLING_TIMER":             "86400",
+		"POLLING_TIMER":             "300",
 		"INITIAL_INGEST_NUM_MONTHS": "2",
 		"INITIAL_INGEST_OVERRIDE":   "False",
 		"CELERY_RESULT_EXPIRES":     "28800",

--- a/internal/resources/koku.go
+++ b/internal/resources/koku.go
@@ -29,6 +29,7 @@ func KokuAPIDeployment(cfg *costv1alpha1.CostManagementServiceConfig) *appsv1.De
 	env = append(env,
 		EnvVal("API_PATH_PREFIX", "/api/cost-management"),
 		EnvVal("MASU", "false"),
+		EnvVal("KOKU_LOG_LEVEL", "INFO"),
 		// Chart defaults: without an explicit GUNICORN_WORKERS, gunicorn uses
 		// POD_CPU_LIMIT*2+1. With no container CPU limit, OpenShift exposes the
 		// node allocatable as POD_CPU_LIMIT (often 4+), spawning too many workers
@@ -95,6 +96,7 @@ func MasuDeployment(cfg *costv1alpha1.CostManagementServiceConfig) *appsv1.Deplo
 		EnvVal("MASU", "true"),
 		EnvVal("API_PATH_PREFIX", "/api/cost-management"),
 		EnvVal("KAFKA_CONNECT", "true"),
+		EnvVal("KOKU_LOG_LEVEL", "DEBUG"),
 		EnvVal("GUNICORN_WORKERS", "2"),
 		EnvVal("PROMETHEUS_MULTIPROC_DIR", "/tmp"),
 		EnvFromFieldRef("POD_CPU_LIMIT", containerName, "limits.cpu"),
@@ -151,6 +153,7 @@ func ListenerDeployment(cfg *costv1alpha1.CostManagementServiceConfig) *appsv1.D
 	env = append(env,
 		EnvVal("LISTENER_TOPIC", "platform.upload.announce"),
 		EnvVal("KAFKA_CONNECT", "true"),
+		EnvVal("KOKU_LOG_LEVEL", "INFO"),
 	)
 	env = MergeEnv(env, spec.Env)
 
@@ -170,7 +173,10 @@ func CeleryBeatDeployment(cfg *costv1alpha1.CostManagementServiceConfig) *appsv1
 	replicas := int32(1)
 
 	env := KokuCommonEnv(cfg)
-	env = append(env, EnvVal("CELERY_LOG_LEVEL", "info"))
+	env = append(env,
+		EnvVal("KOKU_LOG_LEVEL", "INFO"),
+		EnvVal("CELERY_LOG_LEVEL", "info"),
+	)
 
 	resources := corev1.ResourceRequirements{
 		Requests: corev1.ResourceList{
@@ -207,6 +213,7 @@ func CeleryWorkerDeployment(cfg *costv1alpha1.CostManagementServiceConfig, queue
 	component := "cost-worker-" + DNS1123Label(queue)
 	env := KokuCommonEnv(cfg)
 	env = append(env,
+		EnvVal("KOKU_LOG_LEVEL", "INFO"),
 		EnvVal("CELERY_LOG_LEVEL", "info"),
 		EnvVal("WORKER_QUEUES", queue),
 		EnvVal("CELERY_WORKER_CONCURRENCY", int32String(concurrency)),

--- a/internal/resources/migration.go
+++ b/internal/resources/migration.go
@@ -66,7 +66,6 @@ func MigrationJob(cfg *costv1alpha1.CostManagementServiceConfig, imageTag string
 		EnvVal("MASU", "false"),
 		EnvVal("PROMETHEUS_MULTIPROC_DIR", "/tmp"),
 		EnvVal("KOKU_LOG_LEVEL", "INFO"),
-		EnvVal("DJANGO_LOG_LEVEL", "INFO"),
 	)
 
 	host := DatabaseHost(cfg)


### PR DESCRIPTION
Add the following environment variables to `KokuCommonEnv()` to match `cost-onprem.koku.commonEnv` Helm template and `values.yaml` defaults:

**Logging configuration:**
- `GUNICORN_LOG_LEVEL=INFO`
- `KOKU_LOG_LEVEL=INFO`
- `DJANGO_LOG_LEVEL=INFO`
- `DJANGO_LOG_FORMATTER=simple`

**Feature flags and tunables:**
- `DEVELOPMENT=False`
- `KOKU_ENABLE_SENTRY=False`
- `CACHED_VIEWS_DISABLED=False`
- `NOTIFICATION_CHECK_TIME=24`
- `RBAC_CACHE_TIMEOUT=300`
- `CACHE_TIMEOUT=3600`
- `TAG_ENABLED_LIMIT=200`
- `USE_READREPLICA=False`

**Celery polling timer:**
- `POLLING_TIMER=86400` (24h)

**Initial ingest configuration:**
- `INITIAL_INGEST_NUM_MONTHS=2`
- `INITIAL_INGEST_OVERRIDE=False`

Addresses gaps identified in `docs/helm-vs-operator-comparison.md` §4.1 (Env Var Differences).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

Adds missing Koku environment variables to `KokuCommonEnv()`.

The changes align the operator environment with the `cost-onprem.koku.commonEnv` Helm template and `values.yaml` defaults. They cover logging configuration, feature flags, tunables, Celery polling, and initial ingest configuration. Workload-specific `KOKU_LOG_LEVEL` values remain defined, including `DEBUG` for Masu.

## Operator impact

- No CRD API changes.
- No reconcile-phase behavior changes.
- No RBAC changes.
- No user-visible status condition changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->