### PR TITLE
fix: append custom CAs to the system pool instead of replacing it

### DIFF
--- a/docs/review-follow-ups.md
+++ b/docs/review-follow-ups.md
@@ -113,6 +113,9 @@ as a workaround, defeating TLS verification.
 from CACombineInitContainer) and set `SSL_CERT_FILE` in the container env.
 Follow the same pattern used by the Envoy gateway and oauth2-proxy.
 
+Envoy itself already trusts this CA (COST-7688 R2; follow-up #18). This
+item is the CronJob-only remaining gap.
+
 ---
 
 ## 8. ~~Keycloak sync: enable/disable lifecycle test~~ — **CLOSED**
@@ -125,30 +128,15 @@ same pattern as `TestKruizeCronJobDeletedWhenDisabled`.
 
 ---
 
-## 9. S3 TLS fields are probe-only — not wired to app pods
+## 9. ~~S3 TLS fields are probe-only — not wired to app pods~~ — **CLOSED**
 
 **Source:** Code review of PR #71 (validation follow-ups).
 
-**Problem:** `spec.objectStorage.insecureSkipVerify` and
-`spec.objectStorage.caCertSecretName` configure the operator's own
-`ListBuckets` validation probe, but are not wired to application pod
-env vars (`AWS_CA_BUNDLE`) or volume mounts. App pods that need to
-reach the same S3 endpoint with a private CA rely on the combined CA
-bundle from `CACombineInitContainer`, which does not read the
-objectStorage TLS fields.
-
-The Keycloak and Cache TLS equivalents (`auth.keycloak.tls`,
-`cache.tls`) are wired to both the operator probe and the app
-containers. S3 should follow the same pattern.
-
-**Impact:** A user sets `caCertSecretName` expecting it to fix S3
-connectivity for both the operator condition and the running workloads.
-The `StorageReady` condition turns green, but uploads still fail if
-the app pods don't have the CA in their trust store via another path.
-
-**Suggested fix:** Wire `objectStorage.caCertSecretName` into the
-`CACombineInitContainer` inputs (or set `AWS_CA_BUNDLE` env var on
-Koku/Masu containers) so app pods trust the same CA.
+**Fixed:** `userCAFiles` includes `objectStorage.caCertSecretName` as
+`object-storage-ca.crt`. `CACombineInitContainer` merges it into the
+combined bundle. Koku/Masu set `AWS_CA_BUNDLE` and `REQUESTS_CA_BUNDLE`
+to that bundle (`internal/resources/env.go`). Covered by
+`internal/resources/volumes_test.go`.
 
 ---
 
@@ -299,3 +287,42 @@ reasons `WaitingForRBAC` / component `"RBAC API"`). Leave the RBAC
 worker as condition-only (it does not block `Available` today).
 
 **Out of scope for PR #105** — COST-7689 leftover, not a COST-7686 AC.
