### PR TITLE
ci: add standalone gitleaks secret scanning

### DIFF
--- a/.github/workflows/gitleaks.yml
+++ b/.github/workflows/gitleaks.yml
@@ -51,6 +51,7 @@ jobs:
           chmod +x gitleaks
 
       - name: Run gitleaks
+        id: gitleaks
         run: |
           # --exit-code 2: leaks found. Scan errors stay 1. Continue only for 0 or 2
           # so the SARIF is available for upload / the fail-on-leaks step.
@@ -62,13 +63,20 @@ jobs:
             --report-path results.sarif \
             --redact \
             --exit-code 2 || code=$?
+          echo "exit_code=$code" >> "$GITHUB_OUTPUT"
           if [ "$code" -ne 0 ] && [ "$code" -ne 2 ]; then
             echo "::error::gitleaks failed with exit code $code (scan error, not leak findings)"
             exit "$code"
           fi
 
+      # Do not use always(): a scan error still writes a partial SARIF that
+      # would overwrite a complete code-scanning result set.
       - name: Upload SARIF
-        if: always() && env.UPLOAD_SARIF == 'true' && hashFiles('results.sarif') != ''
+        if: >-
+          env.UPLOAD_SARIF == 'true'
+          && (steps.gitleaks.outputs.exit_code == '0'
+              || steps.gitleaks.outputs.exit_code == '2')
+          && hashFiles('results.sarif') != ''
         uses: github/codeql-action/upload-sarif@5595ccaf912efad79be6eef63a5619ff05969be3 # v4.37.6
         with:
           sarif_file: results.sarif

--- a/.github/workflows/gitleaks.yml
+++ b/.github/workflows/gitleaks.yml
@@ -23,6 +23,8 @@ concurrency:
 env:
   GITLEAKS_VERSION: "8.30.1"
   GITLEAKS_SHA256: "551f6fc83ea457d62a0d98237cbad105af8d557003051f41f3e7ca7b3f2470eb"
+  # Flip to "true" to publish findings to GitHub code scanning (Security tab).
+  UPLOAD_SARIF: "false"
 
 jobs:
   scan:
@@ -31,7 +33,7 @@ jobs:
     timeout-minutes: 15
     permissions:
       contents: read
-      security-events: write
+      security-events: write # used only when UPLOAD_SARIF is true
 
     steps:
       - name: Checkout
@@ -49,10 +51,24 @@ jobs:
           chmod +x gitleaks
 
       - name: Run gitleaks
-        run: ./gitleaks detect --config .gitleaks.toml --source . --report-format sarif --report-path results.sarif --redact || true
+        run: |
+          # --exit-code 2: leaks found. Scan errors stay 1. Continue only for 0 or 2
+          # so the SARIF is available for upload / the fail-on-leaks step.
+          code=0
+          ./gitleaks detect \
+            --config .gitleaks.toml \
+            --source . \
+            --report-format sarif \
+            --report-path results.sarif \
+            --redact \
+            --exit-code 2 || code=$?
+          if [ "$code" -ne 0 ] && [ "$code" -ne 2 ]; then
+            echo "::error::gitleaks failed with exit code $code (scan error, not leak findings)"
+            exit "$code"
+          fi
 
       - name: Upload SARIF
-        if: always() && hashFiles('results.sarif') != ''
+        if: always() && env.UPLOAD_SARIF == 'true' && hashFiles('results.sarif') != ''
         uses: github/codeql-action/upload-sarif@5595ccaf912efad79be6eef63a5619ff05969be3 # v4.37.6
         with:
           sarif_file: results.sarif

--- a/.github/workflows/gitleaks.yml
+++ b/.github/workflows/gitleaks.yml
@@ -56,6 +56,7 @@ jobs:
         uses: github/codeql-action/upload-sarif@5595ccaf912efad79be6eef63a5619ff05969be3 # v4.37.6
         with:
           sarif_file: results.sarif
+          category: gitleaks
 
       - name: Fail if leaks found
         run: |

