### PR TITLE
fix(pytest): accept current koku migration job success log line

### DIFF
--- a/test/pytest/suites/infrastructure/test_database.py
+++ b/test/pytest/suites/infrastructure/test_database.py
@@ -7,11 +7,17 @@ Tests for database schema validation and migration status.
 import pytest
 
 from utils import (
+    assert_log_contains,
     exec_in_pod,
     execute_db_query,
     run_oc_command,
     get_job_logs,
     validate_logs,
+)
+
+# Koku migrate job wording varies by image; accept any known success line.
+_MIGRATION_LOG_SUCCESS_PATTERN = (
+    r"(Migrations completed successfully|=== Koku migrations completed ===)"
 )
 
 
@@ -184,11 +190,14 @@ class TestDatabaseMigrations:
         if logs is None:
             pytest.skip("Migration job logs not available (job may have been cleaned up)")
         
+        assert_log_contains(
+            logs,
+            _MIGRATION_LOG_SUCCESS_PATTERN,
+            regex=True,
+            message="Migration job did not log a known success marker",
+        )
         validate_logs(
             logs,
-            must_contain=[
-                "Migrations completed successfully",
-            ],
             must_not_contain=[
                 "Migration failed",
                 "Traceback (most recent call last)",


### PR DESCRIPTION
## Summary

- `test_migration_job_logs_success` failed on cluster-bot because the migrate job logs `=== Koku migrations completed ===` while the test only matched the legacy string `Migrations completed successfully`.
- Accept either success marker via regex; keep `must_not_contain` checks for real failures.

## Context

Follow-up from [COST-8121](https://redhat.atlassian.net/browse/COST-8121) triage (`199P/17F/11S/26E`, `--no-ui`). Job status was already green via `test_migration_job_completed`; this was a brittle log assertion only.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Updated `test_migration_job_logs_success` to accept both current and legacy migration success markers.
- Preserved checks for failure messages and tracebacks.
- Migration job status validation remains covered separately.
- Verified the targeted test on cost-onprem with MCE OCP 4.20.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->