+
+---
+
+## 16. ~~Custom CA `RootCAs` replaced the system pool~~ — **CLOSED**
+
+**Source:** [PR #121 review](https://github.com/project-koku/koku-service-operator/pull/121#pullrequestreview-5000508819) (bacciotti).
+
+**Fixed:** `certPoolFromPEM` starts from `x509.SystemCertPool()` and
+appends the custom CA. JWKS and S3 probes share it so a custom CA no
+longer drops public roots. `TestCertPoolFromPEM_AppendsToSystemPool`
+guards the replace-vs-append contract.
+
+---
+
+## 17. ~~Edge overwrites `AuthenticationReady` with `GatewayReady`~~ — **CLOSED**
+
+**Source:** [PR #121 review](https://github.com/project-koku/koku-service-operator/pull/121#pullrequestreview-5000508819) (stale restatement of D3 / COST-7688 G1).
+
+**Already fixed:** `reconcileEdge` writes `GatewayReady` only.
+`validateOIDC` is the only writer of `AuthenticationReady`.
+`TestReconcileEdge_DoesNotOverwriteOIDCUnreachable` asserts OIDC stays
+`OIDCUnreachable` while Gateway goes True. See
+[COST-7688.md](gap_analysis/COST-7688.md).
+
+---
+
+## 18. ~~Envoy ignores Keycloak `caCertSecretName` (D11)~~ — **CLOSED**
+
+**Source:** [PR #121 review](https://github.com/project-koku/koku-service-operator/pull/121#pullrequestreview-5000508819).
+
+D11 was the *operator* JWKS probe ignoring the CA — closed in #11 / PR #121.
+
+Envoy already mounts `auth.keycloak.tls.caCertSecretName` via
+`CACombineInitContainer` (`/ca-extra` → combined bundle) and uses
+`trusted_ca`. `caCertSecretName` wins over `insecureSkipVerify`. Tests:
+`TestEnvoyDeploymentMountsKeycloakCACert`,
+`TestEnvoyYAMLCASecretWinsOverSkipVerify`. See COST-7688 R2.
+
+**Still open:** Keycloak sync CronJob does not mount that Secret — item #7.

--- a/internal/controller/validation.go
+++ b/internal/controller/validation.go
@@ -199,11 +199,24 @@ func (r *CostManagementServiceConfigReconciler) keycloakCACertPool(ctx context.C
 	if err != nil {
 		return nil, err
 	}
-	caCertPool := x509.NewCertPool()
-	if !caCertPool.AppendCertsFromPEM(caSecret.Data[caCertKey]) {
+	pool, err := certPoolFromPEM(caSecret.Data[caCertKey])
+	if err != nil {
 		return nil, fmt.Errorf("secret %q key %q contains no valid PEM certificates", caName, caCertKey)
 	}
-	return caCertPool, nil
+	return pool, nil
+}
+
+// certPoolFromPEM starts from the system CA pool and appends the given PEM
+// certificates so a custom CA does not drop public roots.
+func certPoolFromPEM(pem []byte) (*x509.CertPool, error) {
+	pool, err := x509.SystemCertPool()
+	if err != nil || pool == nil {
+		pool = x509.NewCertPool()
+	}
+	if !pool.AppendCertsFromPEM(pem) {
+		return nil, fmt.Errorf("PEM data contains no valid certificates")
+	}
+	return pool, nil
 }
 
 // blockingDependencyMessage summarizes why DB/Cache validation blocked reconcile.
@@ -256,8 +269,8 @@ func kafkaTCPProbe(bootstrapServers string, timeout time.Duration) error {
 // with a non-empty keys array (what Envoy needs to validate JWTs).
 // 4xx is an error: 401/403 means the endpoint is misconfigured; 404 means
 // the JWKS URL or realm is wrong. Uses the reconcile context so shutdown
-// cancels an in-flight probe. When caCertPool is non-nil, it is used instead
-// of the system CA pool for TLS verification.
+// cancels an in-flight probe. When caCertPool is non-nil it is installed as
+// RootCAs (callers should include system roots plus any custom CA).
 func jwksProbe(ctx context.Context, rawURL string, insecureSkipVerify bool, caCertPool *x509.CertPool, timeout time.Duration) error {
 	base, ok := http.DefaultTransport.(*http.Transport)
 	if !ok {

--- a/internal/controller/validation_s3.go
+++ b/internal/controller/validation_s3.go
@@ -51,10 +51,10 @@ func (r *CostManagementServiceConfigReconciler) validateObjectStorage(ctx contex
 				"StorageCACertInvalid", err.Error())
 			return
 		}
-		caCertPool = x509.NewCertPool()
-		if !caCertPool.AppendCertsFromPEM(caSecret.Data[caCertKey]) {
+		caCertPool, err = certPoolFromPEM(caSecret.Data[caCertKey])
+		if err != nil {
 			r.setCondition(cfg, costv1alpha1.ConditionStorageReady, metav1.ConditionFalse,
-				"StorageCACertInvalid", fmt.Sprintf("secret %q key ca.crt contains no valid PEM certificates", caName))
+				"StorageCACertInvalid", fmt.Sprintf("secret %q key %q contains no valid PEM certificates", caName, caCertKey))
 			return
 		}
 	}

--- a/internal/controller/validation_test.go
+++ b/internal/controller/validation_test.go
@@ -557,6 +557,39 @@ func TestReconcileValidation_OIDCWithCustomCA(t *testing.T) {
 	})
 }
 
+func TestCertPoolFromPEM_AppendsToSystemPool(t *testing.T) {
+	sys, err := x509.SystemCertPool()
+	if err != nil || sys == nil || sys.Equal(x509.NewCertPool()) {
+		t.Skip("system cert pool unavailable or empty")
+	}
+
+	srv := httptest.NewTLSServer(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {}))
+	t.Cleanup(srv.Close)
+	pemBytes := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: srv.Certificate().Raw})
+
+	pool, err := certPoolFromPEM(pemBytes)
+	if err != nil {
+		t.Fatalf("certPoolFromPEM: %v", err)
+	}
+
+	customOnly := x509.NewCertPool()
+	if !customOnly.AppendCertsFromPEM(pemBytes) {
+		t.Fatal("test CA PEM did not parse")
+	}
+	if pool.Equal(customOnly) {
+		t.Fatal("cert pool replaced the system roots; custom CA should be appended")
+	}
+	if pool.Equal(sys) {
+		t.Fatal("custom CA was not added to the system pool")
+	}
+}
+
+func TestCertPoolFromPEM_RejectsInvalidPEM(t *testing.T) {
+	if _, err := certPoolFromPEM([]byte("not-a-certificate")); err == nil {
+		t.Fatal("expected error for invalid PEM")
+	}
+}
+
 func TestReconcileValidation_DBSecretMissingKeys(t *testing.T) {
 	ln := listenLocalTCP(t)
 	addr := ln.Addr().(*net.TCPAddr)


### PR DESCRIPTION
## Summary
- JWKS and S3 probes now start from `x509.SystemCertPool()` and append the custom CA PEM, so a `caCertSecretName` no longer drops public roots.
- Shared helper `certPoolFromPEM` is covered by tests that fail if the pool is custom-CA-only.
- Recorded PR #121 review follow-ups in `docs/review-follow-ups.md`: closed the RootCAs item (#16), noted Edge/AuthenticationReady as already closed (#17), noted Envoy already uses the Keycloak CA (#18), closed stale S3-to-app-pods item (#9). Remaining Keycloak CA gap is CronJob mount (#7).

## Test plan
- [x] `go test ./internal/controller/ -run 'TestCertPoolFromPEM|TestReconcileValidation_OIDCWithCustomCA|TestReconcileValidation_S3' -count=1`
- [x] `golangci-lint run ./internal/controller/`
- [ ] Confirm CI on this PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Preserve public system CA roots when JWKS and S3 probes append certificates from configured CA Secrets.
- Reuse `certPoolFromPEM` for system and custom CA certificates.
- Add tests for custom certificate appending and invalid PEM input.
- Document PR `#121` follow-ups and the remaining Keycloak sync CronJob CA mount gap.

## Operator impact

- CRD APIs remain compatible.
- JWKS and S3 probes can continue to validate public certificates when `caCertSecretName` is configured.
- Reconciliation continues to report invalid CA data as a validation error with the Secret and key identified.
- No RBAC changes.
- The Keycloak sync CronJob still requires a separate private-CA mount update.

## Validation

- Targeted controller tests were added.
- `golangci-lint` is included in the test plan.
- CI confirmation is pending.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->