### PR TITLE
fix: honor custom CA for Keycloak JWKS probe

### DIFF
--- a/docs/review-follow-ups.md
+++ b/docs/review-follow-ups.md
@@ -206,29 +206,15 @@ branch.
 
 ---
 
-## 11. `jwksProbe` ignores `caCertSecretName` — false `AuthenticationReady: False`
+## 11. ~~`jwksProbe` ignores `caCertSecretName` — false `AuthenticationReady: False`~~ — **CLOSED**
 
 **Source:** PR #74 review (Jordi)
 
-**Problem:** `jwksProbe` (validation.go:195) builds its TLS transport from
-Go's default cert pool and only honours `insecureSkipVerify`. When a user
-sets `spec.authentication.keycloak.tls.caCertSecretName` for an internal
-Keycloak with a self-signed or private CA, Envoy gets the CA mounted via
-`/ca-extra` and validates JWKS fine — but the operator's own health probe
-uses a different TLS path and reports `AuthenticationReady: False /
-OIDCUnreachable` even though authentication works end-to-end.
-
-**Concrete failure mode:** user has a real CA, sets `caCertSecretName`,
-does NOT set `insecureSkipVerify` (correctly — they have a proper CA).
-Envoy works. Operator says auth is broken.
-
-**Fix:** Thread the CA secret into `jwksProbe` — read the Secret, load
-certs into a `tls.Config.RootCAs` pool, pass the custom transport.
-Requires Secrets read RBAC in the validation phase.
-
-**Workaround:** set `insecureSkipVerify: true` alongside `caCertSecretName`
-to suppress the false negative (Envoy still validates properly with the
-mounted CA).
+**Fixed:** `reconcileValidation` now reads `ca.crt` from
+`auth.keycloak.tls.caCertSecretName` and passes a custom `x509.CertPool` to
+`jwksProbe`. Missing or invalid CA data reports `OIDCCACertInvalid`. When
+`insecureSkipVerify=true`, the operator skips CA Secret loading and honors the
+explicit insecure setting.
 
 ---
 

--- a/docs/review-follow-ups.md
+++ b/docs/review-follow-ups.md
@@ -210,7 +210,8 @@ branch.
 
 **Source:** PR #74 review (Jordi)
 
-**Fixed:** `reconcileValidation` now reads `ca.crt` from
+**Fixed:** `reconcileValidation` now delegates Keycloak CA loading to
+`keycloakCACertPool`, which reads `ca.crt` from
 `auth.keycloak.tls.caCertSecretName` and passes a custom `x509.CertPool` to
 `jwksProbe`. Missing or invalid CA data reports `OIDCCACertInvalid`. When
 `insecureSkipVerify=true`, the operator skips CA Secret loading and honors the

--- a/internal/controller/validation.go
+++ b/internal/controller/validation.go
@@ -173,7 +173,7 @@ func (r *CostManagementServiceConfigReconciler) validateOIDC(ctx context.Context
 	caCertPool, err := r.keycloakCACertPool(ctx, cfg)
 	if err != nil {
 		r.setCondition(cfg, costv1alpha1.ConditionAuthReady, metav1.ConditionFalse,
-			"OIDCCACertInvalid", err.Error())
+			"OIDCCACertInvalid", fmt.Errorf("load Keycloak CA Secret: %w", err).Error())
 		return
 	}
 	if err := jwksProbe(ctx, jwksURL, insecure, caCertPool, validationTimeout); err != nil {
@@ -201,7 +201,7 @@ func (r *CostManagementServiceConfigReconciler) keycloakCACertPool(ctx context.C
 	}
 	caCertPool := x509.NewCertPool()
 	if !caCertPool.AppendCertsFromPEM(caSecret.Data[caCertKey]) {
-		return nil, fmt.Errorf("secret %q key ca.crt contains no valid PEM certificates", caName)
+		return nil, fmt.Errorf("secret %q key %q contains no valid PEM certificates", caName, caCertKey)
 	}
 	return caCertPool, nil
 }

