### PR TITLE
(COST-8124) add beta customer install guides 

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ existing external infrastructure (PostgreSQL, Kafka, S3, OIDC).
 
 | Document | Description |
 |----------|-------------|
+| [docs/install/](docs/install/) | **Install and configure** (prerequisites, quickstart, production, CMMO) |
 | [docs/development/clusterbot.md](docs/development/clusterbot.md) | Cluster Bot day-one: Redpanda BYOI → in-cluster operator |
 | [docs/development/pre-prod-install.md](docs/development/pre-prod-install.md) | Pre-prod BYOI → operator → UI install walkthrough |
 | [docs/development/ownnamespace.md](docs/development/ownnamespace.md) | OwnNamespace install/watch model and RBAC shape |
@@ -23,6 +24,11 @@ existing external infrastructure (PostgreSQL, Kafka, S3, OIDC).
 | [docs/jira/](docs/jira/) | JIRA ticket source (COST-7678–7700) |
 
 ## Quick start
+
+Customer install (BYOI, `ros.enabled: false`): [docs/install/quickstart.md](docs/install/quickstart.md).
+Prerequisites and Secret keys: [docs/install/prerequisites.md](docs/install/prerequisites.md).
+
+Contributor local loop:
 
 ```bash
 make generate manifests    # regenerate CRD and deep-copy code

--- a/config/samples/service.costmanagement_v1alpha1_costmanagementserviceconfig_minimal.yaml
+++ b/config/samples/service.costmanagement_v1alpha1_costmanagementserviceconfig_minimal.yaml
@@ -25,7 +25,7 @@
 #   (ros-* and kruize-* keys match the CRD credential list; unused while ros.enabled is false.)
 #
 #   kubectl create secret generic my-cache-credentials \
-#     --from-literal=password=<password>
+#     --from-literal=redis-password=<password>
 #
 #   kubectl create secret generic my-s3-credentials \
 #     --from-literal=access-key=<key> \

--- a/docs/development/clusterbot.md
+++ b/docs/development/clusterbot.md
@@ -7,6 +7,8 @@ Short path to get a `CostManagementServiceConfig` reconciling on a **Cluster Bot
 **Beta:** ROS/Kruize are off by default (`spec.ros.enabled` defaults to `false`).
 Day-one success does not require ROS images or migrate Jobs.
 
+Customer install/config: [docs/install/](../install/README.md).
+
 For a fuller BYOI → UI walkthrough (AMQ Streams + Keycloak), see
 [pre-prod-install.md](pre-prod-install.md). For laptop **CRC** with bundled DB,
 see [crc-testing.md](crc-testing.md).

--- a/docs/development/pre-prod-install.md
+++ b/docs/development/pre-prod-install.md
@@ -4,6 +4,9 @@ End-to-end path for a **pre-prod / lab** OpenShift cluster: optional fixture
 dependencies (BYOI), then the mandatory operator + `CostManagementServiceConfig`,
 ending at a working Cost Management UI login.
 
+Customer install/config (prerequisites, Secret keys, quickstart, production, CMMO):
+[docs/install/](../install/README.md).
+
 This is **not** an OLM Catalog / production packaging guide (COST-7695). It uses
 the OwnNamespace model: **operator install namespace == CR namespace**. BYOI
 infra may live elsewhere and is referenced only via CR connection fields.

--- a/docs/gap_analysis/BETA-PRIORITY.md
+++ b/docs/gap_analysis/BETA-PRIORITY.md
@@ -131,7 +131,7 @@ UI already reads `spec.profile` when `spec.ui.*.resources` are unset ([#65](http
 | [COST-7693](https://redhat.atlassian.net/browse/COST-7693) | Upgrade/scaling/rollback | **P2** (basic image-tag migrate exists) |
 | [COST-7694](https://redhat.atlassian.net/browse/COST-7694) | Secret rotation annotation | **P2** (day-2); CA merge overlaps [7691 G3](COST-7691.md) **P1** |
 | [COST-7696](https://redhat.atlassian.net/browse/COST-7696)–[7699](https://redhat.atlassian.net/browse/COST-7699) | Bundle CI / E2E / OpenShift CI | **P2** for beta; **P1** if beta needs automated install proof |
-| [COST-7700](https://redhat.atlassian.net/browse/COST-7700) | Install/config guides | **P1** (beta customers need a BYOI quickstart with `ros.enabled: false`) |
+| [COST-7700](https://redhat.atlassian.net/browse/COST-7700) / [COST-8124](../jira/COST-8124.md) | Install/config guides | **P1** (beta BYOI quickstart with `ros.enabled: false`). GA remainder is [COST-8125](../jira/COST-8125.md). |
 
 Tickets marked ✅ in `tasks.md` that gap audits found incomplete: **7683, 7684, 7687, 7688, 7690, 7691, 7692** (docs drift — do not treat tracker checkmarks as beta-ready). COST-7689 readiness (G2) is closed; sizing moved to COST-8095.
 
@@ -161,7 +161,7 @@ Tickets marked ✅ in `tasks.md` that gap audits found incomplete: **7683, 7684,
 15. S3 connectivity probe (ListBuckets/HeadBucket) ([7684 G1](COST-7684.md)).
 16. NetworkPolicies for UI + Masu/Listener (start of [7691 G1](COST-7691.md); skip ROS and Kruize).
 17. App readiness timeout → Degraded for **core** Deployments only (COST-7686) — **closed** in PR #105 (Ingress/Envoy/UI still 30s; [follow-up #12](../review-follow-ups.md)).
-18. BYOI install/config quickstart: `ros.enabled: false`, ROS/Kruize unsupported in beta (COST-7700); remaining optionality → COST-8054.
+18. BYOI install/config quickstart: `ros.enabled: false`, ROS/Kruize unsupported in beta ([COST-8124](../jira/COST-8124.md) / COST-7700); remaining optionality → COST-8054. GA docs remainder → [COST-8125](../jira/COST-8125.md).
 19. Admission webhook scaffold for rules CEL cannot express ([7678 G1](COST-7678.md)).
 20. **Conditional `ros-*` Validation keys** when `ros.enabled=false` ([COST-8054](../jira/COST-8054.md)) — required for honest Cost-only BYOI secrets (otherwise customers must still provision unused ROS DB keys).
 

--- a/docs/install/README.md
+++ b/docs/install/README.md
@@ -1,0 +1,28 @@
+# Install and configure Cost Management (on-prem)
+
+Customer-facing guides for the Cost Management service operator. You install
+the operator, apply one `CostManagementServiceConfig` (short name `cmsc`), and
+the operator deploys the application stack against **your** PostgreSQL, Kafka,
+object storage, and OIDC.
+
+**Beta.** Resource Optimization (ROS) and Kruize are not supported. Leave
+`spec.ros.enabled: false` (the CRD default). These guides describe that
+Cost-only path.
+
+There is no OperatorHub catalog yet. Install the operator into the **same
+namespace** as the CR (OwnNamespace). See [quickstart.md](quickstart.md#install-the-operator).
+
+| Guide | Use when |
+|-------|----------|
+| [Prerequisites](prerequisites.md) | You need the external services, buckets, Kafka topic, and Secret key names |
+| [Quickstart](quickstart.md) | Prerequisites and the operator are ready; you want a working CR in under 30 minutes |
+| [Production](production.md) | You are sizing, hardening TLS, and planning backup for a lasting deploy |
+| [CMMO](cmmo.md) | You need reporting clusters to upload metrics into this instance |
+
+Each guide is self-contained. The quickstart clock starts **after**
+prerequisites and the operator are in place.
+
+## Not these guides
+
+Contributor and lab paths (Cluster Bot, CRC bundled Postgres, `demo-preprod.sh`)
+live under [docs/development/](../development/).

--- a/docs/install/cmmo.md
+++ b/docs/install/cmmo.md
@@ -1,0 +1,134 @@
+# Configure Cost Management Metrics Operator (CMMO)
+
+How to point **Cost Management Metrics Operator** on a reporting cluster at the
+Cost Management instance this operator deployed — not at `console.redhat.com`.
+
+CMMO is a **separate** product. This operator does not install or manage it.
+
+**Lab-derived.** The `api_url` + `ingress_path` combination below comes from
+the in-repo lab script (`scripts/setup-cost-mgmt-tls.sh`). Treat it as the
+path we use in testing, not a certified CMMO support contract. Confirm with
+CMMO owners before a GA install.
+
+**Beta.** Disable Resource Optimization collection on CMMO. Do not enable
+`spec.ros.enabled` on the Cost Management CR.
+
+## What CMMO talks to
+
+Uploads go through the **Envoy gateway Route**, which only matches path `/api`
+and forwards `/api/ingress/` to insights-ingress-go.
+
+| Piece | Value |
+|-------|--------|
+| Gateway host | `{cr-name}-gateway-{namespace}.{apps-domain}` |
+| `spec.api_url` | `https://<gateway-host>` — **no path**, not `console.redhat.com` |
+| `spec.upload.ingress_path` | `/api/ingress/v1/upload` |
+| Resulting upload URL | `https://<gateway-host>/api/ingress/v1/upload` |
+| Auth | Keycloak `client_credentials` (CMMO `authentication.type: service-account`) |
+| JWT audiences Envoy accepts | `cost-management-operator`, `cost-management-ui` |
+
+Find the host:
+
+```bash
+oc -n "$NAMESPACE" get route -l app.kubernetes.io/component=gateway \
+  -o jsonpath='{.items[0].spec.host}{"\n"}'
+```
+
+## Keycloak client for CMMO
+
+Create a confidential client in the same realm the Cost Management CR uses
+(samples: `kubernetes`) with the **client credentials** grant. The access token
+must be accepted by Envoy (audience in `spec.auth.keycloak.audiences`).
+
+On **each reporting cluster**, store that client in a Secret. CMMO’s field
+names use underscores:
+
+| Key | Required |
+|-----|----------|
+| `client_id` | Yes |
+| `client_secret` | Yes |
+
+```bash
+# On the reporting cluster, in the namespace where you install CMMO
+oc -n costmanagement-metrics-operator create secret generic cost-management-auth-secret \
+  --from-literal=client_id='<cmmo-client-id>' \
+  --from-literal=client_secret='<cmmo-client-secret>'
+```
+
+Token URL (replace host and realm):
+
+`https://<keycloak-issuer-host>/realms/kubernetes/protocol/openid-connect/token`
+
+Use the same issuer host that matches `spec.auth.keycloak.issuerURL` (or `url`
+when issuer is derived from it).
+
+## CostManagementMetricsConfig
+
+Install CMMO from OperatorHub on the reporting cluster (OpenShift documentation
+for that operator), then apply a config. Example:
+
+```yaml
+apiVersion: costmanagement-metrics-cfg.openshift.io/v1beta1
+kind: CostManagementMetricsConfig
+metadata:
+  name: costmanagementmetricscfg
+  namespace: costmanagement-metrics-operator
+spec:
+  # Must be THIS instance's gateway. Empty/default uploads to console.redhat.com.
+  api_url: "https://cost-management-minimal-gateway-cost-onprem.apps.cluster.example.com"
+
+  authentication:
+    type: service-account
+    token_url: "https://keycloak-keycloak.apps.cluster.example.com/realms/kubernetes/protocol/openid-connect/token"
+    secret_name: cost-management-auth-secret
+
+  upload:
+    upload_toggle: true
+    upload_cycle: 360
+    ingress_path: /api/ingress/v1/upload
+    # Production: true, with a CA that trusts the gateway Route.
+    # Lab self-signed only: false.
+    validate_cert: true
+
+  prometheus_config:
+    service_address: "https://thanos-querier.openshift-monitoring.svc:9091"
+    skip_tls_verification: false
+    collect_previous_data: true
+    context_timeout: 120
+    disable_metrics_collection_cost_management: false
+    disable_metrics_collection_resource_optimization: true
+
+  source:
+    create_source: true
+    check_cycle: 1440
+    sources_path: /api/cost-management/v1/
+    name: ""
+```
+
+Set `disable_metrics_collection_resource_optimization: true` for beta.
+
+`validate_cert: false` appears in the lab script for self-signed Keycloak and
+must not be copied into production. Trust the gateway and token URL
+certificates instead.
+
+## Do not
+
+- Do not run `scripts/setup-cost-mgmt-tls.sh` on a customer cluster. It is a
+  same-cluster E2E helper (installs CMMO next to the stack, skips cert
+  validation).
+- Do not leave `api_url` unset — CMMO then talks to hosted console.redhat.com.
+- Do not enable ROS collection against a Cost-only (`ros.enabled: false`)
+  instance.
+
+## Check
+
+On the reporting cluster:
+
+```bash
+oc -n costmanagement-metrics-operator get costmanagementmetricsconfig
+oc -n costmanagement-metrics-operator logs deploy/costmanagement-metrics-operator
+```
+
+On the Cost Management cluster, Listener and Ingress should see uploads on
+topic `platform.upload.announce` after a successful CMMO cycle. The UI Sources
+page lists the cluster when `source.create_source` is true.

