### PR TITLE
Update catalog image tags to use short SHA

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -263,16 +263,19 @@ jobs:
 
       - name: Build and push catalog image
         run: |
+          # Match operator/bundle short-SHA tags (metadata-action {{sha}} default length).
+          SHORT_SHA="${GITHUB_SHA::7}"
+          CATALOG_IMG="quay.io/project-koku/koku-service-operator-catalog:${SHORT_SHA}"
           make catalog-build \
             BUNDLE_IMGS=quay.io/project-koku/koku-service-operator-bundle@${{ steps.bundle-push.outputs.digest }} \
-            CATALOG_IMG=quay.io/project-koku/koku-service-operator-catalog:${{ github.sha }}
-          docker tag \
-            quay.io/project-koku/koku-service-operator-catalog:${{ github.sha }} \
+            CATALOG_IMG="${CATALOG_IMG}"
+          docker tag "${CATALOG_IMG}" \
             quay.io/project-koku/koku-service-operator-catalog:latest
-          docker tag \
-            quay.io/project-koku/koku-service-operator-catalog:${{ github.sha }} \
+          docker tag "${CATALOG_IMG}" \
             quay.io/project-koku/koku-service-operator-catalog:main
-          docker push -a quay.io/project-koku/koku-service-operator-catalog
+          docker push "${CATALOG_IMG}"
+          docker push quay.io/project-koku/koku-service-operator-catalog:latest
+          docker push quay.io/project-koku/koku-service-operator-catalog:main
 
   e2e:
     name: E2E


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Updates the bundle-publish workflow to tag catalog images with the seven-character commit SHA.
- Pushes the short-SHA tag explicitly with `latest` and `main`.
- Removes the previous full-SHA tag and `docker push -a` behavior.

## Operator impact

- No CRD API compatibility changes.
- No reconcile-phase behavior changes.
- No RBAC changes.
- No user-visible status-condition changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->