--- a/internal/controller/validation.go
+++ b/internal/controller/validation.go
@@ -3,6 +3,7 @@ package controller
 import (
 	"context"
 	"crypto/tls"
+	"crypto/x509"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -143,17 +144,7 @@ func (r *CostManagementServiceConfigReconciler) reconcileValidation(ctx context.
 	r.validateObjectStorage(ctx, cfg)
 
 	// --- OIDC / Keycloak (non-blocking; skipped when URL not explicitly set) ---
-	if u := strings.TrimSpace(cfg.Spec.Auth.Keycloak.URL); u != "" {
-		jwksURL := resources.KeycloakJWKSURL(cfg)
-		insecure := cfg.Spec.Auth.Keycloak.TLS.InsecureSkipVerify
-		if err := jwksProbe(ctx, jwksURL, insecure, validationTimeout); err != nil {
-			r.setCondition(cfg, costv1alpha1.ConditionAuthReady, metav1.ConditionFalse,
-				"OIDCUnreachable", fmt.Sprintf("JWKS %s: %v", jwksURL, err))
-		} else {
-			r.setCondition(cfg, costv1alpha1.ConditionAuthReady, metav1.ConditionTrue,
-				"OIDCReachable", jwksURL)
-		}
-	}
+	r.validateOIDC(ctx, cfg)
 
 	if !allReady {
 		// Blocking DB/Cache failures must not leave stale Available=True /
@@ -167,6 +158,52 @@ func (r *CostManagementServiceConfigReconciler) reconcileValidation(ctx context.
 		return Result{RequeueAfter: requeueSlow}, nil
 	}
 	return Result{}, nil
+}
+
+// validateOIDC probes the configured Keycloak JWKS endpoint. It is
+// non-blocking for the reconciliation pipeline, but records authentication
+// readiness and invalid custom CA configuration in status.
+func (r *CostManagementServiceConfigReconciler) validateOIDC(ctx context.Context, cfg *costv1alpha1.CostManagementServiceConfig) {
+	if strings.TrimSpace(cfg.Spec.Auth.Keycloak.URL) == "" {
+		return
+	}
+
+	jwksURL := resources.KeycloakJWKSURL(cfg)
+	insecure := cfg.Spec.Auth.Keycloak.TLS.InsecureSkipVerify
+	caCertPool, err := r.keycloakCACertPool(ctx, cfg)
+	if err != nil {
+		r.setCondition(cfg, costv1alpha1.ConditionAuthReady, metav1.ConditionFalse,
+			"OIDCCACertInvalid", err.Error())
+		return
+	}
+	if err := jwksProbe(ctx, jwksURL, insecure, caCertPool, validationTimeout); err != nil {
+		r.setCondition(cfg, costv1alpha1.ConditionAuthReady, metav1.ConditionFalse,
+			"OIDCUnreachable", fmt.Sprintf("JWKS %s: %v", jwksURL, err))
+		return
+	}
+	r.setCondition(cfg, costv1alpha1.ConditionAuthReady, metav1.ConditionTrue,
+		"OIDCReachable", jwksURL)
+}
+
+// keycloakCACertPool loads the configured Keycloak CA unless TLS verification
+// was explicitly disabled. A nil pool preserves the system CA behavior.
+func (r *CostManagementServiceConfigReconciler) keycloakCACertPool(ctx context.Context, cfg *costv1alpha1.CostManagementServiceConfig) (*x509.CertPool, error) {
+	if cfg.Spec.Auth.Keycloak.TLS.InsecureSkipVerify {
+		return nil, nil
+	}
+	caName := cfg.Spec.Auth.Keycloak.TLS.CACertSecretName
+	if caName == "" {
+		return nil, nil
+	}
+	caSecret, err := r.getSecret(ctx, cfg.Namespace, caName, []string{caCertKey})
+	if err != nil {
+		return nil, err
+	}
+	caCertPool := x509.NewCertPool()
+	if !caCertPool.AppendCertsFromPEM(caSecret.Data[caCertKey]) {
+		return nil, fmt.Errorf("secret %q key ca.crt contains no valid PEM certificates", caName)
+	}
+	return caCertPool, nil
 }
 
 // blockingDependencyMessage summarizes why DB/Cache validation blocked reconcile.
@@ -219,8 +256,9 @@ func kafkaTCPProbe(bootstrapServers string, timeout time.Duration) error {
 // with a non-empty keys array (what Envoy needs to validate JWTs).
 // 4xx is an error: 401/403 means the endpoint is misconfigured; 404 means
 // the JWKS URL or realm is wrong. Uses the reconcile context so shutdown
-// cancels an in-flight probe.
-func jwksProbe(ctx context.Context, rawURL string, insecureSkipVerify bool, timeout time.Duration) error {
+// cancels an in-flight probe. When caCertPool is non-nil, it is used instead
+// of the system CA pool for TLS verification.
+func jwksProbe(ctx context.Context, rawURL string, insecureSkipVerify bool, caCertPool *x509.CertPool, timeout time.Duration) error {
 	base, ok := http.DefaultTransport.(*http.Transport)
 	if !ok {
 		base = &http.Transport{}
@@ -231,6 +269,12 @@ func jwksProbe(ctx context.Context, rawURL string, insecureSkipVerify bool, time
 			transport.TLSClientConfig = &tls.Config{}
 		}
 		transport.TLSClientConfig.InsecureSkipVerify = true //nolint:gosec // user-opted-in
+	}
+	if caCertPool != nil {
+		if transport.TLSClientConfig == nil {
+			transport.TLSClientConfig = &tls.Config{}
+		}
+		transport.TLSClientConfig.RootCAs = caCertPool
 	}
 	ctx, cancel := context.WithTimeout(ctx, timeout)
 	defer cancel()

--- a/internal/controller/validation_test.go
+++ b/internal/controller/validation_test.go
@@ -2,6 +2,8 @@ package controller
 
 import (
 	"context"
+	"crypto/x509"
+	"encoding/pem"
 	"net"
 	"net/http"
 	"net/http/httptest"
@@ -94,15 +96,38 @@ func TestJWKSProbe(t *testing.T) {
 				_, _ = w.Write([]byte(tc.body))
 			}))
 			t.Cleanup(srv.Close)
-			err := jwksProbe(ctx, srv.URL, false, time.Second)
+			err := jwksProbe(ctx, srv.URL, false, nil, time.Second)
 			if (err != nil) != tc.wantErr {
 				t.Errorf("jwksProbe status=%d body=%q: err=%v, wantErr=%v", tc.status, tc.body, err, tc.wantErr)
 			}
 		})
 	}
 
+	t.Run("TLS custom CA", func(t *testing.T) {
+		srv := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(validJWKS))
+		}))
+		t.Cleanup(srv.Close)
+		pool := x509.NewCertPool()
+		pool.AddCert(srv.Certificate())
+		if err := jwksProbe(ctx, srv.URL, false, pool, time.Second); err != nil {
+			t.Fatalf("expected success with custom CA, got %v", err)
+		}
+	})
+
+	t.Run("TLS verification failure without custom CA", func(t *testing.T) {
+		srv := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			_, _ = w.Write([]byte(validJWKS))
+		}))
+		t.Cleanup(srv.Close)
+		if err := jwksProbe(ctx, srv.URL, false, nil, time.Second); err == nil {
+			t.Fatal("expected TLS verification error")
+		}
+	})
+
 	t.Run("unreachable", func(t *testing.T) {
-		if err := jwksProbe(ctx, "http://"+localHost+":1/jwks", false, 200*time.Millisecond); err == nil {
+		if err := jwksProbe(ctx, "http://"+localHost+":1/jwks", false, nil, 200*time.Millisecond); err == nil {
 			t.Fatal("expected error for unreachable server")
 		}
 	})
@@ -114,7 +139,7 @@ func TestJWKSProbe(t *testing.T) {
 		t.Cleanup(srv.Close)
 		cancelled, cancel := context.WithCancel(context.Background())
 		cancel()
-		if err := jwksProbe(cancelled, srv.URL, false, time.Second); err == nil {
+		if err := jwksProbe(cancelled, srv.URL, false, nil, time.Second); err == nil {
 			t.Fatal("expected error when parent context is cancelled")
 		}
 	})
@@ -435,6 +460,101 @@ func TestReconcileValidation_OIDCJWKS(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestReconcileValidation_OIDCWithCustomCA(t *testing.T) {
+	t.Run("custom CA", func(t *testing.T) {
+		srv := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"keys":[{"kty":"RSA","kid":"1"}]}`))
+		}))
+		t.Cleanup(srv.Close)
+
+		cfg := &costv1alpha1.CostManagementServiceConfig{
+			ObjectMeta: metav1.ObjectMeta{Name: testCRName, Namespace: testNamespace},
+			Spec:       bundledNoKafkaSpec(),
+		}
+		cfg.Spec.Auth.Keycloak.URL = srv.URL
+		cfg.Spec.Auth.Keycloak.TLS.CACertSecretName = "keycloak-ca"
+		caPEM := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: srv.Certificate().Raw})
+		caSecret := &corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{Name: "keycloak-ca", Namespace: testNamespace},
+			Data:       map[string][]byte{caCertKey: caPEM},
+		}
+
+		r := newValidationReconciler(t, caSecret)
+		if _, err := r.reconcileValidation(context.Background(), cfg); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		found := findCondition(cfg.Status.Conditions, costv1alpha1.ConditionAuthReady)
+		if found == nil || found.Status != metav1.ConditionTrue || found.Reason != "OIDCReachable" {
+			t.Fatalf("AuthenticationReady=%+v, want OIDCReachable", found)
+		}
+	})
+
+	t.Run("missing CA Secret", func(t *testing.T) {
+		cfg := &costv1alpha1.CostManagementServiceConfig{
+			ObjectMeta: metav1.ObjectMeta{Name: testCRName, Namespace: testNamespace},
+			Spec:       bundledNoKafkaSpec(),
+		}
+		cfg.Spec.Auth.Keycloak.URL = "https://keycloak.example.com"
+		cfg.Spec.Auth.Keycloak.TLS.CACertSecretName = "missing-ca"
+
+		r := newValidationReconciler(t)
+		if _, err := r.reconcileValidation(context.Background(), cfg); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		found := findCondition(cfg.Status.Conditions, costv1alpha1.ConditionAuthReady)
+		if found == nil || found.Status != metav1.ConditionFalse || found.Reason != "OIDCCACertInvalid" {
+			t.Fatalf("AuthenticationReady=%+v, want OIDCCACertInvalid", found)
+		}
+	})
+
+	t.Run("invalid CA data", func(t *testing.T) {
+		cfg := &costv1alpha1.CostManagementServiceConfig{
+			ObjectMeta: metav1.ObjectMeta{Name: testCRName, Namespace: testNamespace},
+			Spec:       bundledNoKafkaSpec(),
+		}
+		cfg.Spec.Auth.Keycloak.URL = "https://keycloak.example.com"
+		cfg.Spec.Auth.Keycloak.TLS.CACertSecretName = "invalid-ca"
+		caSecret := &corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{Name: "invalid-ca", Namespace: testNamespace},
+			Data:       map[string][]byte{caCertKey: []byte("not-a-certificate")},
+		}
+
+		r := newValidationReconciler(t, caSecret)
+		if _, err := r.reconcileValidation(context.Background(), cfg); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		found := findCondition(cfg.Status.Conditions, costv1alpha1.ConditionAuthReady)
+		if found == nil || found.Status != metav1.ConditionFalse || found.Reason != "OIDCCACertInvalid" {
+			t.Fatalf("AuthenticationReady=%+v, want OIDCCACertInvalid", found)
+		}
+	})
+
+	t.Run("insecure skips CA Secret loading", func(t *testing.T) {
+		srv := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			_, _ = w.Write([]byte(`{"keys":[{"kty":"RSA","kid":"1"}]}`))
+		}))
+		t.Cleanup(srv.Close)
+
+		cfg := &costv1alpha1.CostManagementServiceConfig{
+			ObjectMeta: metav1.ObjectMeta{Name: testCRName, Namespace: testNamespace},
+			Spec:       bundledNoKafkaSpec(),
+		}
+		cfg.Spec.Auth.Keycloak.URL = srv.URL
+		cfg.Spec.Auth.Keycloak.TLS.CACertSecretName = "missing-ca"
+		cfg.Spec.Auth.Keycloak.TLS.InsecureSkipVerify = true
+
+		r := newValidationReconciler(t)
+		if _, err := r.reconcileValidation(context.Background(), cfg); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		found := findCondition(cfg.Status.Conditions, costv1alpha1.ConditionAuthReady)
+		if found == nil || found.Status != metav1.ConditionTrue || found.Reason != "OIDCReachable" {
+			t.Fatalf("AuthenticationReady=%+v, want OIDCReachable", found)
+		}
+	})
 }
 
 func TestReconcileValidation_DBSecretMissingKeys(t *testing.T) {


### PR DESCRIPTION
## Summary

- Load the configured Keycloak CA Secret for JWKS validation.
- Report invalid or missing CA data as OIDCCACertInvalid.
- Honor insecureSkipVerify without loading the CA Secret.
- Add coverage and close the review follow-up.

## Validation

- make setup-envtest
- KUBEBUILDER_ASSETS=bin/k8s/1.33.0-darwin-arm64 go test ./internal/controller/...

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

- OIDC validation uses `ca.crt` from the configured Keycloak CA Secret for JWKS TLS verification.
- Missing or invalid CA data sets `AuthenticationReady=False` with reason `OIDCCACertInvalid`.
- When `insecureSkipVerify=true`, validation skips CA Secret loading and certificate verification.
- The change does not modify the CRD API or RBAC.
- Added coverage for custom CA data, missing or invalid CA data, TLS failures, and insecure TLS.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->