### PR TITLE
[COST-8121] fix(pytest): honor verify=False when REQUESTS_CA_BUNDLE is set

### DIFF
--- a/scripts/run-pytest.sh
+++ b/scripts/run-pytest.sh
@@ -79,6 +79,9 @@
 
 set -e
 
+# Homebrew/macOS often exports REQUESTS_CA_BUNDLE, which overrides session.verify=False.
+unset REQUESTS_CA_BUNDLE SSL_CERT_FILE 2>/dev/null || true
+
 # Script configuration
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 PROJECT_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"

--- a/test/pytest/conftest.py
+++ b/test/pytest/conftest.py
@@ -334,6 +334,7 @@ def create_authenticated_session(
     session.headers["Authorization"] = f"Bearer {token.access_token}"
     if content_type:
         session.headers["Content-Type"] = content_type
+    session.trust_env = False
     session.verify = False
     return session
 
@@ -1272,6 +1273,7 @@ def test_csv_data() -> str:
 def http_session() -> requests.Session:
     """Create a requests session with SSL verification disabled."""
     session = requests.Session()
+    session.trust_env = False
     session.verify = False
     return session
 
@@ -1297,6 +1299,7 @@ def authenticated_session(user_jwt_token: JWTToken) -> requests.Session:
     session.headers.update({
         "Authorization": f"Bearer {user_jwt_token.access_token}",
     })
+    session.trust_env = False
     session.verify = False
     return session
 

--- a/test/pytest/suites/auth/conftest.py
+++ b/test/pytest/suites/auth/conftest.py
@@ -66,5 +66,6 @@ def non_admin_user_credentials():
 def http_session() -> requests.Session:
     """Shared requests session with SSL verification disabled."""
     session = requests.Session()
+    session.trust_env = False
     session.verify = False
     return session

--- a/test/pytest/suites/cost_management/conftest.py
+++ b/test/pytest/suites/cost_management/conftest.py
@@ -320,6 +320,7 @@ def cost_validation_data(cluster_config, s3_config, keycloak_config, ingress_url
         
         # Create a session with SSL verification disabled
         session = requests.Session()
+        session.trust_env = False
         session.verify = False
         
         response = upload_with_retry(

--- a/test/pytest/suites/e2e/test_rbac_access.py
+++ b/test/pytest/suites/e2e/test_rbac_access.py
@@ -394,6 +394,7 @@ def rbac_cluster_data(
     # to the same schema succeed. We retry with fresh JWT tokens.
     upload_url = f"{ingress_url}/v1/upload"
     upload_session = requests.Session()
+    upload_session.trust_env = False
     upload_session.verify = False
 
     max_upload_retries = 3


### PR DESCRIPTION
## Jira Ticket

[COST-8121](https://redhat.atlassian.net/browse/COST-8121)

## Summary

- Set `session.trust_env = False` on pytest `requests.Session` fixtures that disable TLS verification (`conftest.py`, auth/cost_management conftests, rbac upload session).
- Unset `REQUESTS_CA_BUNDLE` and `SSL_CERT_FILE` at the start of `run-pytest.sh`.

## Description

On macOS with Homebrew Python, `REQUESTS_CA_BUNDLE` is often exported. With `trust_env=True` (requests default), that env var overrides `session.verify=False`, causing mass `SSLCertVerificationError` against cluster-bot self-signed routes — even though tests intentionally disable verification for lab clusters.

Validated on Cluster Bot MCE (Aug 2026): pass rate went from ~30% to ~83% after this workaround.

## Testing

- [ ] `unset REQUESTS_CA_BUNDLE` + run `pytest suites/auth/test_keycloak.py::TestKeycloakConnectivity::test_keycloak_reachable` against a lab cluster — passes
- [ ] Same test with `REQUESTS_CA_BUNDLE` set — still passes after this change
- [ ] `run-pytest.sh --no-ui` smoke on macOS (or Linux CI — no regression expected)

## Related

- [COST-7697](https://redhat.atlassian.net/browse/COST-7697)
- Cluster-bot pytest runbook: PR #125