### PR TITLE
[COST-8121] fix(pytest): add missing rh_identity_header fixture in interpod suite

### DIFF
--- a/test/pytest/suites/interpod/conftest.py
+++ b/test/pytest/suites/interpod/conftest.py
@@ -115,6 +115,12 @@ def internal_identity_header(cluster_config: ClusterConfig, org_id: str) -> str:
 
 
 @pytest.fixture
+def rh_identity_header(org_id: str) -> str:
+    """Admin X-Rh-Identity header for pod_session (aligned with e2e/sources suites)."""
+    return create_rh_identity_header(org_id)
+
+
+@pytest.fixture
 def pod_session(
     test_runner_pod: str,
     cluster_config: ClusterConfig,


### PR DESCRIPTION
## Jira Ticket

[COST-8121](https://redhat.atlassian.net/browse/COST-8121)

## Summary

- Add `rh_identity_header` fixture to `test/pytest/suites/interpod/conftest.py`.
- Matches the pattern already used in `suites/e2e/conftest.py` and `suites/sources/conftest.py`.

## Description

`pod_session` in the interpod suite depends on `rh_identity_header`, but that fixture was never defined in `suites/interpod/conftest.py`. All four interpod tests failed at setup with:

```
fixture 'rh_identity_header' not found
```

## Testing

- [ ] `pytest test/pytest/suites/interpod/ --collect-only` — no fixture errors
- [ ] Interpod tests pass against a deployed cluster (or skip cleanly if pods unavailable)

## Related

- [COST-7697](https://redhat.atlassian.net/browse/COST-7697)
- Cluster-bot pytest triage (Aug 2026)
- PR #126 (SSL), PR #127 (S4 credentials)