--- a/docs/install/prerequisites.md
+++ b/docs/install/prerequisites.md
@@ -1,0 +1,284 @@
+# Prerequisites
+
+What must exist **before** you apply a `CostManagementServiceConfig`. The
+operator does not provision production PostgreSQL, Kafka, object storage, or
+OIDC. It connects to services you already run.
+
+**Beta.** Leave `spec.ros.enabled: false`. ROS and Kruize workloads are not
+supported. You must still provision the ROS/Kruize database users listed below:
+the operator validates those Secret keys even when ROS is off.
+
+Companion guides: [quickstart](quickstart.md), [production](production.md),
+[CMMO](cmmo.md).
+
+## What you need
+
+| Dependency | Who owns it | Operator role |
+|------------|-------------|----------------|
+| OpenShift cluster | You | Discovers cluster domain and default StorageClass |
+| PostgreSQL | You | TCP probe + credentials; runs schema Jobs |
+| Redis-compatible cache (Valkey/Redis) | You | TCP probe + credentials |
+| Kafka (AMQ Streams recommended) | You | TCP probe; Listener consumes `platform.upload.announce` |
+| S3-compatible object storage | You | Validates `access-key` / `secret-key`; does **not** create buckets |
+| OIDC (Keycloak / RHBK) | You | JWKS probe; Envoy + UI oauth2-proxy |
+| This operator | You, in the CR namespace | Deploys Cost Management application services |
+
+`spec.database.deploy: true` and `spec.cache.deploy: true` are for local
+development and CI only. Do not use them in production. Kafka is never bundled.
+
+## OpenShift
+
+- Cluster-admin (or equivalent) to install the operator and create the CR
+  namespace
+- Ability to pull application images (`registry.redhat.io`, Quay) via the
+  cluster pull secret
+- A default StorageClass is only required if you later enable bundled
+  Postgres/Valkey (dev). Production BYOI does not need it for Cost Management
+  itself
+
+Install the operator into the **same namespace** as the CR. Runtime is
+OwnNamespace even though a published OperatorHub catalog is not available yet.
+See [quickstart.md](quickstart.md#install-the-operator).
+
+## PostgreSQL
+
+The operator connects to a single host (`spec.database.host`, default port
+`5432`) and uses **four databases** with **separate application users**.
+
+| Database | User Secret keys | Used in beta |
+|----------|------------------|--------------|
+| `costonprem_koku` | `koku-user`, `koku-password` | Yes |
+| `costonprem_rbac` | `rbac-user`, `rbac-password` | Yes |
+| `costonprem_ros` | `ros-user`, `ros-password` | Keys required; database unused while ROS is off |
+| `costonprem_kruize` | `kruize-user`, `kruize-password` | Keys required; database unused while ROS is off |
+
+Also provide a superuser (or equivalent) pair `postgres-user` /
+`postgres-password` in the same Secret. Schema migration Jobs use the
+application users.
+
+`spec.database.sslMode` is one of `disable`, `require`, `verify-ca`,
+`verify-full` (default `disable`). Use `require` or stricter in production.
+
+### Secret: `spec.database.secretName`
+
+Create this Secret in the **CR namespace**. All ten keys are required today,
+including `ros-*` and `kruize-*`.
+
+| Key | Purpose |
+|-----|---------|
+| `postgres-user` | Admin / bootstrap user |
+| `postgres-password` | |
+| `koku-user` | Owner of `costonprem_koku` |
+| `koku-password` | |
+| `rbac-user` | Owner of `costonprem_rbac` |
+| `rbac-password` | |
+| `ros-user` | Owner of `costonprem_ros` (validated even when ROS is off) |
+| `ros-password` | |
+| `kruize-user` | Owner of `costonprem_kruize` (validated even when ROS is off) |
+| `kruize-password` | |
+
+```bash
+kubectl -n "$NAMESPACE" create secret generic my-db-credentials \
+  --from-literal=postgres-user=postgres \
+  --from-literal=postgres-password='<password>' \
+  --from-literal=koku-user=koku \
+  --from-literal=koku-password='<password>' \
+  --from-literal=rbac-user=rbac_user \
+  --from-literal=rbac-password='<password>' \
+  --from-literal=ros-user=ros_user \
+  --from-literal=ros-password='<password>' \
+  --from-literal=kruize-user=kruize_user \
+  --from-literal=kruize-password='<password>'
+```
+
+Missing keys set `DatabaseReady=False` with reason `DatabaseSecretInvalid` and
+block migrations.
+
+## Cache (Valkey / Redis)
+
+Point `spec.cache.host` at an existing Redis protocol endpoint (default port
+`6379`). Set `spec.cache.auth.enabled: true` and `spec.cache.auth.secretName`.
+
+### Secret: `spec.cache.auth.secretName`
+
+| Key | Required |
+|-----|----------|
+| `redis-password` | Yes |
+| `redis-username` | Optional (ACL username) |
+
+The key name is `redis-password`, not `password`.
+
+```bash
+kubectl -n "$NAMESPACE" create secret generic my-cache-credentials \
+  --from-literal=redis-password='<password>'
+```
+
+Optional TLS: `spec.cache.tls.enabled: true` and
+`spec.cache.tls.caCertSecretName` with key `ca.crt`.
+
+Unreachable cache or a missing `redis-password` sets `CacheReady=False` and
+blocks the pipeline.
+
+## Kafka
+
+Kafka is always external. Set `spec.kafka.bootstrapServers` to the AMQ Streams
+bootstrap (for example
+`cost-onprem-kafka-kafka-bootstrap.kafka.svc.cluster.local:9092`).
+
+**Required topic (Cost / beta):** `platform.upload.announce`  
+Ingress publishes upload announcements here; the Listener consumes it. Create
+the topic before applying the CR. The operator does not create KafkaTopic CRs.
+
+Other topics used by the lab fixture (`hccm.ros.events`,
+`rosocp.kruize.recommendations`, `platform.sources.event-stream`,
+`platform.payload-status`) are unused on the Cost-only path.
+
+`spec.kafka.securityProtocol` is one of `PLAINTEXT`, `SSL`, `SASL_PLAINTEXT`,
+`SASL_SSL` (default `PLAINTEXT`).
+
+### Secret: `spec.kafka.sasl.existingSecret` (when SASL is enabled)
+
+| Key | Required |
+|-----|----------|
+| `username` | Yes |
+| `password` | Yes |
+
+```bash
+kubectl -n "$NAMESPACE" create secret generic my-kafka-sasl-credentials \
+  --from-literal=username='<user>' \
+  --from-literal=password='<password>'
+```
+
+Optional TLS CA: `spec.kafka.tls.enabled: true` and
+`spec.kafka.tls.caCertSecret` with key `ca.crt`.
+
+Kafka probe failures set `KafkaReady=False` but do **not** block later stages
+(pods retry with init containers). A missing SASL Secret still fails
+`KafkaReady`.
+
+## Object storage (S3-compatible)
+
+Set `spec.objectStorage.endpoint` (hostname only, no scheme or port),
+`port`, `useSSL`, and `secretName`. For beta, provide credentials yourself;
+do not rely on OBC/NooBaa auto-detection.
+
+**The operator never creates buckets.** Create them before uploads, or Ingress
+returns HTTP 500.
+
+| Bucket | Spec field | Default | Beta |
+|--------|------------|---------|------|
+| Cost / Ingress staging | `spec.costManagement.storage.bucketName` | `koku-bucket` | Required |
+| Ingress staging override | `spec.ingress.stagingBucket` | same as Cost bucket | Optional |
+| ROS | `spec.costManagement.storage.rosBucketName` | `ros-data` | Not used while ROS is off |
+
+### Secret: `spec.objectStorage.secretName`
+
+| Key | Required |
+|-----|----------|
+| `access-key` | Yes |
+| `secret-key` | Yes |
+
+```bash
+kubectl -n "$NAMESPACE" create secret generic my-s3-credentials \
+  --from-literal=access-key='<key>' \
+  --from-literal=secret-key='<secret>'
+```
+
+Optional TLS CA: `spec.objectStorage.caCertSecretName` with key `ca.crt`.
+`insecureSkipVerify` is for lab self-signed endpoints only.
+
+Missing keys set `StorageReady=False` (`StorageSecretInvalid`). S3 failures do
+not block the rest of the pipeline, but uploads will not work.
+
+## OIDC (Keycloak / RHBK)
+
+The operator never deploys Keycloak. Configure a realm (samples use
+`kubernetes`) and JWT audiences that match Envoy:
+
+- `cost-management-operator`
+- `cost-management-ui`
+
+| Spec field | Purpose |
+|------------|---------|
+| `spec.auth.keycloak.url` | In-cluster base URL used to fetch JWKS (prefer a Service URL so Envoy does not depend on the router) |
+| `spec.auth.keycloak.issuerURL` | Token `iss` value. Set this to the public Route URL when RHBK issues tokens with that `iss` even if clients talk to the in-cluster Service |
+| `spec.auth.keycloak.realm` | Default `kubernetes` |
+| `spec.auth.keycloak.audiences` | Default `cost-management-operator`, `cost-management-ui` |
+
+Optional TLS: `spec.auth.keycloak.tls.caCertSecretName` with key `ca.crt`
+(needed when `issuerURL` is a Route and the cluster service CA does not trust
+it). `insecureSkipVerify` is lab-only.
+
+When `url` is set, a failed JWKS probe sets `AuthenticationReady=False`. That
+does not by itself block `GatewayReady`.
+
+### UI OAuth client Secret
+
+The UI sidecar (oauth2-proxy) needs a confidential OIDC client. Create a
+Secret in the CR namespace. Default name: `{metadata.name}-ui-oauth-client`
+(override with `spec.ui.oauthClientSecretRef.name`).
+
+| Key | Required |
+|-----|----------|
+| `client-id` | Yes |
+| `client-secret` | Yes |
+
+Redirect URI the client must allow:
+
+`https://{cr-name}-ui-{namespace}.{apps-domain}/oauth2/callback`
+
+Until this Secret exists with both keys, `UIReady` stays False
+(`OAuthClientSecretMissing`) and `status.phase` stays `Progressing`. Core APIs
+can still become `Available`.
+
+```bash
+kubectl -n "$NAMESPACE" create secret generic cost-management-minimal-ui-oauth-client \
+  --from-literal=client-id='<ui-client-id>' \
+  --from-literal=client-secret='<ui-client-secret>'
+```
+
+Name the Secret `{cr-name}-ui-oauth-client` to match the CR `metadata.name`, or
+set `spec.ui.oauthClientSecretRef`.
+
+## Optional: RBAC bootstrap admin
+
+If you set `spec.rbac.bootstrapAdmin.enabled: true`, also create a Secret
+referenced by `spec.rbac.bootstrapAdmin.secretRef`:
+
+| Key | Required |
+|-----|----------|
+| `org-id` | Yes |
+| `account-number` | Yes |
+| `username` | Yes |
+
+Skip this for a minimal Cost-only start. Leave `enabled` unset/false.
+
+## Secrets the operator creates (do not pre-create unless you intend to keep them)
+
+These are **create-only**: the operator writes them if absent and never
+overwrites them on later reconciles.
+
+| Secret | Keys | Purpose |
+|--------|------|---------|
+| `{cr}-django-secret` | `secret-key` | Django `SECRET_KEY` |
+| `{cr}-ui-cookie-secret` | `session-secret` | oauth2-proxy cookie encryption |
+
+Rotate them yourself if needed; there is no operator annotation to roll them
+yet.
+
+## Versions tested in the lab fixture (not a support matrix)
+
+These are what the in-repo BYOI fixture and Kafka script use. They are **not**
+certified support statements.
+
+| Component | Lab fixture |
+|-----------|-------------|
+| PostgreSQL | 16 |
+| Valkey | 8 |
+| AMQ Streams channel / Kafka | `amq-streams-3.1.x` / Kafka 4.1.0 |
+| OpenShift | whatever cluster you install the operator on |
+
+## Next
+
+1. Install the operator in the CR namespace — [quickstart](quickstart.md#install-the-operator)
+2. Apply the minimal CR — [quickstart](quickstart.md)

--- a/docs/install/production.md
+++ b/docs/install/production.md
@@ -1,0 +1,165 @@
+# Production deployment
+
+How to run a lasting BYOI deploy of Cost Management on OpenShift. This is
+**not** a claim that every Jira “HA / monitoring / NetworkPolicy” item is
+implemented. Read the honesty notes in each section.
+
+**Beta.** Keep `spec.ros.enabled: false`. Do not treat `spec.profile: ha` as a
+full-stack HA switch.
+
+Prerequisites and a first CR: [prerequisites.md](prerequisites.md),
+[quickstart.md](quickstart.md).
+
+## Production-shaped sample
+
+Use
+[`config/samples/service.costmanagement_v1alpha1_costmanagementserviceconfig_production.yaml`](../../config/samples/service.costmanagement_v1alpha1_costmanagementserviceconfig_production.yaml)
+as the template. It demonstrates:
+
+- External DB, cache, Kafka, S3, OIDC (`deploy: false`)
+- `spec.profile: ha` (see [HA profile](#ha-profile) — UI only today)
+- `monitoring.enabled: true`
+- Explicit `spec.*.resources` and replica counts on core workloads
+- SASL_SSL Kafka, cache TLS, S3 CA
+- `ros.enabled: false`
+
+Pin **release** image tags. The sample’s ingress tag `master` is a placeholder
+and is not a production pin.
+
+## HA profile
+
+`spec.profile` is `standard` (default) or `ha`.
+
+**Today `ha` only raises default UI CPU/memory** when `spec.ui.*.resources` are
+unset. Koku API, Masu, Listener, RBAC, Celery, Envoy, and Ingress do **not**
+read the profile. Size those with explicit `spec.*.replicas` and
+`spec.*.resources` (as the production sample does).
+
+Shared profile maps for the rest of the stack are not in this operator yet.
+Until they are, copy the production sample’s resource blocks rather than
+expecting `profile: ha` to resize workers.
+
+For true HA of Postgres, Kafka, and object storage, use your infrastructure
+operators (AMQ Streams, ODF, and so on). This operator does not manage them.
+
+## Resource tuning
+
+Set requests/limits on the components you care about. The production sample
+uses replica `2` on API, Masu, Listener, Envoy, RBAC, and UI, and raises Celery
+worker replica counts on the on-prem queues.
+
+SaaS-only Celery queues (`hcs`, `subsExtraction`, `subsTransmission`) default
+to `replicas: 0`. Leave them at zero.
+
+`spec.costManagement.dataRetentionMonths` (default `4`, range 1–60) is how many
+months of cost report data Koku retains. That is application retention, not a
+database backup policy.
+
+## TLS
+
+Prefer CA Secrets over `insecureSkipVerify` / `sslMode: disable`.
+
+| Path | Spec | Secret key |
+|------|------|------------|
+| PostgreSQL | `database.sslMode: require` (or `verify-ca` / `verify-full`) | — |
+| Cache | `cache.tls.enabled` + `caCertSecretName` | `ca.crt` |
+| Kafka | `securityProtocol: SASL_SSL` (or `SSL`) + `kafka.tls.caCertSecret` | `ca.crt` |
+| S3 | `objectStorage.useSSL: true` + `caCertSecretName` | `ca.crt` |
+| Keycloak / issuer Route | `auth.keycloak.tls.caCertSecretName` | `ca.crt` |
+| API Route | Edge termination, insecure policy `Redirect` (CRD only allows `edge`) | OpenShift router |
+| UI Route | Passthrough (oauth2-proxy terminates TLS) | Service CA on the UI Service |
+
+Gateway Route host defaults to `{name}-gateway-{namespace}.{clusterDomain}`
+with path `/api` and a 180s router timeout.
+
+## NetworkPolicies
+
+The operator applies **ingress** NetworkPolicies for:
+
+- Gateway (Envoy)
+- Ingress
+- RBAC API
+- Koku API
+- UI
+- Listener
+- Masu
+
+It does **not** cover Celery workers/beat. External Postgres, Kafka, cache, and
+S3 in other namespaces are **your** NetworkPolicies (the operator does not
+watch those namespaces).
+
+Bundled DB/cache NetworkPolicies exist only when `database.deploy` /
+`cache.deploy` are true (dev). Production BYOI should restrict those services
+on the infrastructure side.
+
+ROS/Kruize policies are applied only when `ros.enabled` is true — leave them
+off for beta.
+
+## Monitoring
+
+`spec.monitoring.enabled` defaults to **true**. When true, the operator applies
+a `ServiceMonitor` and a `PrometheusRule` **if** the Prometheus Operator CRDs
+exist. If those CRDs are absent, the stage is skipped and reconcile continues.
+
+What exists today:
+
+- App ServiceMonitor (port `metrics` / 9000) selecting several application
+  Services
+- Five alert rules, including `CostManagementMigrationFailed` and
+  `CostManagementDegraded`
+- A Kruize ServiceMonitor is still applied even with ROS off (no scrape target
+  in beta)
+
+What is **not** a complete in-cluster monitoring story yet: many scrape
+targets do not match Service ports/labels, custom operator metrics are not
+shipped, and you should not expect every workload to appear in Prometheus.
+Use CR conditions and Kubernetes Events (`Ready`, `MigrationStarted` /
+`Complete` / `Failed`, `ReconcileError`) as the supported operator signals.
+
+To skip Prometheus CRs entirely:
+
+```yaml
+spec:
+  monitoring:
+    enabled: false
+```
+
+## Backup and restore
+
+The operator does **not** back up or restore anything. You own:
+
+| Data | Typical backup |
+|------|----------------|
+| PostgreSQL (`costonprem_koku`, `costonprem_rbac`, and unused ROS/Kruize DBs) | Your DBA / Postgres operator |
+| Object storage buckets | Bucket versioning / replication on the S3 provider |
+| Kafka topics | AMQ Streams / Kafka ops (offset and topic config) |
+| OIDC (Keycloak) | RHBK backup |
+| Operator-generated Secrets (`{cr}-django-secret`, `{cr}-ui-cookie-secret`) | Export and store outside the cluster; the operator will not recreate them if you delete them after first create |
+
+Restore order: restore Postgres and buckets, restore Secrets into the CR
+namespace, then re-apply the CR (or let the operator reconcile). Schema Jobs
+are not re-run for a tag that already succeeded.
+
+## Operator behavior you should plan for
+
+**Server-Side Apply with force.** The operator owns every field it sets on
+namespace-scoped objects. Manual `kubectl edit` of those fields is reverted on
+the next reconcile (including a 5-minute drift requeue). Change desired state
+in the CR, not on child Deployments.
+
+**Secrets are create-only.** User Secrets (`my-db-credentials`, …) are never
+overwritten. Operator-generated Secrets are created once. Updating a password
+in a Secret you own takes effect on the next pod restart; the operator does not
+roll pods on Secret rotation yet.
+
+**Images.** Changing a service image tag can retrigger that service’s
+migration Job. Pin tags (and digests when you can).
+
+**Pause.** Annotation
+`costmanagementserviceconfigs.service.costmanagement.openshift.io/pause=true`
+on the CR (key `…/pause`, value `true`) halts reconcile (`Paused` condition).
+Remove it to resume.
+
+## Next
+
+Point reporting clusters at this instance: [cmmo.md](cmmo.md).

--- a/docs/install/quickstart.md
+++ b/docs/install/quickstart.md
@@ -1,0 +1,175 @@
+# Quickstart
+
+Apply a minimal `CostManagementServiceConfig` and wait until core Cost
+Management is `Available`. This walkthrough is for **beta** (`ros.enabled` off)
+and assumes [prerequisites](prerequisites.md) are already met.
+
+**Time:** under 30 minutes after the operator is running and Secrets/buckets
+exist. Provisioning Postgres, Kafka, S3, and Keycloak is **not** part of this
+clock.
+
+**Beta.** Do not set `spec.ros.enabled: true`.
+
+## Install the operator
+
+The operator must run **in the same namespace as the CR**. There is no
+OperatorHub catalog yet. Two current vehicles:
+
+1. **OLM bundle** (preferred when you have a bundle image) — follow
+   [olm-bundle-testing.md](../development/olm-bundle-testing.md)
+   (`make bundle-run`). Create the target namespace first and install into it.
+2. **In-cluster Deployment** from this repo —
+   `IMG=<your-image> ./hack/deploy-incluster.sh "$NAMESPACE"` after CRDs/RBAC
+   (`./hack/deploy-dev.sh "$NAMESPACE"`).
+
+The generated CSV currently advertises AllNamespaces; the **runtime** still
+watches only the install namespace. Put the CR in that namespace.
+
+Do not run `make run` on a laptop against `*.svc.cluster.local` hosts. Database
+and cache probes will stay False.
+
+Confirm the manager is up:
+
+```bash
+export NAMESPACE=cost-onprem
+oc -n "$NAMESPACE" get deploy,pods
+oc get crd costmanagementserviceconfigs.service.costmanagement.openshift.io
+```
+
+## 1. Namespace and Secrets
+
+```bash
+export NAMESPACE=cost-onprem
+oc get ns "$NAMESPACE" >/dev/null 2>&1 || oc new-project "$NAMESPACE"
+```
+
+Create the Secrets from [prerequisites](prerequisites.md) in `$NAMESPACE`
+(`my-db-credentials`, `my-cache-credentials`, `my-s3-credentials`, and the UI
+OAuth client Secret). Kafka SASL/TLS Secrets are only needed if you enabled
+those protocols.
+
+## 2. Copy and edit the minimal CR
+
+The checked-in sample is
+[`config/samples/service.costmanagement_v1alpha1_costmanagementserviceconfig_minimal.yaml`](../../config/samples/service.costmanagement_v1alpha1_costmanagementserviceconfig_minimal.yaml).
+
+Replace at least:
+
+- `metadata.namespace`
+- `spec.global.clusterDomain` (or omit it and let discovery fill
+  `status.discoveredConfig.clusterDomain` from the cluster Ingress)
+- `spec.database.host` / `secretName`
+- `spec.cache.host` / `auth.secretName`
+- `spec.kafka.bootstrapServers`
+- `spec.objectStorage.endpoint` / `secretName`
+- `spec.auth.keycloak.url` (and `issuerURL` if token `iss` is the public Route)
+- Image `repository` / `tag` values for your environment
+
+Leave `spec.database.deploy` and `spec.cache.deploy` **false**. Leave
+monitoring off for this pass (`monitoring.enabled: false` in the sample). Do
+not add a `ros` block; the CRD default is `enabled: false`.
+
+Example shape (hosts are placeholders):
+
+```yaml
+apiVersion: service.costmanagement.openshift.io/v1alpha1
+kind: CostManagementServiceConfig
+metadata:
+  name: cost-management-minimal
+  namespace: cost-onprem
+spec:
+  global:
+    clusterDomain: "apps.cluster.example.com"
+  database:
+    deploy: false
+    host: "postgresql.databases.svc.cluster.local"
+    port: 5432
+    sslMode: "require"
+    secretName: "my-db-credentials"
+  cache:
+    deploy: false
+    host: "redis.cache.svc.cluster.local"
+    port: 6379
+    auth:
+      enabled: true
+      secretName: "my-cache-credentials"
+  kafka:
+    bootstrapServers: "kafka-kafka-bootstrap.kafka.svc.cluster.local:9092"
+  objectStorage:
+    endpoint: "s3.openshift-storage.svc.cluster.local"
+    port: 443
+    useSSL: true
+    secretName: "my-s3-credentials"
+  auth:
+    keycloak:
+      url: "https://keycloak.auth.svc.cluster.local"
+      realm: "kubernetes"
+  # image repository/tag blocks: copy from the sample and pin your tags
+  monitoring:
+    enabled: false
+```
+
+Do not apply that abbreviated snippet (it omits required image blocks). Copy the
+sample file, edit hosts and tags, then:
+
+```bash
+oc apply -f config/samples/service.costmanagement_v1alpha1_costmanagementserviceconfig_minimal.yaml
+```
+
+## 3. Watch conditions (not Phase)
+
+Conditions are the API. `status.phase` stays `Progressing` until the UI is
+ready, even when APIs are already up.
+
+```bash
+oc -n "$NAMESPACE" get cmsc
+oc -n "$NAMESPACE" get cmsc cost-management-minimal -o jsonpath='{range .status.conditions[*]}{.type}={.status} ({.reason}){"\n"}{end}'
+oc -n "$NAMESPACE" describe cmsc cost-management-minimal
+```
+
+| Condition | Day-one goal |
+|-----------|----------------|
+| `DiscoveryComplete` | True |
+| `DatabaseReady`, `CacheReady` | True (blocking if False) |
+| `StorageReady`, `KafkaReady` | True for a working upload path |
+| `SchemaUpToDate` | True (migrations finished) |
+| `RBACReady`, `IngressReady`, `GatewayReady` | True |
+| `Available` | True (`KokuAvailable`) — **success for this quickstart** |
+| `ROSEnabled` | False |
+| `AuthenticationReady` | True once JWKS is reachable |
+| `UIReady` | True only after the UI OAuth Secret exists |
+
+If `DatabaseReady` or `CacheReady` is False, fix the Secret keys or network
+path before waiting on Deployments.
+
+## 4. Confirm workloads and URLs
+
+```bash
+oc -n "$NAMESPACE" get deploy,job,route
+```
+
+With CR name `cost-management-minimal` in namespace `cost-onprem`:
+
+| URL | Host pattern |
+|-----|----------------|
+| API gateway | `https://cost-management-minimal-gateway-cost-onprem.{apps-domain}` (Route path `/api`) |
+| UI | `https://cost-management-minimal-ui-cost-onprem.{apps-domain}/` |
+
+The OpenShift console Application menu also gets a **Cost Management**
+ConsoleLink when the UI Route exists.
+
+## If something stays False
+
+| Symptom | Typical cause |
+|---------|----------------|
+| `DatabaseSecretInvalid` / `CacheSecretInvalid` | Wrong Secret keys — see [prerequisites](prerequisites.md) (`redis-password`, all ten DB keys) |
+| `DatabaseUnreachable` | Host/port not reachable from the operator pod (NetworkPolicy, wrong Service DNS) |
+| `SchemaUpToDate` never True | Migration Job failed — `oc -n "$NAMESPACE" get jobs,logs` |
+| `Available` True but `UIReady` False | Missing `{cr}-ui-oauth-client` with `client-id` / `client-secret` |
+| `StorageReady` False | Missing `access-key` / `secret-key`, or bucket does not exist |
+| Uploads return 500 | Bucket `koku-bucket` (or your `bucketName`) was never created |
+
+## Next
+
+- Size and TLS: [production.md](production.md)
+- Point Cost Management Metrics Operator at this instance: [cmmo.md](cmmo.md)

--- a/docs/install/quickstart.md
+++ b/docs/install/quickstart.md
@@ -164,7 +164,7 @@ ConsoleLink when the UI Route exists.
 |---------|----------------|
 | `DatabaseSecretInvalid` / `CacheSecretInvalid` | Wrong Secret keys — see [prerequisites](prerequisites.md) (`redis-password`, all ten DB keys) |
 | `DatabaseUnreachable` | Host/port not reachable from the operator pod (NetworkPolicy, wrong Service DNS) |
-| `SchemaUpToDate` never True | Migration Job failed — `oc -n "$NAMESPACE" get jobs,logs` |
+| `SchemaUpToDate` never True | Migration Job failed. List Jobs, then logs for the failed one: `oc -n "$NAMESPACE" get jobs` then `oc -n "$NAMESPACE" logs job/<cr>-koku-migrate` (beta Cost-only; RBAC is `{cr}-rbac-migrate`) |
 | `Available` True but `UIReady` False | Missing `{cr}-ui-oauth-client` with `client-id` / `client-secret` |
 | `StorageReady` False | Missing `access-key` / `secret-key`, or bucket does not exist |
 | Uploads return 500 | Bucket `koku-bucket` (or your `bucketName`) was never created |

--- a/docs/jira/COST-7700.md
+++ b/docs/jira/COST-7700.md
@@ -2,17 +2,25 @@
 
 **Jira:** [COST-7700](https://redhat.atlassian.net/browse/COST-7700)
 **Type:** Story
-**Status:** To Do
-**Assignee:** Elkana Hendler
-**Priority:** Normal
+**Status:** In Progress
+**Priority:** Major
 **Created:** 2026-06-10
-**Updated:** 2026-06-10
 **Parent:** [COST-7470](https://redhat.atlassian.net/browse/COST-7470) — Cost Management on-prem operator
+
+Split 2026-08-21:
+
+| Sub-task | Summary |
+|----------|---------|
+| [COST-8124](COST-8124.md) | Beta customer install and configuration guides |
+| [COST-8125](COST-8125.md) | GA install and configuration guide remainder |
+
+Close this parent when both sub-tasks are done.
 
 ## Description
 
-Deliver comprehensive documentation:* Prerequisites guide -- required external services (PostgreSQL, Kafka, OIDC/Keycloak, S3-compatible storage) with version requirements, configuration expectations, and Secret format specifications
+Deliver comprehensive documentation:
 
+- Prerequisites guide -- required external services (PostgreSQL, Kafka, OIDC/Keycloak, S3-compatible storage) with version requirements, configuration expectations, and Secret format specifications
 - Quickstart guide -- minimal CR to get a working deployment with step-by-step instructions
 - Production deployment guide -- HA profile configuration, resource tuning, NetworkPolicy considerations, monitoring setup, backup/restore recommendations
 - CMMO configuration guide -- how to configure Cost Management Metrics Operator to send data to the operator-deployed instance
@@ -23,4 +31,3 @@ Deliver comprehensive documentation:* Prerequisites guide -- required external s
 - Each guide is self-contained and can be followed independently
 - Prerequisites guide lists exact Secret key names expected by the operator
 - Quickstart can be completed in under 30 minutes (assuming prerequisites are met)
-

--- a/docs/jira/COST-8124.md
+++ b/docs/jira/COST-8124.md
@@ -1,0 +1,41 @@
+# COST-8124: Beta customer install and configuration guides
+
+**Jira:** [COST-8124](https://redhat.atlassian.net/browse/COST-8124)
+**Type:** Sub-task
+**Status:** In Progress
+**Parent:** [COST-7700](COST-7700.md) — Write installation and configuration guides
+**Sibling:** [COST-8125](COST-8125.md) — GA remainder
+
+## Description
+
+Deliver beta-honest customer documentation in the operator repository under
+`docs/install/`.
+
+### Scope
+
+- Prerequisites: external PostgreSQL, Kafka, OIDC/Keycloak, S3. Exact Secret
+  key names (including `redis-password`). `ros-*` and `kruize-*` DB keys still
+  required while ROS is off.
+- Quickstart: minimal BYOI CR to `Available` in under 30 minutes after
+  prerequisites and the operator. `ros.enabled` stays false.
+- Production-shaped BYOI: production sample, explicit resources/replicas, TLS
+  CA Secrets, NetworkPolicies that exist today, monitoring if Prometheus CRDs
+  exist, backup as customer-owned. Do not claim `profile: ha` sizes the stack.
+- CMMO: lab-derived gateway host + `/api/ingress/v1/upload`, service-account
+  auth, ROS collection off. Do not tell customers to run
+  `setup-cost-mgmt-tls.sh`.
+
+### Out of scope
+
+Certified version matrix, full-stack `profile: ha`, operator backup/restore,
+complete NetworkPolicy/monitoring, OperatorHub/catalog, certified CMMO
+contract. Those are [COST-8125](COST-8125.md).
+
+## Acceptance Criteria
+
+- Guides are Markdown in `docs/install/`
+- Each guide is self-contained
+- Prerequisites lists exact Secret key names
+- Quickstart can be completed in under 30 minutes assuming prerequisites and
+  the operator are met
+- Beta banners present; ROS/Kruize documented as unsupported

--- a/docs/jira/COST-8125.md
+++ b/docs/jira/COST-8125.md
@@ -1,0 +1,38 @@
+# COST-8125: GA install and configuration guide remainder
+
+**Jira:** [COST-8125](https://redhat.atlassian.net/browse/COST-8125)
+**Type:** Sub-task
+**Status:** New
+**Parent:** [COST-7700](COST-7700.md) — Write installation and configuration guides
+**Sibling:** [COST-8124](COST-8124.md) — Beta customer guides
+
+## Description
+
+Rewrite and extend `docs/install/` so it matches a GA reading of COST-7700.
+This ticket is documentation. It depends on product and engineering work
+landing first (COST-8095, COST-7695, NetworkPolicy/monitoring completeness,
+CMMO owner confirmation).
+
+### Scope
+
+- Product-approved version matrix (OpenShift, PostgreSQL, Kafka/AMQ Streams,
+  RHBK, S3, CMMO)
+- `profile: ha` as a full-stack sizing switch after COST-8095
+- NetworkPolicy and monitoring docs that match scrapable, complete behavior
+- Backup/restore runbook for customer infra plus operator-generated Secrets
+- OperatorHub / catalog install once COST-7695 is the customer vehicle
+- CMMO upload URL, path, and auth confirmed with CMMO owners; production TLS
+
+### Out of scope
+
+Beta docs from COST-8124 except where this ticket replaces lab-derived or
+beta-limited wording.
+
+## Acceptance Criteria
+
+- Production and CMMO guides no longer carry lab-derived or beta-limit banners
+  for items that are actually supported
+- Version requirements are product-approved, not fixture-only
+- Prerequisites Secret key list still matches the operator
+- Quickstart still works in under 30 minutes after prerequisites and a catalog
+  install of the operator

--- a/docs/tasks.md
+++ b/docs/tasks.md
@@ -61,7 +61,7 @@ Last audited: 2026-08-19.
 | [COST-7697](https://redhat.atlassian.net/browse/COST-7697) | Adapt existing E2E suite for operator | ❌ | |
 | [COST-7698](https://redhat.atlassian.net/browse/COST-7698) | Implement operator-specific E2E scenarios | ❌ | Unit tests for discovery, ownership, migration pipeline present. Full operator E2E not written. |
 | [COST-7699](https://redhat.atlassian.net/browse/COST-7699) | Set up OpenShift CI integration | ❌ | |
-| [COST-7700](https://redhat.atlassian.net/browse/COST-7700) | Write installation and configuration guides | ❌ | README, CLAUDE.md, CRC dev guide, design docs present. Formal installation/configuration/quickstart guides not written. |
+| [COST-7700](https://redhat.atlassian.net/browse/COST-7700) | Write installation and configuration guides | 🔄 | Split: [COST-8124](jira/COST-8124.md) beta guides in [docs/install/](install/README.md) (this branch). [COST-8125](jira/COST-8125.md) GA remainder (post-beta). Close parent when both sub-tasks are done. |
 
 ---
 
@@ -98,6 +98,7 @@ Short version: bundled infra is dev-only (intentional), profile-based sizing for
 |--------|---------|-------|
 | [COST-8095](https://redhat.atlassian.net/browse/COST-8095) | `spec.profile` sizing maps | Shared `standard`/`ha` maps for remaining Cost workloads. UI already wired. ROS/Kruize rows stay with COST-8054. See [jira snapshot](jira/COST-8095.md). |
 | [COST-8103](https://redhat.atlassian.net/browse/COST-8103) | `CoreServicesAvailable` / mid-pipeline `Available` | Sparse success Events (`Ready`); stop treating Koku-API-up as product-available. See [jira snapshot](jira/COST-8103.md). |
+| [COST-8125](https://redhat.atlassian.net/browse/COST-8125) | GA install/config guide remainder | Certified versions, full-stack `profile: ha` docs, backup, complete NP/monitoring, OperatorHub, confirmed CMMO contract. Parent [COST-7700](jira/COST-7700.md). See [jira snapshot](jira/COST-8125.md). |
 
 ---
 


### PR DESCRIPTION
## Summary
- Add customer install/config guides under `docs/install/` for the Cost-only beta path (`ros.enabled: false`): prerequisites with exact Secret keys, quickstart, production-shaped BYOI, and a lab-derived CMMO guide.
- Point the repo README and lab docs at `docs/install/`. Fix the minimal sample cache Secret comment (`redis-password`, which is what the operator validates).
- Split COST-7700 in the tracker: this PR is COST-8124. GA remainder (certified versions, full-stack `profile: ha`, OperatorHub, backup, confirmed CMMO contract) stays on COST-8125.

## Test plan
- [ ] Read `docs/install/README.md` and follow each guide as a self-contained doc (no Cluster Bot / `demo-preprod.sh` / CRC bundled DB).
- [ ] Confirm the Secret key tables match the operator (`redis-password`, all ten DB keys including unused `ros-*` / `kruize-*`, S3 `access-key` / `secret-key`, UI `client-id` / `client-secret`).
- [ ] Confirm production.md does not claim `profile: ha` sizes the full stack, and that backup is described as customer-owned.
- [ ] Confirm cmmo.md uses the gateway host plus `/api/ingress/v1/upload`, ROS collection off, and does not tell customers to run `setup-cost-mgmt-tls.sh`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Adds beta customer installation and configuration guides for the Cost-only path with `ros.enabled: false`.
- Documents prerequisites, Secret keys, quickstart installation, production-shaped BYOI deployment, and CMMO configuration.
- Updates README and lab documentation links.
- Corrects the minimal cache Secret example to use `redis-password`.
- Updates `docs/tasks.md` to track the split between COST-8124 beta work and COST-8125 GA work.

## Operator impact

- No CRD API changes.
- No reconcile-phase behavior changes.
- No RBAC changes.
- Documents operator readiness checks and user-visible status conditions for installation verification.
- Documents the beta requirement that the operator runs in the Cost Management CR namespace.
- GA scope remains in COST-8125, including certified versions, `profile: ha`, OperatorHub, backup, and the confirmed CMMO contract.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->