--- a/.github/workflows/gitleaks.yml
+++ b/.github/workflows/gitleaks.yml
@@ -1,0 +1,71 @@
+name: Gitleaks
+
+# Full-history secret scan. Uses a checksum-verified release binary (not the
+# commercial gitleaks-action wrapper). Known BYOI fixtures are allowlisted in
+# .gitleaks.toml.
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  schedule:
+    - cron: "17 5 * * 3" # weekly Wednesday 05:17 UTC
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  GITLEAKS_VERSION: "8.30.1"
+  GITLEAKS_SHA256: "551f6fc83ea457d62a0d98237cbad105af8d557003051f41f3e7ca7b3f2470eb"
+
+jobs:
+  scan:
+    name: Scan for secrets
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    permissions:
+      contents: read
+      security-events: write
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Install gitleaks (pinned, checksum-verified)
+        run: |
+          curl -sSL -o gitleaks.tar.gz \
+            "https://github.com/gitleaks/gitleaks/releases/download/v${GITLEAKS_VERSION}/gitleaks_${GITLEAKS_VERSION}_linux_x64.tar.gz"
+          echo "${GITLEAKS_SHA256}  gitleaks.tar.gz" | sha256sum -c -
+          tar -xzf gitleaks.tar.gz gitleaks
+          chmod +x gitleaks
+
+      - name: Run gitleaks
+        run: ./gitleaks detect --config .gitleaks.toml --source . --report-format sarif --report-path results.sarif --redact || true
+
+      - name: Upload SARIF
+        if: always() && hashFiles('results.sarif') != ''
+        uses: github/codeql-action/upload-sarif@5595ccaf912efad79be6eef63a5619ff05969be3 # v4.37.6
+        with:
+          sarif_file: results.sarif
+
+      - name: Fail if leaks found
+        run: |
+          if [ ! -f results.sarif ]; then
+            echo "::error::gitleaks did not write results.sarif"
+            exit 1
+          fi
+          count=$(jq '.runs[0].results | length' results.sarif)
+          if [ "$count" -gt 0 ]; then
+            echo "::error::gitleaks detected $count potential secret(s) not covered by .gitleaks.toml"
+            exit 1
+          fi
+          echo "No uncategorized secrets detected."

--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -1,0 +1,27 @@
+# Gitleaks config for koku-service-operator.
+# Allowlist known non-production BYOI fixture credentials and doc examples.
+# Real secrets must never be added here — fix the leak instead.
+
+title = "koku-service-operator"
+
+[extend]
+useDefault = true
+
+[allowlist]
+description = "Dev-only BYOI fixtures (fixed lab credentials — not for production)"
+paths = [
+  '''(^|/)config/samples/byoi/''',
+  '''(^|/)docs/jira/''',
+]
+
+# Explicit fixture credential strings (also referenced outside byoi YAML).
+regexes = [
+  '''byoi-postgres-password''',
+  '''byoi-koku-password''',
+  '''byoi-ros-password''',
+  '''byoi-kruize-password''',
+  '''byoi-rbac-password''',
+  '''byoi-valkey-password''',
+  '''byoi-minio-access''',
+  '''byoi-minio-secret-key''',
+]


### PR DESCRIPTION
## Summary
- Add a standalone **Gitleaks** workflow (full-history secret scan, checksum-verified binary, SARIF upload to code scanning).
- Add **`.gitleaks.toml`** allowlisting known `config/samples/byoi/` lab credentials and `docs/jira/` prose that trips the generic-api-key rule.
- Not a required merge gate yet — enable later once it has been green on `main`.

Sliced out of #46 so Gitleaks can land independently of CodeQL, Scorecard, and SECURITY.md.

## Test plan
- [ ] Confirm the Gitleaks workflow appears under Actions on this PR
- [ ] No false positives on BYOI fixtures / `docs/jira/`
- [ ] Job fails if a real-looking secret is added outside the allowlist
- [ ] Do **not** add as a required status check until the first green runs on `main`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

- Adds a standalone Gitleaks workflow for full-history scans.
- Verifies the pinned Gitleaks binary with SHA256 before execution.
- Distinguishes leak findings from scanner failures.
- Uploads SARIF results with the `gitleaks` category after clean scans or scans with leak findings.
- Skips SARIF uploads when the scanner fails.
- Runs on pushes and pull requests to `main`, weekly, and manual triggers.
- Adds allowlists for known BYOI fixture credentials and Jira documentation examples.
- The workflow should not become a required merge gate until it has successful runs on `main`.

## Operator impact

- No CRD API changes.
- No reconcile-phase changes.
- No RBAC changes.
- No user-visible status-condition changes.

## Test plan

- Confirm workflow visibility and trigger behavior.
- Confirm checksum verification and full-history scanning.
- Confirm scanner failures fail the job without uploading partial SARIF.
- Confirm leak findings produce SARIF and fail the dedicated leak check.
- Confirm clean scans produce SARIF when upload is enabled.
- Confirm known allowlisted content does not produce false positives.
- Confirm a real-looking secret outside the allowlist is detected.
- Delay required status-check configuration until successful `main` runs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->