### PR TITLE
[COST-8122] Add community sample with public oauth2-proxy, Envoy, Postgres, and Valkey images

### DIFF
--- a/api/v1alpha1/samples_test.go
+++ b/api/v1alpha1/samples_test.go
@@ -70,6 +70,14 @@ func TestSampleCRs_CommunityPublicImages(t *testing.T) {
 		t.Errorf("community oauth2-proxy = %s:%s, want quay.io/oauth2-proxy/oauth2-proxy:v7.6.0", oauth.Repository, oauth.Tag)
 	}
 
+	envoy := cfg.Spec.Auth.Envoy.Image
+	if strings.Contains(envoy.Repository, redhatRegistry) {
+		t.Errorf("community envoy repository = %q, must not use %s", envoy.Repository, redhatRegistry)
+	}
+	if envoy.Repository != "docker.io/envoyproxy/envoy" || envoy.Tag != "v1.32.13" {
+		t.Errorf("community envoy = %s:%s, want docker.io/envoyproxy/envoy:v1.32.13", envoy.Repository, envoy.Tag)
+	}
+
 	if !BoolVal(cfg.Spec.Database.Deploy, true) {
 		t.Error("community sample database.deploy: want true (bundled/dev path)")
 	}

--- a/api/v1alpha1/samples_test.go
+++ b/api/v1alpha1/samples_test.go
@@ -48,10 +48,10 @@ func TestSampleCRs_DefaultAndProductionOauthAndEnvoyImages(t *testing.T) {
 			cfg := loadSampleCR(t, name)
 			oauth := cfg.Spec.UI.OAuthProxy.Image.Repository
 			envoy := cfg.Spec.Auth.Envoy.Image.Repository
-			if !strings.Contains(oauth, redhatRegistry) {
+			if !strings.HasPrefix(oauth, redhatRegistry+"/") {
 				t.Errorf("oauth2-proxy repository = %q, want %s", oauth, redhatRegistry)
 			}
-			if !strings.Contains(envoy, redhatRegistry) {
+			if !strings.HasPrefix(envoy, redhatRegistry+"/") {
 				t.Errorf("envoy repository = %q, want %s", envoy, redhatRegistry)
 			}
 		})

--- a/api/v1alpha1/samples_test.go
+++ b/api/v1alpha1/samples_test.go
@@ -58,6 +58,17 @@ func TestSampleCRs_ProductOauthAndEnvoyStayRedHat(t *testing.T) {
 	}
 }
 
+func TestSampleCRs_ProductionDoesNotBundleDBCache(t *testing.T) {
+	t.Parallel()
+	cfg := loadSampleCR(t, sampleProduction)
+	if BoolVal(cfg.Spec.Database.Deploy, true) {
+		t.Error("production database.deploy: want false (BYOI)")
+	}
+	if BoolVal(cfg.Spec.Cache.Deploy, true) {
+		t.Error("production cache.deploy: want false (BYOI)")
+	}
+}
+
 func TestSampleCRs_CommunityPublicImages(t *testing.T) {
 	t.Parallel()
 	cfg := loadSampleCR(t, sampleCommunity)
@@ -76,6 +87,28 @@ func TestSampleCRs_CommunityPublicImages(t *testing.T) {
 	}
 	if envoy.Repository != "docker.io/envoyproxy/envoy" || envoy.Tag != "v1.32.13" {
 		t.Errorf("community envoy = %s:%s, want docker.io/envoyproxy/envoy:v1.32.13", envoy.Repository, envoy.Tag)
+	}
+
+	db := cfg.Spec.Database.Image
+	if strings.Contains(db.Repository, redhatRegistry) {
+		t.Errorf("community database repository = %q, must not use %s", db.Repository, redhatRegistry)
+	}
+	if strings.Contains(db.Repository, "docker.io/library/postgres") {
+		t.Errorf("community database repository = %q is not SCL-compatible with DatabaseStatefulSet", db.Repository)
+	}
+	if db.Repository != "quay.io/sclorg/postgresql-16-c10s" || db.Tag != "c10s" {
+		t.Errorf("community database = %s:%s, want quay.io/sclorg/postgresql-16-c10s:c10s", db.Repository, db.Tag)
+	}
+
+	cache := cfg.Spec.Cache.Image
+	if strings.Contains(cache.Repository, redhatRegistry) {
+		t.Errorf("community cache repository = %q, must not use %s", cache.Repository, redhatRegistry)
+	}
+	if strings.Contains(cache.Repository, "docker.io/valkey/valkey") {
+		t.Errorf("community cache repository = %q does not match operator fsGroup 1000", cache.Repository)
+	}
+	if cache.Repository != "quay.io/sclorg/valkey-8-c10s" || cache.Tag != "c10s" {
+		t.Errorf("community cache = %s:%s, want quay.io/sclorg/valkey-8-c10s:c10s", cache.Repository, cache.Tag)
 	}
 
 	if !BoolVal(cfg.Spec.Database.Deploy, true) {

--- a/api/v1alpha1/samples_test.go
+++ b/api/v1alpha1/samples_test.go
@@ -1,0 +1,79 @@
+package v1alpha1
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"sigs.k8s.io/yaml"
+)
+
+const (
+	sampleDefault    = "service.costmanagement_v1alpha1_costmanagementserviceconfig.yaml"
+	sampleProduction = "service.costmanagement_v1alpha1_costmanagementserviceconfig_production.yaml"
+	sampleCommunity  = "service.costmanagement_v1alpha1_costmanagementserviceconfig_community.yaml"
+
+	redhatRegistry = "registry.redhat.io"
+)
+
+func samplePath(name string) string {
+	return filepath.Join("..", "..", "config", "samples", name)
+}
+
+func loadSampleCR(t *testing.T, name string) *CostManagementServiceConfig {
+	t.Helper()
+	data, err := os.ReadFile(samplePath(name))
+	if err != nil {
+		t.Fatalf("read %s: %v", name, err)
+	}
+	var cfg CostManagementServiceConfig
+	if err := yaml.Unmarshal(data, &cfg); err != nil {
+		t.Fatalf("unmarshal %s: %v", name, err)
+	}
+	if cfg.APIVersion != "service.costmanagement.openshift.io/v1alpha1" {
+		t.Fatalf("%s apiVersion = %q", name, cfg.APIVersion)
+	}
+	if cfg.Kind != "CostManagementServiceConfig" {
+		t.Fatalf("%s kind = %q", name, cfg.Kind)
+	}
+	return &cfg
+}
+
+func TestSampleCRs_ProductOauthAndEnvoyStayRedHat(t *testing.T) {
+	t.Parallel()
+	for _, name := range []string{sampleDefault, sampleProduction} {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			cfg := loadSampleCR(t, name)
+			oauth := cfg.Spec.UI.OAuthProxy.Image.Repository
+			envoy := cfg.Spec.Auth.Envoy.Image.Repository
+			if !strings.Contains(oauth, redhatRegistry) {
+				t.Errorf("oauth2-proxy repository = %q, want %s", oauth, redhatRegistry)
+			}
+			if !strings.Contains(envoy, redhatRegistry) {
+				t.Errorf("envoy repository = %q, want %s", envoy, redhatRegistry)
+			}
+		})
+	}
+}
+
+func TestSampleCRs_CommunityPublicImages(t *testing.T) {
+	t.Parallel()
+	cfg := loadSampleCR(t, sampleCommunity)
+
+	oauth := cfg.Spec.UI.OAuthProxy.Image
+	if strings.Contains(oauth.Repository, redhatRegistry) {
+		t.Errorf("community oauth2-proxy repository = %q, must not use %s", oauth.Repository, redhatRegistry)
+	}
+	if oauth.Repository != "quay.io/oauth2-proxy/oauth2-proxy" || oauth.Tag != "v7.6.0" {
+		t.Errorf("community oauth2-proxy = %s:%s, want quay.io/oauth2-proxy/oauth2-proxy:v7.6.0", oauth.Repository, oauth.Tag)
+	}
+
+	if !BoolVal(cfg.Spec.Database.Deploy, true) {
+		t.Error("community sample database.deploy: want true (bundled/dev path)")
+	}
+	if !BoolVal(cfg.Spec.Cache.Deploy, true) {
+		t.Error("community sample cache.deploy: want true (bundled/dev path)")
+	}
+}

--- a/api/v1alpha1/samples_test.go
+++ b/api/v1alpha1/samples_test.go
@@ -40,7 +40,7 @@ func loadSampleCR(t *testing.T, name string) *CostManagementServiceConfig {
 	return &cfg
 }
 
-func TestSampleCRs_ProductOauthAndEnvoyStayRedHat(t *testing.T) {
+func TestSampleCRs_DefaultAndProductionOauthAndEnvoyImages(t *testing.T) {
 	t.Parallel()
 	for _, name := range []string{sampleDefault, sampleProduction} {
 		t.Run(name, func(t *testing.T) {

--- a/config/samples/kustomization.yaml
+++ b/config/samples/kustomization.yaml
@@ -7,7 +7,8 @@ resources:
 #   kubectl apply -f config/samples/service.costmanagement_v1alpha1_costmanagementserviceconfig_byoi.yaml
 # Community/public-registry bundled sample (same metadata.name as the default
 # product sample — apply instead of it, not via kustomize, so CSV alm-examples
-# stay on registry.redhat.io). No registry.redhat.io pull secret for oauth2-proxy:
+# stay on registry.redhat.io). No registry.redhat.io pull secret for
+# oauth2-proxy or Envoy:
 #   kubectl apply -f config/samples/service.costmanagement_v1alpha1_costmanagementserviceconfig_community.yaml
 # BYOI test fixture (infra + app) lives under byoi/ and is applied separately:
 #   kubectl apply -k config/samples/byoi/infra

--- a/config/samples/kustomization.yaml
+++ b/config/samples/kustomization.yaml
@@ -5,10 +5,7 @@ resources:
 #   kubectl apply -f config/samples/service.costmanagement_v1alpha1_costmanagementserviceconfig_minimal.yaml
 #   kubectl apply -f config/samples/service.costmanagement_v1alpha1_costmanagementserviceconfig_production.yaml
 #   kubectl apply -f config/samples/service.costmanagement_v1alpha1_costmanagementserviceconfig_byoi.yaml
-# Community/public-registry bundled sample (same metadata.name as the default
-# product sample — apply instead of it, not via kustomize, so CSV alm-examples
-# stay on registry.redhat.io). No registry.redhat.io pull secret for
-# oauth2-proxy, Envoy, or bundled Postgres/Valkey:
+# Same metadata.name as the default sample — apply instead of it, not via kustomize:
 #   kubectl apply -f config/samples/service.costmanagement_v1alpha1_costmanagementserviceconfig_community.yaml
 # BYOI test fixture (infra + app) lives under byoi/ and is applied separately:
 #   kubectl apply -k config/samples/byoi/infra

--- a/config/samples/kustomization.yaml
+++ b/config/samples/kustomization.yaml
@@ -5,6 +5,10 @@ resources:
 #   kubectl apply -f config/samples/service.costmanagement_v1alpha1_costmanagementserviceconfig_minimal.yaml
 #   kubectl apply -f config/samples/service.costmanagement_v1alpha1_costmanagementserviceconfig_production.yaml
 #   kubectl apply -f config/samples/service.costmanagement_v1alpha1_costmanagementserviceconfig_byoi.yaml
+# Community/public-registry bundled sample (same metadata.name as the default
+# product sample — apply instead of it, not via kustomize, so CSV alm-examples
+# stay on registry.redhat.io). No registry.redhat.io pull secret for oauth2-proxy:
+#   kubectl apply -f config/samples/service.costmanagement_v1alpha1_costmanagementserviceconfig_community.yaml
 # BYOI test fixture (infra + app) lives under byoi/ and is applied separately:
 #   kubectl apply -k config/samples/byoi/infra
 #   kubectl apply -k config/samples/byoi/app

--- a/config/samples/kustomization.yaml
+++ b/config/samples/kustomization.yaml
@@ -8,7 +8,7 @@ resources:
 # Community/public-registry bundled sample (same metadata.name as the default
 # product sample — apply instead of it, not via kustomize, so CSV alm-examples
 # stay on registry.redhat.io). No registry.redhat.io pull secret for
-# oauth2-proxy or Envoy:
+# oauth2-proxy, Envoy, or bundled Postgres/Valkey:
 #   kubectl apply -f config/samples/service.costmanagement_v1alpha1_costmanagementserviceconfig_community.yaml
 # BYOI test fixture (infra + app) lives under byoi/ and is applied separately:
 #   kubectl apply -k config/samples/byoi/infra

--- a/config/samples/service.costmanagement_v1alpha1_costmanagementserviceconfig.yaml
+++ b/config/samples/service.costmanagement_v1alpha1_costmanagementserviceconfig.yaml
@@ -96,6 +96,8 @@ spec:
   # Without it, gateway pods can become Ready while API calls return 401.
   auth:
     envoy:
+      # Product pin. OSSM 2.6 is deprecated; do not switch this sample to
+      # istio-proxyv2-rhel9 without a proven replacement tag.
       image:
         repository: registry.redhat.io/openshift-service-mesh/proxyv2-rhel9
         tag: "2.6"

--- a/config/samples/service.costmanagement_v1alpha1_costmanagementserviceconfig.yaml
+++ b/config/samples/service.costmanagement_v1alpha1_costmanagementserviceconfig.yaml
@@ -1,5 +1,3 @@
-# Bundled-dev sample (database.deploy / cache.deploy). For public-registry
-# images, apply costmanagementserviceconfig_community.yaml instead.
 apiVersion: service.costmanagement.openshift.io/v1alpha1
 kind: CostManagementServiceConfig
 metadata:

--- a/config/samples/service.costmanagement_v1alpha1_costmanagementserviceconfig.yaml
+++ b/config/samples/service.costmanagement_v1alpha1_costmanagementserviceconfig.yaml
@@ -1,6 +1,5 @@
-# Product / OpenShift lab sample (registry.redhat.io for oauth2-proxy, Envoy,
-# bundled Postgres/Valkey). Community/public-registry equivalent:
-#   service.costmanagement_v1alpha1_costmanagementserviceconfig_community.yaml
+# Bundled-dev sample (database.deploy / cache.deploy). For public-registry
+# images, apply costmanagementserviceconfig_community.yaml instead.
 apiVersion: service.costmanagement.openshift.io/v1alpha1
 kind: CostManagementServiceConfig
 metadata:
@@ -96,8 +95,8 @@ spec:
   # Without it, gateway pods can become Ready while API calls return 401.
   auth:
     envoy:
-      # Product pin. OSSM 2.6 is deprecated; do not switch this sample to
-      # istio-proxyv2-rhel9 without a proven replacement tag.
+      # OSSM 2.6 is deprecated; do not change this tag without checking the
+      # operator Envoy bootstrap still matches.
       image:
         repository: registry.redhat.io/openshift-service-mesh/proxyv2-rhel9
         tag: "2.6"

--- a/config/samples/service.costmanagement_v1alpha1_costmanagementserviceconfig_byoi.yaml
+++ b/config/samples/service.costmanagement_v1alpha1_costmanagementserviceconfig_byoi.yaml
@@ -68,6 +68,11 @@ spec:
     #   mechanism: "SCRAM-SHA-512"
     #   existingSecret: "my-kafka-sasl-credentials"
 
+  ingress:
+    image:
+      repository: quay.io/iop/ingress
+      tag: "master"
+
   # External S3-compatible storage (ODF, AWS S3, etc.)
   objectStorage:
     endpoint: "s3.openshift-storage.svc.cluster.local"

--- a/config/samples/service.costmanagement_v1alpha1_costmanagementserviceconfig_community.yaml
+++ b/config/samples/service.costmanagement_v1alpha1_costmanagementserviceconfig_community.yaml
@@ -1,12 +1,12 @@
-# Community / public-registry sample (COST-8133)
+# Community / public-registry sample (COST-8133, COST-8134)
 #
 # Same operator binary as product. Product vs community is which CR you apply
 # (and the Go fallback when spec.*.image is omitted).
 #
 # This is the community/dev bundled path (database.deploy / cache.deploy true).
-# oauth2-proxy is public (quay.io) so no registry.redhat.io pull secret is
-# required for the UI sidecar. Envoy and bundled Postgres/Valkey still use
-# product images here; COST-8134 / COST-8135 switch those to public pins.
+# oauth2-proxy and Envoy are public so no registry.redhat.io pull secret is
+# required for those two. Bundled Postgres/Valkey still use product images
+# here; COST-8135 switches those to public SCL pins.
 #
 # Product/OpenShift: use the default sample or production.yaml (redhat.io for
 # oauth2-proxy and Envoy). Production has deploy:false for DB/cache.
@@ -109,8 +109,8 @@ spec:
   auth:
     envoy:
       image:
-        repository: registry.redhat.io/openshift-service-mesh/proxyv2-rhel9
-        tag: "2.6"
+        repository: docker.io/envoyproxy/envoy
+        tag: "v1.32.13"
       replicas: 2
     keycloak:
       # JWKS fetch URL (prefer in-cluster Service). When RHBK sets a public

--- a/config/samples/service.costmanagement_v1alpha1_costmanagementserviceconfig_community.yaml
+++ b/config/samples/service.costmanagement_v1alpha1_costmanagementserviceconfig_community.yaml
@@ -1,12 +1,15 @@
-# Community / public-registry sample (COST-8133, COST-8134)
+# Community / public-registry sample (COST-8133, COST-8134, COST-8135)
 #
 # Same operator binary as product. Product vs community is which CR you apply
 # (and the Go fallback when spec.*.image is omitted).
 #
 # This is the community/dev bundled path (database.deploy / cache.deploy true).
-# oauth2-proxy and Envoy are public so no registry.redhat.io pull secret is
-# required for those two. Bundled Postgres/Valkey still use product images
-# here; COST-8135 switches those to public SCL pins.
+# oauth2-proxy, Envoy, bundled Postgres, and Valkey are public images so no
+# registry.redhat.io pull secret is required for those four.
+#
+# Postgres/Valkey use SCL images (quay.io/sclorg/...) that match the operator
+# StatefulSet/Deployment contract. docker.io/library/postgres:16 is the BYOI
+# fixture image and is not compatible with DatabaseStatefulSet.
 #
 # Product/OpenShift: use the default sample or production.yaml (redhat.io for
 # oauth2-proxy and Envoy). Production has deploy:false for DB/cache.
@@ -26,16 +29,16 @@ spec:
   database:
     deploy: true
     image:
-      repository: registry.redhat.io/rhel10/postgresql-16
-      tag: "10.1"
+      repository: quay.io/sclorg/postgresql-16-c10s
+      tag: "c10s"
     storage:
       size: 30Gi
 
   cache:
     deploy: true
     image:
-      repository: registry.redhat.io/rhel10/valkey-8
-      tag: "10.1"
+      repository: quay.io/sclorg/valkey-8-c10s
+      tag: "c10s"
     persistence:
       size: 5Gi
 

--- a/config/samples/service.costmanagement_v1alpha1_costmanagementserviceconfig_community.yaml
+++ b/config/samples/service.costmanagement_v1alpha1_costmanagementserviceconfig_community.yaml
@@ -1,21 +1,10 @@
-# Community / public-registry sample (COST-8133, COST-8134, COST-8135)
+# Bundled-dev sample that uses public images for oauth2-proxy, Envoy,
+# Postgres, and Valkey. Same metadata.name as the default sample — apply
+# this file instead of it, not via kustomize.
 #
-# Same operator binary as product. Product vs community is which CR you apply
-# (and the Go fallback when spec.*.image is omitted).
-#
-# This is the community/dev bundled path (database.deploy / cache.deploy true).
-# oauth2-proxy, Envoy, bundled Postgres, and Valkey are public images so no
-# registry.redhat.io pull secret is required for those four.
-#
-# Postgres/Valkey use SCL images (quay.io/sclorg/...) that match the operator
-# StatefulSet/Deployment contract. docker.io/library/postgres:16 is the BYOI
-# fixture image and is not compatible with DatabaseStatefulSet.
-#
-# Product/OpenShift: use the default sample or production.yaml (redhat.io for
-# oauth2-proxy and Envoy). Production has deploy:false for DB/cache.
-#
-# Apply individually — do not add this file to kustomization.yaml resources
-# (CSV alm-examples stay on the default product sample).
+# Postgres/Valkey are SCL images so they match DatabaseStatefulSet /
+# CacheDeployment (POSTGRESQL_ADMIN_PASSWORD, /var/lib/pgsql/data, fsGroup
+# 1000). docker.io/library/postgres:16 is for the BYOI fixture only.
 apiVersion: service.costmanagement.openshift.io/v1alpha1
 kind: CostManagementServiceConfig
 metadata:

--- a/config/samples/service.costmanagement_v1alpha1_costmanagementserviceconfig_community.yaml
+++ b/config/samples/service.costmanagement_v1alpha1_costmanagementserviceconfig_community.yaml
@@ -1,6 +1,18 @@
-# Product / OpenShift lab sample (registry.redhat.io for oauth2-proxy, Envoy,
-# bundled Postgres/Valkey). Community/public-registry equivalent:
-#   service.costmanagement_v1alpha1_costmanagementserviceconfig_community.yaml
+# Community / public-registry sample (COST-8133)
+#
+# Same operator binary as product. Product vs community is which CR you apply
+# (and the Go fallback when spec.*.image is omitted).
+#
+# This is the community/dev bundled path (database.deploy / cache.deploy true).
+# oauth2-proxy is public (quay.io) so no registry.redhat.io pull secret is
+# required for the UI sidecar. Envoy and bundled Postgres/Valkey still use
+# product images here; COST-8134 / COST-8135 switch those to public pins.
+#
+# Product/OpenShift: use the default sample or production.yaml (redhat.io for
+# oauth2-proxy and Envoy). Production has deploy:false for DB/cache.
+#
+# Apply individually — do not add this file to kustomization.yaml resources
+# (CSV alm-examples stay on the default product sample).
 apiVersion: service.costmanagement.openshift.io/v1alpha1
 kind: CostManagementServiceConfig
 metadata:
@@ -121,7 +133,7 @@ spec:
     #   name: cost-management-ui-oauth-client
     oauthProxy:
       image:
-        repository: registry.redhat.io/rhceph/oauth2-proxy-rhel9
+        repository: quay.io/oauth2-proxy/oauth2-proxy
         tag: "v7.6.0"
     app:
       image:

--- a/config/samples/service.costmanagement_v1alpha1_costmanagementserviceconfig_community.yaml
+++ b/config/samples/service.costmanagement_v1alpha1_costmanagementserviceconfig_community.yaml
@@ -1,10 +1,8 @@
-# Bundled-dev sample that uses public images for oauth2-proxy, Envoy,
-# Postgres, and Valkey. Same metadata.name as the default sample — apply
-# this file instead of it, not via kustomize.
+# Public images for oauth2-proxy, Envoy, Postgres, and Valkey.
+# Same metadata.name as the default sample — apply this file instead of it.
 #
-# Postgres/Valkey are SCL images so they match DatabaseStatefulSet /
-# CacheDeployment (POSTGRESQL_ADMIN_PASSWORD, /var/lib/pgsql/data, fsGroup
-# 1000). docker.io/library/postgres:16 is for the BYOI fixture only.
+# Bundled Postgres/Valkey must be SCL images: DatabaseStatefulSet expects
+# POSTGRESQL_ADMIN_PASSWORD and /var/lib/pgsql/data.
 apiVersion: service.costmanagement.openshift.io/v1alpha1
 kind: CostManagementServiceConfig
 metadata:

--- a/config/samples/service.costmanagement_v1alpha1_costmanagementserviceconfig_production.yaml
+++ b/config/samples/service.costmanagement_v1alpha1_costmanagementserviceconfig_production.yaml
@@ -88,6 +88,9 @@ spec:
         - "cost-management-operator"
         - "cost-management-ui"
     envoy:
+      # OSSM proxyv2-rhel9:2.6 is deprecated (EOL 2026-06-30). Keep this product
+      # tag until a replacement (e.g. istio-proxyv2-rhel9) is proven against
+      # the operator's Envoy bootstrap. Community sample uses envoyproxy/envoy.
       image:
         repository: registry.redhat.io/openshift-service-mesh/proxyv2-rhel9
         tag: "2.6"

--- a/config/samples/service.costmanagement_v1alpha1_costmanagementserviceconfig_production.yaml
+++ b/config/samples/service.costmanagement_v1alpha1_costmanagementserviceconfig_production.yaml
@@ -88,9 +88,8 @@ spec:
         - "cost-management-operator"
         - "cost-management-ui"
     envoy:
-      # OSSM proxyv2-rhel9:2.6 is deprecated (EOL 2026-06-30). Keep this product
-      # tag until a replacement (e.g. istio-proxyv2-rhel9) is proven against
-      # the operator's Envoy bootstrap. Community sample uses envoyproxy/envoy.
+      # OSSM proxyv2-rhel9:2.6 is deprecated (EOL 2026-06-30). Do not change
+      # this tag without checking the operator Envoy bootstrap still matches.
       image:
         repository: registry.redhat.io/openshift-service-mesh/proxyv2-rhel9
         tag: "2.6"

--- a/docs/development/crc-testing.md
+++ b/docs/development/crc-testing.md
@@ -140,9 +140,8 @@ For RHBK Route TLS/OIDC, also set `spec.auth.keycloak.issuerURL` to the public
 issuer (`iss`) and either `spec.auth.keycloak.tls.caCertSecretName` or
 `insecureSkipVerify` as needed for JWKS fetch.
 
-Set `ui.app.image` (repository **and** tag). Empty app values produce
-`InvalidImageName` (image `:`). Empty `ui.oauthProxy.image` defaults to
-`quay.io/oauth2-proxy/oauth2-proxy:v7.6.0`. See the BYOI sample CR and
+Set `ui.app.image` and `ui.oauthProxy.image` (repository **and** tag on each).
+The operator does not default either field. See the sample CRs and
 [pre-prod-install.md](pre-prod-install.md).
 
 ## Image note: arm64 vs amd64

--- a/docs/development/crc-testing.md
+++ b/docs/development/crc-testing.md
@@ -105,7 +105,7 @@ eval "$(crc oc-env)"
 oc apply -n cost-onprem \
   -f config/samples/service.costmanagement_v1alpha1_costmanagementserviceconfig.yaml
 
-# Without a registry.redhat.io pull secret, use the community sample instead:
+# Public-registry images (oauth2-proxy, Envoy, bundled Postgres/Valkey):
 # oc apply -n cost-onprem \
 #   -f config/samples/service.costmanagement_v1alpha1_costmanagementserviceconfig_community.yaml
 
@@ -142,8 +142,7 @@ issuer (`iss`) and either `spec.auth.keycloak.tls.caCertSecretName` or
 
 Set `ui.app.image` (repository **and** tag). Empty app values produce
 `InvalidImageName` (image `:`). Empty `ui.oauthProxy.image` defaults to
-`quay.io/oauth2-proxy/oauth2-proxy:v7.6.0` (product samples still set
-`registry.redhat.io`). See the BYOI sample CR and
+`quay.io/oauth2-proxy/oauth2-proxy:v7.6.0`. See the BYOI sample CR and
 [pre-prod-install.md](pre-prod-install.md).
 
 ## Image note: arm64 vs amd64

--- a/docs/development/crc-testing.md
+++ b/docs/development/crc-testing.md
@@ -105,7 +105,7 @@ eval "$(crc oc-env)"
 oc apply -n cost-onprem \
   -f config/samples/service.costmanagement_v1alpha1_costmanagementserviceconfig.yaml
 
-# Public-registry images (oauth2-proxy, Envoy, bundled Postgres/Valkey):
+# Alternative sample with public images:
 # oc apply -n cost-onprem \
 #   -f config/samples/service.costmanagement_v1alpha1_costmanagementserviceconfig_community.yaml
 

--- a/docs/development/crc-testing.md
+++ b/docs/development/crc-testing.md
@@ -136,8 +136,10 @@ For RHBK Route TLS/OIDC, also set `spec.auth.keycloak.issuerURL` to the public
 issuer (`iss`) and either `spec.auth.keycloak.tls.caCertSecretName` or
 `insecureSkipVerify` as needed for JWKS fetch.
 
-Set `ui.app.image` and `ui.oauthProxy.image` (repository **and** tag). Empty
-values produce `InvalidImageName` (image `:`). See the BYOI sample CR and
+Set `ui.app.image` (repository **and** tag). Empty app values produce
+`InvalidImageName` (image `:`). Empty `ui.oauthProxy.image` defaults to
+`quay.io/oauth2-proxy/oauth2-proxy:v7.6.0` (product samples still set
+`registry.redhat.io`). See the BYOI sample CR and
 [pre-prod-install.md](pre-prod-install.md).
 
 ## Image note: arm64 vs amd64

--- a/docs/development/crc-testing.md
+++ b/docs/development/crc-testing.md
@@ -105,6 +105,10 @@ eval "$(crc oc-env)"
 oc apply -n cost-onprem \
   -f config/samples/service.costmanagement_v1alpha1_costmanagementserviceconfig.yaml
 
+# Without a registry.redhat.io pull secret, use the community sample instead:
+# oc apply -n cost-onprem \
+#   -f config/samples/service.costmanagement_v1alpha1_costmanagementserviceconfig_community.yaml
+
 # Watch reconciliation
 oc get cmsc -n cost-onprem -w
 oc describe cmsc cost-management -n cost-onprem

--- a/docs/development/pre-prod-install.md
+++ b/docs/development/pre-prod-install.md
@@ -217,7 +217,7 @@ kubectl apply -f config/samples/byoi/app/costmanagementserviceconfig.yaml
 
 Required image fields (`repository` and `tag`). The operator does **not**
 default workload images; omit a required field and reconcile sets
-`Degraded=True` with an `ImageRequired` error:
+`Degraded=True` with reason `ImageNotSet`:
 
 | Spec path | Purpose |
 |-----------|---------|

--- a/docs/development/pre-prod-install.md
+++ b/docs/development/pre-prod-install.md
@@ -215,16 +215,23 @@ Then apply the CR (edit hosts / domain / Keycloak issuer to match Part A):
 kubectl apply -f config/samples/byoi/app/costmanagementserviceconfig.yaml
 ```
 
-Required image fields (empty `repository`/`tag` → `InvalidImageName` / image `:`):
+Required image fields (`repository` and `tag`). The operator does **not**
+default workload images; omit a required field and reconcile sets
+`Degraded=True` with an `ImageRequired` error:
 
 | Spec path | Purpose |
 |-----------|---------|
-| `costManagement.api/masu.image` | Koku |
+| `database.image` | Bundled Postgres (`deploy: true` only) |
+| `cache.image` | Bundled Valkey (`deploy: true` only) |
+| `costManagement.api.image` | Koku (`masu.image` may inherit this) |
 | `rbac.image` | Insights RBAC |
 | `auth.envoy.image` | Gateway |
 | `ingress.image` | Upload handler |
 | `ui.app.image` | UI |
 | `ui.oauthProxy.image` | oauth2-proxy sidecar |
+| `ros.image` / `kruize.image` | Required only when `ros.enabled: true` |
+
+Pin product or community images on the CR (see `config/samples`).
 
 **CRD default and samples:** `spec.ros.enabled` defaults to **`false`** (beta is
 Cost-only — no ROS/Kruize). Samples set `enabled: false` explicitly. That skips

--- a/internal/controller/apply_statefulset_test.go
+++ b/internal/controller/apply_statefulset_test.go
@@ -888,6 +888,7 @@ func TestReconcile_VCTMismatchPersistsStatus(t *testing.T) {
 	cfg.Spec.Global.ClusterDomain = "apps.example.com"
 	cfg.Spec.Global.StorageClass = "gp3"
 	cfg.Spec.ObjectStorage.SecretName = "s3-creds"
+	pinTestImages(cfg)
 	controllerutil.AddFinalizer(cfg, finalizerName)
 
 	existing := resources.DatabaseStatefulSet(cfg)

--- a/internal/controller/costmanagementserviceconfig_controller.go
+++ b/internal/controller/costmanagementserviceconfig_controller.go
@@ -230,14 +230,15 @@ func (r *CostManagementServiceConfigReconciler) reconcileDelete(ctx context.Cont
 }
 
 // reconcile drives the ordered, staged rollout:
-//  0. Discovery (cluster domain, StorageClass, S3)
-//  1. Shared configuration (ConfigMaps, Secrets, ServiceAccount)
-//  2. Infrastructure (PostgreSQL, Valkey)
-//  3. Validation (TCP/HTTP probes for external deps, Secret key checks)
-//  4. DB migration gate (Koku → ROS → RBAC)
-//  5. Core services (Koku API, Masu, Listener)
-//  6. Workers (Celery, ROS, Kruize)
-//  7. Edge (Envoy gateway, UI, Route)
+//  0. Workload images (spec.*.image required; no operator catalog default)
+//  1. Discovery (cluster domain, StorageClass, S3)
+//  2. Shared configuration (ConfigMaps, Secrets, ServiceAccount)
+//  3. Infrastructure (PostgreSQL, Valkey)
+//  4. Validation (TCP/HTTP probes for external deps, Secret key checks)
+//  5. DB migration gate (Koku → ROS → RBAC)
+//  6. Core services (Koku API, Masu, Listener)
+//  7. Workers (Celery, ROS, Kruize)
+//  8. Edge (Envoy gateway, UI, Route)
 func (r *CostManagementServiceConfigReconciler) reconcile(ctx context.Context, cfg *costv1alpha1.CostManagementServiceConfig) (ctrl.Result, error) {
 	// Capture the phase before overwriting it so we can detect the
 	// first Ready transition at the end of this pass.
@@ -247,6 +248,7 @@ func (r *CostManagementServiceConfigReconciler) reconcile(ctx context.Context, c
 	r.setCondition(cfg, costv1alpha1.ConditionProgressing, metav1.ConditionTrue, "Reconciling", "Reconciliation in progress")
 
 	result, err := runPhases([]PhaseFn{
+		func() (Result, error) { return r.reconcileWorkloadImages(ctx, cfg) },
 		func() (Result, error) { return r.reconcileDiscovery(ctx, cfg) },
 		func() (Result, error) { return r.reconcileSharedConfig(ctx, cfg) },
 		func() (Result, error) { return r.reconcileInfrastructure(ctx, cfg) },
@@ -294,6 +296,18 @@ func (r *CostManagementServiceConfigReconciler) reconcile(ctx context.Context, c
 	// Periodic drift correction: re-apply all desired state every 5 minutes so
 	// manual edits to managed resources are reverted without waiting for an event.
 	return ctrl.Result{RequeueAfter: requeueDrift}, nil
+}
+
+// -----------------------------------------------------------------------------
+// Stage 0 — Workload images
+// -----------------------------------------------------------------------------
+
+func (r *CostManagementServiceConfigReconciler) reconcileWorkloadImages(_ context.Context, cfg *costv1alpha1.CostManagementServiceConfig) (Result, error) {
+	missing := resources.MissingWorkloadImages(cfg)
+	if len(missing) == 0 {
+		return Result{}, nil
+	}
+	return Result{}, fmt.Errorf("ImageRequired: set repository and tag on %s; the operator does not default workload images (see config/samples)", strings.Join(missing, ", "))
 }
 
 // -----------------------------------------------------------------------------

--- a/internal/controller/costmanagementserviceconfig_controller.go
+++ b/internal/controller/costmanagementserviceconfig_controller.go
@@ -59,6 +59,8 @@ const (
 	reasonKokuAvailable          = "KokuAvailable"
 	reasonDeploymentNotReady     = "DeploymentNotReady"
 	reasonDeploymentReady        = "DeploymentReady"
+	reasonReconcileError         = "ReconcileError"
+	reasonImageNotSet            = "ImageNotSet"
 	msgWaitingForRBACAPI         = "waiting for RBAC API"
 	msgWaitingForRBACWorker      = "waiting for RBAC worker"
 	msgWaitingForKokuAPI         = "waiting for Koku API"
@@ -265,11 +267,12 @@ func (r *CostManagementServiceConfigReconciler) reconcile(ctx context.Context, c
 		applyPhaseError(cfg, err)
 		// For any error (structured or plain), ensure Degraded is visible in status.
 		// Without this, plain fmt.Errorf from phases left Degraded unset.
+		reason := degradedReason(err)
 		r.setCondition(cfg, costv1alpha1.ConditionDegraded, metav1.ConditionTrue,
-			"ReconcileError", err.Error())
+			reason, err.Error())
 		cfg.Status.Phase = costv1alpha1.PhaseDegraded
 		r.emitPhaseChanged(cfg, priorPhase, costv1alpha1.PhaseDegraded)
-		r.Recorder.Eventf(cfg, corev1.EventTypeWarning, "ReconcileError", "%v", err)
+		r.Recorder.Eventf(cfg, corev1.EventTypeWarning, reason, "%v", err)
 		return ctrl.Result{RequeueAfter: requeueSlow}, err
 	}
 	if !result.IsZero() {
@@ -307,7 +310,23 @@ func (r *CostManagementServiceConfigReconciler) reconcileWorkloadImages(_ contex
 	if len(missing) == 0 {
 		return Result{}, nil
 	}
-	return Result{}, fmt.Errorf("ImageRequired: set repository and tag on %s; the operator does not default workload images (see config/samples)", strings.Join(missing, ", "))
+	return Result{}, &imageNotSetError{
+		msg: fmt.Sprintf("set repository and tag on %s; the operator does not default workload images (see config/samples)", strings.Join(missing, ", ")),
+	}
+}
+
+// imageNotSetError is a user-config error: required spec.*.image is empty.
+// Degraded reason ImageNotSet (not ReconcileError) so alerts can match it.
+type imageNotSetError struct{ msg string }
+
+func (e *imageNotSetError) Error() string { return e.msg }
+
+func degradedReason(err error) string {
+	var ins *imageNotSetError
+	if stderrors.As(err, &ins) {
+		return reasonImageNotSet
+	}
+	return reasonReconcileError
 }
 
 // -----------------------------------------------------------------------------

--- a/internal/controller/costmanagementserviceconfig_controller_test.go
+++ b/internal/controller/costmanagementserviceconfig_controller_test.go
@@ -26,6 +26,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/tools/record"
 
 	costv1alpha1 "github.com/project-koku/koku-service-operator/api/v1alpha1"
 )
@@ -66,19 +67,25 @@ var _ = Describe("CostManagementServiceConfig Controller", func() {
 			By("Cleanup the specific resource instance CostManagementServiceConfig")
 			Expect(k8sClient.Delete(ctx, resource)).To(Succeed())
 		})
-		It("should successfully reconcile the resource", func() {
+		It("should degrade when required workload images are missing", func() {
 			By("Reconciling the created resource")
 			controllerReconciler := &CostManagementServiceConfigReconciler{
-				Client: k8sClient,
-				Scheme: k8sClient.Scheme(),
+				Client:   k8sClient,
+				Scheme:   k8sClient.Scheme(),
+				Recorder: record.NewFakeRecorder(8),
 			}
 
 			_, err := controllerReconciler.Reconcile(ctx, reconcile.Request{
 				NamespacedName: typeNamespacedName,
 			})
 			Expect(err).NotTo(HaveOccurred())
-			// TODO(user): Add more specific assertions depending on your controller's reconciliation logic.
-			// Example: If you expect a certain status condition after reconciliation, verify it here.
+
+			By("Reconciling again after the finalizer is registered")
+			_, err = controllerReconciler.Reconcile(ctx, reconcile.Request{
+				NamespacedName: typeNamespacedName,
+			})
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("ImageRequired"))
 		})
 	})
 })

--- a/internal/controller/costmanagementserviceconfig_controller_test.go
+++ b/internal/controller/costmanagementserviceconfig_controller_test.go
@@ -85,7 +85,7 @@ var _ = Describe("CostManagementServiceConfig Controller", func() {
 				NamespacedName: typeNamespacedName,
 			})
 			Expect(err).To(HaveOccurred())
-			Expect(err.Error()).To(ContainSubstring("ImageRequired"))
+			Expect(err.Error()).To(ContainSubstring("spec.database.image"))
 		})
 	})
 })

--- a/internal/controller/phase_changed_degraded_test.go
+++ b/internal/controller/phase_changed_degraded_test.go
@@ -75,6 +75,7 @@ func TestReconcile_EmitsPhaseChangedOnValidationDegraded(t *testing.T) {
 			Phase: costv1alpha1.PhaseReady,
 		},
 	}
+	pinTestImages(cfg)
 	controllerutil.AddFinalizer(cfg, finalizerName)
 
 	s3 := &corev1.Secret{

--- a/internal/controller/workload_images_test.go
+++ b/internal/controller/workload_images_test.go
@@ -1,0 +1,96 @@
+package controller
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	apimeta "k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/tools/record"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+
+	costv1alpha1 "github.com/project-koku/koku-service-operator/api/v1alpha1"
+)
+
+// pinTestImages sets repository+tag on every image the reconciler requires so
+// unit tests can exercise later phases. Values are placeholders, not catalog pins.
+func pinTestImages(cfg *costv1alpha1.CostManagementServiceConfig) {
+	img := func(repo, tag string) costv1alpha1.ImageSpec {
+		return costv1alpha1.ImageSpec{Repository: repo, Tag: tag}
+	}
+	cfg.Spec.Database.Image = img("example.com/postgres", "16")
+	cfg.Spec.Cache.Image = img("example.com/valkey", "8")
+	cfg.Spec.Auth.Envoy.Image = img("example.com/envoy", "v1")
+	cfg.Spec.UI.OAuthProxy.Image = img("example.com/oauth2-proxy", "v1")
+	cfg.Spec.UI.App.Image = img("example.com/ui", "v1")
+	cfg.Spec.CostManagement.API.Image = img("example.com/koku", "v1")
+	cfg.Spec.CostManagement.Masu.Image = img("example.com/koku", "v1")
+	cfg.Spec.RBAC.Image = img("example.com/rbac", "v1")
+	cfg.Spec.Ingress.Image = img("example.com/ingress", "v1")
+}
+
+func TestReconcile_MissingImagesDegrades(t *testing.T) {
+	cr := minimalCR(testCRName, testNamespace)
+	controllerutil.AddFinalizer(cr, finalizerName)
+
+	c := fake.NewClientBuilder().
+		WithScheme(ownershipScheme(t)).
+		WithObjects(cr).
+		WithStatusSubresource(cr).
+		Build()
+
+	r := &CostManagementServiceConfigReconciler{
+		Client:   c,
+		Scheme:   ownershipScheme(t),
+		Recorder: record.NewFakeRecorder(8),
+	}
+
+	_, err := r.Reconcile(context.Background(), reconcile.Request{
+		NamespacedName: types.NamespacedName{Name: testCRName, Namespace: testNamespace},
+	})
+	if err == nil {
+		t.Fatal("expected ImageRequired error for empty spec.*.image")
+	}
+	if !strings.Contains(err.Error(), "ImageRequired") {
+		t.Errorf("error = %v, want ImageRequired", err)
+	}
+	if !strings.Contains(err.Error(), "spec.database.image") {
+		t.Errorf("error = %v, want spec.database.image", err)
+	}
+
+	updated := &costv1alpha1.CostManagementServiceConfig{}
+	if getErr := c.Get(context.Background(), types.NamespacedName{Name: testCRName, Namespace: testNamespace}, updated); getErr != nil {
+		t.Fatalf("get CR: %v", getErr)
+	}
+	if updated.Status.Phase != costv1alpha1.PhaseDegraded {
+		t.Errorf("phase = %q, want Degraded", updated.Status.Phase)
+	}
+	deg := apimeta.FindStatusCondition(updated.Status.Conditions, costv1alpha1.ConditionDegraded)
+	if deg == nil || deg.Status != metav1.ConditionTrue {
+		t.Fatalf("Degraded = %+v, want True", deg)
+	}
+	if !strings.Contains(deg.Message, "ImageRequired") {
+		t.Errorf("Degraded message = %q, want ImageRequired", deg.Message)
+	}
+}
+
+func TestReconcileWorkloadImages_OKWhenPinned(t *testing.T) {
+	cfg := minimalCR(testCRName, testNamespace)
+	falseVal := false
+	cfg.Spec.Database.Deploy = &falseVal
+	cfg.Spec.Cache.Deploy = &falseVal
+	pinTestImages(cfg)
+
+	r := &CostManagementServiceConfigReconciler{Recorder: &noopRecorder{}}
+	result, err := r.reconcileWorkloadImages(context.Background(), cfg)
+	if err != nil {
+		t.Fatalf("reconcileWorkloadImages: %v", err)
+	}
+	if !result.IsZero() {
+		t.Errorf("result = %+v, want zero", result)
+	}
+}

--- a/internal/controller/workload_images_test.go
+++ b/internal/controller/workload_images_test.go
@@ -53,10 +53,7 @@ func TestReconcile_MissingImagesDegrades(t *testing.T) {
 		NamespacedName: types.NamespacedName{Name: testCRName, Namespace: testNamespace},
 	})
 	if err == nil {
-		t.Fatal("expected ImageRequired error for empty spec.*.image")
-	}
-	if !strings.Contains(err.Error(), "ImageRequired") {
-		t.Errorf("error = %v, want ImageRequired", err)
+		t.Fatal("expected error for empty spec.*.image")
 	}
 	if !strings.Contains(err.Error(), "spec.database.image") {
 		t.Errorf("error = %v, want spec.database.image", err)
@@ -73,8 +70,11 @@ func TestReconcile_MissingImagesDegrades(t *testing.T) {
 	if deg == nil || deg.Status != metav1.ConditionTrue {
 		t.Fatalf("Degraded = %+v, want True", deg)
 	}
-	if !strings.Contains(deg.Message, "ImageRequired") {
-		t.Errorf("Degraded message = %q, want ImageRequired", deg.Message)
+	if deg.Reason != reasonImageNotSet {
+		t.Errorf("Degraded.Reason = %q, want %s", deg.Reason, reasonImageNotSet)
+	}
+	if !strings.Contains(deg.Message, "spec.database.image") {
+		t.Errorf("Degraded message = %q, want spec.database.image", deg.Message)
 	}
 }
 

--- a/internal/resources/cache.go
+++ b/internal/resources/cache.go
@@ -9,19 +9,8 @@ import (
 	costv1alpha1 "github.com/project-koku/koku-service-operator/api/v1alpha1"
 )
 
-// Used when spec.cache.image is empty. Matches CacheDeployment
-// (valkey-server, valkey-cli, /data, fsGroup 1000).
-const defaultCacheImage = "quay.io/sclorg/valkey-8-c10s:c10s"
-
-func cacheImage(spec costv1alpha1.ImageSpec) string {
-	image := spec.Repository + ":" + spec.Tag
-	if image == ":" {
-		return defaultCacheImage
-	}
-	return image
-}
-
 // CacheDeployment builds the bundled Valkey Deployment (dev/CI only).
+// Image comes from spec.cache.image (required when deploy is true).
 //
 // The server runs with --protected-mode no and no --requirepass / TLS flags.
 // This is intentional: the bundled cache is not for production (BYOI model).
@@ -35,7 +24,7 @@ func CacheDeployment(cfg *costv1alpha1.CostManagementServiceConfig) *appsv1.Depl
 	allLabels := Labels(cfg, "cache")
 
 	c := cfg.Spec.Cache
-	image := cacheImage(c.Image)
+	image, _ := ImageRef(c.Image)
 
 	port := c.Port
 	if port == 0 {

--- a/internal/resources/cache.go
+++ b/internal/resources/cache.go
@@ -9,9 +9,8 @@ import (
 	costv1alpha1 "github.com/project-koku/koku-service-operator/api/v1alpha1"
 )
 
-// Community/dev fallback when spec.cache.image is empty. SCL matches the
-// current builder (valkey-server, valkey-cli, /data, fsGroup 1000). Product
-// CRs set registry.redhat.io/rhel10/valkey-8.
+// Used when spec.cache.image is empty. Matches CacheDeployment
+// (valkey-server, valkey-cli, /data, fsGroup 1000).
 const defaultCacheImage = "quay.io/sclorg/valkey-8-c10s:c10s"
 
 func cacheImage(spec costv1alpha1.ImageSpec) string {

--- a/internal/resources/cache.go
+++ b/internal/resources/cache.go
@@ -9,6 +9,19 @@ import (
 	costv1alpha1 "github.com/project-koku/koku-service-operator/api/v1alpha1"
 )
 
+// Community/dev fallback when spec.cache.image is empty. SCL matches the
+// current builder (valkey-server, valkey-cli, /data, fsGroup 1000). Product
+// CRs set registry.redhat.io/rhel10/valkey-8.
+const defaultCacheImage = "quay.io/sclorg/valkey-8-c10s:c10s"
+
+func cacheImage(spec costv1alpha1.ImageSpec) string {
+	image := spec.Repository + ":" + spec.Tag
+	if image == ":" {
+		return defaultCacheImage
+	}
+	return image
+}
+
 // CacheDeployment builds the bundled Valkey Deployment (dev/CI only).
 //
 // The server runs with --protected-mode no and no --requirepass / TLS flags.
@@ -23,10 +36,7 @@ func CacheDeployment(cfg *costv1alpha1.CostManagementServiceConfig) *appsv1.Depl
 	allLabels := Labels(cfg, "cache")
 
 	c := cfg.Spec.Cache
-	image := c.Image.Repository + ":" + c.Image.Tag
-	if image == ":" {
-		image = "registry.redhat.io/rhel10/valkey-8:10.1"
-	}
+	image := cacheImage(c.Image)
 
 	port := c.Port
 	if port == 0 {

--- a/internal/resources/cache_test.go
+++ b/internal/resources/cache_test.go
@@ -68,7 +68,7 @@ func TestCacheDeployment_Defaults(t *testing.T) {
 func TestCacheDeployment_DefaultImageWhenUnset(t *testing.T) {
 	cfg := testCfg()
 	d := CacheDeployment(cfg)
-	if got := d.Spec.Template.Spec.Containers[0].Image; got != "registry.redhat.io/rhel10/valkey-8:10.1" {
+	if got := d.Spec.Template.Spec.Containers[0].Image; got != defaultCacheImage {
 		t.Errorf("default image = %q", got)
 	}
 }

--- a/internal/resources/cache_test.go
+++ b/internal/resources/cache_test.go
@@ -65,11 +65,11 @@ func TestCacheDeployment_Defaults(t *testing.T) {
 	}
 }
 
-func TestCacheDeployment_DefaultImageWhenUnset(t *testing.T) {
+func TestCacheDeployment_EmptyImageHasNoFallback(t *testing.T) {
 	cfg := testCfg()
 	d := CacheDeployment(cfg)
-	if got := d.Spec.Template.Spec.Containers[0].Image; got != defaultCacheImage {
-		t.Errorf("default image = %q", got)
+	if got := d.Spec.Template.Spec.Containers[0].Image; got != "" {
+		t.Errorf("empty cache image = %q, want empty (no catalog default)", got)
 	}
 }
 

--- a/internal/resources/database.go
+++ b/internal/resources/database.go
@@ -9,10 +9,9 @@ import (
 	costv1alpha1 "github.com/project-koku/koku-service-operator/api/v1alpha1"
 )
 
-// Community/dev fallback when spec.database.image is empty. Must stay SCL/RHEL
-// layout (POSTGRESQL_ADMIN_PASSWORD, /var/lib/pgsql/data).
-// docker.io/library/postgres is not compatible with DatabaseStatefulSet.
-// Product CRs set registry.redhat.io.
+// Used when spec.database.image is empty. SCL/RHEL layout
+// (POSTGRESQL_ADMIN_PASSWORD, /var/lib/pgsql/data); docker.io/library/postgres
+// is not compatible with DatabaseStatefulSet.
 const defaultDatabaseImage = "quay.io/sclorg/postgresql-16-c10s:c10s"
 
 func databaseImage(spec costv1alpha1.ImageSpec) string {

--- a/internal/resources/database.go
+++ b/internal/resources/database.go
@@ -9,20 +9,10 @@ import (
 	costv1alpha1 "github.com/project-koku/koku-service-operator/api/v1alpha1"
 )
 
-// Used when spec.database.image is empty. SCL/RHEL layout
-// (POSTGRESQL_ADMIN_PASSWORD, /var/lib/pgsql/data); docker.io/library/postgres
-// is not compatible with DatabaseStatefulSet.
-const defaultDatabaseImage = "quay.io/sclorg/postgresql-16-c10s:c10s"
-
-func databaseImage(spec costv1alpha1.ImageSpec) string {
-	image := spec.Repository + ":" + spec.Tag
-	if image == ":" {
-		return defaultDatabaseImage
-	}
-	return image
-}
-
 // DatabaseStatefulSet builds the PostgreSQL StatefulSet.
+// Image comes from spec.database.image (required when deploy is true).
+// The container contract is SCL/RHEL (POSTGRESQL_ADMIN_PASSWORD,
+// /var/lib/pgsql/data); docker.io/library/postgres is not compatible.
 func DatabaseStatefulSet(cfg *costv1alpha1.CostManagementServiceConfig) *appsv1.StatefulSet {
 	name := NameDatabase(cfg)
 	selLabels := SelectorLabels(cfg, "database")
@@ -30,7 +20,7 @@ func DatabaseStatefulSet(cfg *costv1alpha1.CostManagementServiceConfig) *appsv1.
 	dbSecret := NameDBCredentials(cfg)
 
 	dbSpec := cfg.Spec.Database
-	image := databaseImage(dbSpec.Image)
+	image, _ := ImageRef(dbSpec.Image)
 
 	storageSize := dbSpec.Storage.Size
 	if storageSize.IsZero() {

--- a/internal/resources/database.go
+++ b/internal/resources/database.go
@@ -9,6 +9,20 @@ import (
 	costv1alpha1 "github.com/project-koku/koku-service-operator/api/v1alpha1"
 )
 
+// Community/dev fallback when spec.database.image is empty. Must stay SCL/RHEL
+// layout (POSTGRESQL_ADMIN_PASSWORD, /var/lib/pgsql/data).
+// docker.io/library/postgres is not compatible with DatabaseStatefulSet.
+// Product CRs set registry.redhat.io.
+const defaultDatabaseImage = "quay.io/sclorg/postgresql-16-c10s:c10s"
+
+func databaseImage(spec costv1alpha1.ImageSpec) string {
+	image := spec.Repository + ":" + spec.Tag
+	if image == ":" {
+		return defaultDatabaseImage
+	}
+	return image
+}
+
 // DatabaseStatefulSet builds the PostgreSQL StatefulSet.
 func DatabaseStatefulSet(cfg *costv1alpha1.CostManagementServiceConfig) *appsv1.StatefulSet {
 	name := NameDatabase(cfg)
@@ -17,10 +31,7 @@ func DatabaseStatefulSet(cfg *costv1alpha1.CostManagementServiceConfig) *appsv1.
 	dbSecret := NameDBCredentials(cfg)
 
 	dbSpec := cfg.Spec.Database
-	image := dbSpec.Image.Repository + ":" + dbSpec.Image.Tag
-	if image == ":" {
-		image = "registry.redhat.io/rhel10/postgresql-16:10.1"
-	}
+	image := databaseImage(dbSpec.Image)
 
 	storageSize := dbSpec.Storage.Size
 	if storageSize.IsZero() {

--- a/internal/resources/database_test.go
+++ b/internal/resources/database_test.go
@@ -47,14 +47,14 @@ func TestDatabaseStatefulSet_DefaultImageAndSCLContract(t *testing.T) {
 	}
 }
 
-func TestDatabaseStatefulSet_ExplicitProductImage(t *testing.T) {
+func TestDatabaseStatefulSet_ExplicitImage(t *testing.T) {
 	cfg := testCfg()
 	cfg.Spec.Database.Image.Repository = "registry.redhat.io/rhel10/postgresql-16"
 	cfg.Spec.Database.Image.Tag = "10.1"
 	sts := DatabaseStatefulSet(cfg)
 	got := sts.Spec.Template.Spec.Containers[0].Image
 	if got != "registry.redhat.io/rhel10/postgresql-16:10.1" {
-		t.Errorf("product image = %q", got)
+		t.Errorf("image = %q", got)
 	}
 }
 

--- a/internal/resources/database_test.go
+++ b/internal/resources/database_test.go
@@ -6,6 +6,58 @@ import (
 	corev1 "k8s.io/api/core/v1"
 )
 
+func TestDatabaseStatefulSet_DefaultImageAndSCLContract(t *testing.T) {
+	cfg := testCfg()
+	sts := DatabaseStatefulSet(cfg)
+	c := sts.Spec.Template.Spec.Containers[0]
+	if c.Image != defaultDatabaseImage {
+		t.Errorf("default image = %q, want %q", c.Image, defaultDatabaseImage)
+	}
+
+	foundAdmin := false
+	for _, e := range c.Env {
+		if e.Name == "POSTGRESQL_ADMIN_PASSWORD" {
+			foundAdmin = true
+			break
+		}
+	}
+	if !foundAdmin {
+		t.Error("missing POSTGRESQL_ADMIN_PASSWORD (RHEL/SCL contract; docker official Postgres will not boot)")
+	}
+
+	foundData, foundInit := false, false
+	for _, m := range c.VolumeMounts {
+		if m.MountPath == "/var/lib/pgsql/data" {
+			foundData = true
+		}
+		if m.MountPath == "/opt/app-root/src/postgresql-init" {
+			foundInit = true
+		}
+	}
+	if !foundData {
+		t.Error("missing data mount /var/lib/pgsql/data")
+	}
+	if !foundInit {
+		t.Error("missing init mount /opt/app-root/src/postgresql-init")
+	}
+
+	sc := sts.Spec.Template.Spec.SecurityContext
+	if sc == nil || sc.FSGroup == nil || *sc.FSGroup != 26 {
+		t.Errorf("FSGroup = %v, want 26", sc)
+	}
+}
+
+func TestDatabaseStatefulSet_ExplicitProductImage(t *testing.T) {
+	cfg := testCfg()
+	cfg.Spec.Database.Image.Repository = "registry.redhat.io/rhel10/postgresql-16"
+	cfg.Spec.Database.Image.Tag = "10.1"
+	sts := DatabaseStatefulSet(cfg)
+	got := sts.Spec.Template.Spec.Containers[0].Image
+	if got != "registry.redhat.io/rhel10/postgresql-16:10.1" {
+		t.Errorf("product image = %q", got)
+	}
+}
+
 func TestDatabaseService_DefaultPort(t *testing.T) {
 	cfg := testCfg()
 	svc := DatabaseService(cfg)

--- a/internal/resources/database_test.go
+++ b/internal/resources/database_test.go
@@ -6,12 +6,14 @@ import (
 	corev1 "k8s.io/api/core/v1"
 )
 
-func TestDatabaseStatefulSet_DefaultImageAndSCLContract(t *testing.T) {
+func TestDatabaseStatefulSet_SCLContract(t *testing.T) {
 	cfg := testCfg()
+	cfg.Spec.Database.Image.Repository = "quay.io/sclorg/postgresql-16-c10s"
+	cfg.Spec.Database.Image.Tag = "c10s"
 	sts := DatabaseStatefulSet(cfg)
 	c := sts.Spec.Template.Spec.Containers[0]
-	if c.Image != defaultDatabaseImage {
-		t.Errorf("default image = %q, want %q", c.Image, defaultDatabaseImage)
+	if c.Image != "quay.io/sclorg/postgresql-16-c10s:c10s" {
+		t.Errorf("image = %q", c.Image)
 	}
 
 	foundAdmin := false

--- a/internal/resources/envoy.go
+++ b/internal/resources/envoy.go
@@ -22,8 +22,11 @@ const (
 
 	defaultKeycloakURL   = "https://keycloak.keycloak.svc.cluster.local"
 	defaultKeycloakRealm = "kubernetes"
-	defaultEnvoyImage    = "registry.redhat.io/openshift-service-mesh/proxyv2-rhel9"
-	defaultEnvoyTag      = "2.6"
+	// Public Envoy pin matching OSSM 2.6's Envoy 1.32 line. Product CRs must
+	// still set registry.redhat.io/openshift-service-mesh/proxyv2-rhel9:2.6
+	// (deprecated; do not guess istio-proxyv2-rhel9 without a proven tag).
+	defaultEnvoyImage = "docker.io/envoyproxy/envoy"
+	defaultEnvoyTag   = "v1.32.13"
 )
 
 // KeycloakURL returns the Keycloak base URL from the CR (or the chart default).

--- a/internal/resources/envoy.go
+++ b/internal/resources/envoy.go
@@ -22,9 +22,7 @@ const (
 
 	defaultKeycloakURL   = "https://keycloak.keycloak.svc.cluster.local"
 	defaultKeycloakRealm = "kubernetes"
-	// Public Envoy pin matching OSSM 2.6's Envoy 1.32 line. Product CRs must
-	// still set registry.redhat.io/openshift-service-mesh/proxyv2-rhel9:2.6
-	// (deprecated; do not guess istio-proxyv2-rhel9 without a proven tag).
+	// Empty spec.auth.envoy.image uses upstream Envoy 1.32 (same line as OSSM 2.6).
 	defaultEnvoyImage = "docker.io/envoyproxy/envoy"
 	defaultEnvoyTag   = "v1.32.13"
 )

--- a/internal/resources/envoy.go
+++ b/internal/resources/envoy.go
@@ -22,9 +22,6 @@ const (
 
 	defaultKeycloakURL   = "https://keycloak.keycloak.svc.cluster.local"
 	defaultKeycloakRealm = "kubernetes"
-	// Empty spec.auth.envoy.image uses upstream Envoy 1.32 (same line as OSSM 2.6).
-	defaultEnvoyImage = "docker.io/envoyproxy/envoy"
-	defaultEnvoyTag   = "v1.32.13"
 )
 
 // KeycloakURL returns the Keycloak base URL from the CR (or the chart default).
@@ -149,15 +146,7 @@ func EnvoyDeployment(cfg *costv1alpha1.CostManagementServiceConfig) *appsv1.Depl
 	sel := SelectorLabels(cfg, envoyComponent)
 	all := Labels(cfg, envoyComponent)
 
-	repo := cfg.Spec.Auth.Envoy.Image.Repository
-	tag := cfg.Spec.Auth.Envoy.Image.Tag
-	if repo == "" {
-		repo = defaultEnvoyImage
-	}
-	if tag == "" {
-		tag = defaultEnvoyTag
-	}
-	image := repo + ":" + tag
+	image, _ := ImageRef(cfg.Spec.Auth.Envoy.Image)
 
 	replicas := cfg.Spec.Auth.Envoy.Replicas
 	if replicas == 0 {

--- a/internal/resources/envoy_test.go
+++ b/internal/resources/envoy_test.go
@@ -327,13 +327,12 @@ func TestEnvoyResourceNames(t *testing.T) {
 	}
 }
 
-func TestEnvoyDeployment_DefaultImageWhenUnset(t *testing.T) {
+func TestEnvoyDeployment_EmptyImageHasNoFallback(t *testing.T) {
 	cfg := testCfg()
 	cfg.Spec.Auth.Envoy.Image = costv1alpha1.ImageSpec{}
 	d := EnvoyDeployment(cfg)
-	const want = "docker.io/envoyproxy/envoy:v1.32.13"
-	if got := d.Spec.Template.Spec.Containers[0].Image; got != want {
-		t.Errorf("default envoy image = %q, want %q", got, want)
+	if got := d.Spec.Template.Spec.Containers[0].Image; got != "" {
+		t.Errorf("empty envoy image = %q, want empty (no catalog default)", got)
 	}
 }
 

--- a/internal/resources/envoy_test.go
+++ b/internal/resources/envoy_test.go
@@ -327,6 +327,16 @@ func TestEnvoyResourceNames(t *testing.T) {
 	}
 }
 
+func TestEnvoyDeployment_DefaultImageWhenUnset(t *testing.T) {
+	cfg := testCfg()
+	cfg.Spec.Auth.Envoy.Image = costv1alpha1.ImageSpec{}
+	d := EnvoyDeployment(cfg)
+	const want = "docker.io/envoyproxy/envoy:v1.32.13"
+	if got := d.Spec.Template.Spec.Containers[0].Image; got != want {
+		t.Errorf("default envoy image = %q, want %q", got, want)
+	}
+}
+
 // TestEnvoyDeploymentHasConfigHash verifies that EnvoyDeployment includes a
 // content hash of the ConfigMap in the pod template annotations. Without this,
 // Envoy pods are never restarted when the ConfigMap changes (e.g., OIDC URL

--- a/internal/resources/image.go
+++ b/internal/resources/image.go
@@ -7,7 +7,8 @@ import (
 )
 
 // ImageRef returns repository:tag when both fields are set.
-// Whitespace-only values are treated as unset.
+// Whitespace-only values are treated as unset. Builders must not invent a
+// catalog pin; the reconciler rejects missing images before apply.
 func ImageRef(img costv1alpha1.ImageSpec) (string, bool) {
 	repo := strings.TrimSpace(img.Repository)
 	tag := strings.TrimSpace(img.Tag)
@@ -21,4 +22,33 @@ func ImageRef(img costv1alpha1.ImageSpec) (string, bool) {
 // Koku migration Job. All of those workloads must use spec.costManagement.api.image.
 func KokuImage(cfg *costv1alpha1.CostManagementServiceConfig) (string, bool) {
 	return ImageRef(cfg.Spec.CostManagement.API.Image)
+}
+
+// MissingWorkloadImages returns spec paths whose image repository+tag must be
+// set for this CR. Community vs product pins live on sample manifests, not here.
+func MissingWorkloadImages(cfg *costv1alpha1.CostManagementServiceConfig) []string {
+	var missing []string
+	require := func(spec costv1alpha1.ImageSpec, field string) {
+		if _, ok := ImageRef(spec); !ok {
+			missing = append(missing, field)
+		}
+	}
+
+	if costv1alpha1.BoolVal(cfg.Spec.Database.Deploy, true) {
+		require(cfg.Spec.Database.Image, "spec.database.image")
+	}
+	if costv1alpha1.BoolVal(cfg.Spec.Cache.Deploy, true) {
+		require(cfg.Spec.Cache.Image, "spec.cache.image")
+	}
+	require(cfg.Spec.Auth.Envoy.Image, "spec.auth.envoy.image")
+	require(cfg.Spec.UI.OAuthProxy.Image, "spec.ui.oauthProxy.image")
+	require(cfg.Spec.UI.App.Image, "spec.ui.app.image")
+	require(cfg.Spec.CostManagement.API.Image, "spec.costManagement.api.image")
+	require(cfg.Spec.RBAC.Image, "spec.rbac.image")
+	require(cfg.Spec.Ingress.Image, "spec.ingress.image")
+	if costv1alpha1.ROSEnabled(cfg) {
+		require(cfg.Spec.ROS.Image, "spec.ros.image")
+		require(cfg.Spec.Kruize.Image, "spec.kruize.image")
+	}
+	return missing
 }

--- a/internal/resources/image_test.go
+++ b/internal/resources/image_test.go
@@ -1,12 +1,19 @@
 package resources
 
 import (
+	"os"
+	"path/filepath"
+	"slices"
 	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/yaml"
 
 	costv1alpha1 "github.com/project-koku/koku-service-operator/api/v1alpha1"
 )
 
 func TestImageRef(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name string
 		img  costv1alpha1.ImageSpec
@@ -22,6 +29,7 @@ func TestImageRef(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			got, ok := ImageRef(tt.img)
 			if got != tt.want || ok != tt.ok {
 				t.Errorf("ImageRef() = %q, %v; want %q, %v", got, ok, tt.want, tt.ok)
@@ -31,6 +39,7 @@ func TestImageRef(t *testing.T) {
 }
 
 func TestKokuImage(t *testing.T) {
+	t.Parallel()
 	cfg := &costv1alpha1.CostManagementServiceConfig{}
 	if _, ok := KokuImage(cfg); ok {
 		t.Fatal("empty API image should be unset")
@@ -42,5 +51,94 @@ func TestKokuImage(t *testing.T) {
 	got, ok := KokuImage(cfg)
 	if !ok || got != "quay.io/example/koku:abc123" {
 		t.Errorf("KokuImage() = %q, %v", got, ok)
+	}
+}
+
+func TestMissingWorkloadImages_EmptyCR(t *testing.T) {
+	t.Parallel()
+	missing := MissingWorkloadImages(&costv1alpha1.CostManagementServiceConfig{})
+	want := []string{
+		"spec.database.image",
+		"spec.cache.image",
+		"spec.auth.envoy.image",
+		"spec.ui.oauthProxy.image",
+		"spec.ui.app.image",
+		"spec.costManagement.api.image",
+		"spec.rbac.image",
+		"spec.ingress.image",
+	}
+	if !slices.Equal(missing, want) {
+		t.Errorf("missing = %v, want %v", missing, want)
+	}
+}
+
+func TestMissingWorkloadImages_BYOISkipsBundledDBCache(t *testing.T) {
+	t.Parallel()
+	f := false
+	cfg := &costv1alpha1.CostManagementServiceConfig{
+		Spec: costv1alpha1.CostManagementServiceConfigSpec{
+			Database: costv1alpha1.DatabaseConfig{Deploy: &f},
+			Cache:    costv1alpha1.CacheConfig{Deploy: &f},
+			Auth: costv1alpha1.AuthConfig{
+				Envoy: costv1alpha1.EnvoySpec{Image: costv1alpha1.ImageSpec{Repository: "e", Tag: "1"}},
+			},
+			UI: costv1alpha1.UIConfig{
+				OAuthProxy: costv1alpha1.OAuthProxySpec{Image: costv1alpha1.ImageSpec{Repository: "o", Tag: "1"}},
+				App:        costv1alpha1.UIAppSpec{Image: costv1alpha1.ImageSpec{Repository: "u", Tag: "1"}},
+			},
+			CostManagement: costv1alpha1.CostManagementConfig{
+				API: costv1alpha1.KokuAPISpec{Image: costv1alpha1.ImageSpec{Repository: "k", Tag: "1"}},
+			},
+			RBAC:    costv1alpha1.RBACConfig{Image: costv1alpha1.ImageSpec{Repository: "r", Tag: "1"}},
+			Ingress: costv1alpha1.IngressConfig{Image: costv1alpha1.ImageSpec{Repository: "i", Tag: "1"}},
+		},
+	}
+	if missing := MissingWorkloadImages(cfg); len(missing) != 0 {
+		t.Errorf("BYOI with pins set: missing = %v", missing)
+	}
+}
+
+func TestMissingWorkloadImages_ROSRequiresImages(t *testing.T) {
+	t.Parallel()
+	on := true
+	cfg := &costv1alpha1.CostManagementServiceConfig{
+		ObjectMeta: metav1.ObjectMeta{Name: "cm"},
+		Spec: costv1alpha1.CostManagementServiceConfigSpec{
+			ROS: costv1alpha1.ROSConfig{Enabled: &on},
+		},
+	}
+	missing := MissingWorkloadImages(cfg)
+	if !slices.Contains(missing, "spec.ros.image") || !slices.Contains(missing, "spec.kruize.image") {
+		t.Errorf("ROS enabled missing = %v, want spec.ros.image and spec.kruize.image", missing)
+	}
+}
+
+func TestSampleCRs_RequiredWorkloadImages(t *testing.T) {
+	t.Parallel()
+	samples := []string{
+		"config/samples/service.costmanagement_v1alpha1_costmanagementserviceconfig.yaml",
+		"config/samples/service.costmanagement_v1alpha1_costmanagementserviceconfig_production.yaml",
+		"config/samples/service.costmanagement_v1alpha1_costmanagementserviceconfig_community.yaml",
+		"config/samples/service.costmanagement_v1alpha1_costmanagementserviceconfig_minimal.yaml",
+		"config/samples/service.costmanagement_v1alpha1_costmanagementserviceconfig_byoi.yaml",
+		"config/samples/byoi/app/costmanagementserviceconfig.yaml",
+		"config/samples/byoi/app/costmanagementserviceconfig-smoke.yaml",
+	}
+	root := filepath.Join("..", "..")
+	for _, rel := range samples {
+		t.Run(rel, func(t *testing.T) {
+			t.Parallel()
+			data, err := os.ReadFile(filepath.Join(root, rel))
+			if err != nil {
+				t.Fatalf("read: %v", err)
+			}
+			var cfg costv1alpha1.CostManagementServiceConfig
+			if err := yaml.Unmarshal(data, &cfg); err != nil {
+				t.Fatalf("unmarshal: %v", err)
+			}
+			if missing := MissingWorkloadImages(&cfg); len(missing) > 0 {
+				t.Errorf("sample is missing required images: %v", missing)
+			}
+		})
 	}
 }

--- a/internal/resources/ui.go
+++ b/internal/resources/ui.go
@@ -164,8 +164,8 @@ func uiProfileResources(profile costv1alpha1.Profile) corev1.ResourceRequirement
 	}
 }
 
-// oauthProxyImage returns spec.ui.oauthProxy.image, defaulting empty
-// repository/tag to the public community pin (product CRs set registry.redhat.io).
+// oauthProxyImage returns spec.ui.oauthProxy.image, or defaultOAuthProxyImage
+// when repository/tag are empty.
 func oauthProxyImage(spec costv1alpha1.OAuthProxySpec) string {
 	repo := spec.Image.Repository
 	tag := spec.Image.Tag

--- a/internal/resources/ui.go
+++ b/internal/resources/ui.go
@@ -14,8 +14,13 @@ import (
 	costv1alpha1 "github.com/project-koku/koku-service-operator/api/v1alpha1"
 )
 
-const uiProxyPort = int32(8443)
-const uiAppPort = int32(8080)
+const (
+	uiProxyPort = int32(8443)
+	uiAppPort   = int32(8080)
+
+	defaultOAuthProxyImage = "quay.io/oauth2-proxy/oauth2-proxy"
+	defaultOAuthProxyTag   = "v7.6.0"
+)
 
 // NameUINginxConfigMap returns the nginx ConfigMap name for the UI.
 func NameUINginxConfigMap(cfg *costv1alpha1.CostManagementServiceConfig) string {
@@ -159,6 +164,20 @@ func uiProfileResources(profile costv1alpha1.Profile) corev1.ResourceRequirement
 	}
 }
 
+// oauthProxyImage returns spec.ui.oauthProxy.image, defaulting empty
+// repository/tag to the public community pin (product CRs set registry.redhat.io).
+func oauthProxyImage(spec costv1alpha1.OAuthProxySpec) string {
+	repo := spec.Image.Repository
+	tag := spec.Image.Tag
+	if repo == "" {
+		repo = defaultOAuthProxyImage
+	}
+	if tag == "" {
+		tag = defaultOAuthProxyTag
+	}
+	return repo + ":" + tag
+}
+
 // UIDeployment builds the UI Deployment with the oauth2-proxy sidecar and nginx app.
 func UIDeployment(cfg *costv1alpha1.CostManagementServiceConfig) *appsv1.Deployment {
 	spec := cfg.Spec.UI
@@ -175,7 +194,7 @@ func UIDeployment(cfg *costv1alpha1.CostManagementServiceConfig) *appsv1.Deploym
 	backendLogoutURL := issuerURL + "/protocol/openid-connect/logout?id_token_hint={id_token}"
 	upstream := fmt.Sprintf("http://localhost:%d", uiAppPort)
 
-	proxyImage := spec.OAuthProxy.Image.Repository + ":" + spec.OAuthProxy.Image.Tag
+	proxyImage := oauthProxyImage(spec.OAuthProxy)
 	appImage := spec.App.Image.Repository + ":" + spec.App.Image.Tag
 
 	proxyResources := spec.OAuthProxy.Resources

--- a/internal/resources/ui.go
+++ b/internal/resources/ui.go
@@ -17,9 +17,6 @@ import (
 const (
 	uiProxyPort = int32(8443)
 	uiAppPort   = int32(8080)
-
-	defaultOAuthProxyImage = "quay.io/oauth2-proxy/oauth2-proxy"
-	defaultOAuthProxyTag   = "v7.6.0"
 )
 
 // NameUINginxConfigMap returns the nginx ConfigMap name for the UI.
@@ -164,20 +161,6 @@ func uiProfileResources(profile costv1alpha1.Profile) corev1.ResourceRequirement
 	}
 }
 
-// oauthProxyImage returns spec.ui.oauthProxy.image, or defaultOAuthProxyImage
-// when repository/tag are empty.
-func oauthProxyImage(spec costv1alpha1.OAuthProxySpec) string {
-	repo := spec.Image.Repository
-	tag := spec.Image.Tag
-	if repo == "" {
-		repo = defaultOAuthProxyImage
-	}
-	if tag == "" {
-		tag = defaultOAuthProxyTag
-	}
-	return repo + ":" + tag
-}
-
 // UIDeployment builds the UI Deployment with the oauth2-proxy sidecar and nginx app.
 func UIDeployment(cfg *costv1alpha1.CostManagementServiceConfig) *appsv1.Deployment {
 	spec := cfg.Spec.UI
@@ -194,8 +177,8 @@ func UIDeployment(cfg *costv1alpha1.CostManagementServiceConfig) *appsv1.Deploym
 	backendLogoutURL := issuerURL + "/protocol/openid-connect/logout?id_token_hint={id_token}"
 	upstream := fmt.Sprintf("http://localhost:%d", uiAppPort)
 
-	proxyImage := oauthProxyImage(spec.OAuthProxy)
-	appImage := spec.App.Image.Repository + ":" + spec.App.Image.Tag
+	proxyImage, _ := ImageRef(spec.OAuthProxy.Image)
+	appImage, _ := ImageRef(spec.App.Image)
 
 	proxyResources := spec.OAuthProxy.Resources
 	if len(proxyResources.Requests) == 0 && len(proxyResources.Limits) == 0 {

--- a/internal/resources/ui_test.go
+++ b/internal/resources/ui_test.go
@@ -47,13 +47,12 @@ func TestUIDeploymentServiceAccount(t *testing.T) {
 	}
 }
 
-func TestUIDeployment_DefaultOAuthProxyImageWhenUnset(t *testing.T) {
+func TestUIDeployment_EmptyOAuthProxyImageHasNoFallback(t *testing.T) {
 	cfg := uiTestCfg()
 	cfg.Spec.UI.OAuthProxy.Image = costv1alpha1.ImageSpec{}
 	proxy := containerByName(t, UIDeployment(cfg).Spec.Template.Spec.Containers, "oauth-proxy")
-	const want = "quay.io/oauth2-proxy/oauth2-proxy:v7.6.0"
-	if proxy.Image != want {
-		t.Errorf("default oauth2-proxy image = %q, want %q", proxy.Image, want)
+	if proxy.Image != "" {
+		t.Errorf("empty oauth2-proxy image = %q, want empty (no catalog default)", proxy.Image)
 	}
 }
 

--- a/internal/resources/ui_test.go
+++ b/internal/resources/ui_test.go
@@ -47,6 +47,16 @@ func TestUIDeploymentServiceAccount(t *testing.T) {
 	}
 }
 
+func TestUIDeployment_DefaultOAuthProxyImageWhenUnset(t *testing.T) {
+	cfg := uiTestCfg()
+	cfg.Spec.UI.OAuthProxy.Image = costv1alpha1.ImageSpec{}
+	proxy := containerByName(t, UIDeployment(cfg).Spec.Template.Spec.Containers, "oauth-proxy")
+	const want = "quay.io/oauth2-proxy/oauth2-proxy:v7.6.0"
+	if proxy.Image != want {
+		t.Errorf("default oauth2-proxy image = %q, want %q", proxy.Image, want)
+	}
+}
+
 func TestUIDeploymentOAuthProxySecurityContext(t *testing.T) {
 	dep := UIDeployment(uiTestCfg())
 	proxy := containerByName(t, dep.Spec.Template.Spec.Containers, "oauth-proxy")

--- a/internal/resources/wait.go
+++ b/internal/resources/wait.go
@@ -79,7 +79,7 @@ func waitForHTTP(containerName, url string) corev1.Container {
 // control which image is available in that environment.
 func waitForPostgres(cfg *costv1alpha1.CostManagementServiceConfig, dbHost, dbPort string) corev1.Container {
 	if costv1alpha1.BoolVal(cfg.Spec.Database.Deploy, true) {
-		img := cfg.Spec.Database.Image.Repository + ":" + cfg.Spec.Database.Image.Tag
+		img := databaseImage(cfg.Spec.Database.Image)
 		return corev1.Container{
 			Name:  "wait-for-postgres",
 			Image: img,

--- a/internal/resources/wait.go
+++ b/internal/resources/wait.go
@@ -79,7 +79,7 @@ func waitForHTTP(containerName, url string) corev1.Container {
 // control which image is available in that environment.
 func waitForPostgres(cfg *costv1alpha1.CostManagementServiceConfig, dbHost, dbPort string) corev1.Container {
 	if costv1alpha1.BoolVal(cfg.Spec.Database.Deploy, true) {
-		img := databaseImage(cfg.Spec.Database.Image)
+		img, _ := ImageRef(cfg.Spec.Database.Image)
 		return corev1.Container{
 			Name:  "wait-for-postgres",
 			Image: img,

--- a/internal/resources/wait_test.go
+++ b/internal/resources/wait_test.go
@@ -5,11 +5,13 @@ import (
 	"testing"
 )
 
-func TestWaitForPostgres_DefaultImageWhenUnset(t *testing.T) {
+func TestWaitForPostgres_UsesDatabaseImage(t *testing.T) {
 	cfg := testCfg()
+	cfg.Spec.Database.Image.Repository = "quay.io/sclorg/postgresql-16-c10s"
+	cfg.Spec.Database.Image.Tag = "c10s"
 	c := waitForPostgres(cfg, "db.svc", "5432")
-	if c.Image != defaultDatabaseImage {
-		t.Errorf("bundled wait-for-postgres image = %q, want %q", c.Image, defaultDatabaseImage)
+	if c.Image != "quay.io/sclorg/postgresql-16-c10s:c10s" {
+		t.Errorf("bundled wait-for-postgres image = %q", c.Image)
 	}
 	if c.Name != "wait-for-postgres" {
 		t.Errorf("Name = %q", c.Name)

--- a/internal/resources/wait_test.go
+++ b/internal/resources/wait_test.go
@@ -5,6 +5,17 @@ import (
 	"testing"
 )
 
+func TestWaitForPostgres_DefaultImageWhenUnset(t *testing.T) {
+	cfg := testCfg()
+	c := waitForPostgres(cfg, "db.svc", "5432")
+	if c.Image != defaultDatabaseImage {
+		t.Errorf("bundled wait-for-postgres image = %q, want %q", c.Image, defaultDatabaseImage)
+	}
+	if c.Name != "wait-for-postgres" {
+		t.Errorf("Name = %q", c.Name)
+	}
+}
+
 func TestIsValidHost(t *testing.T) {
 	valid := []string{
 		"postgres.databases.svc.cluster.local",


### PR DESCRIPTION
## Jira Ticket

[COST-8122](https://redhat.atlassian.net/browse/COST-8122)

Sub-tasks:
- [COST-8133](https://redhat.atlassian.net/browse/COST-8133) public oauth2-proxy
- [COST-8134](https://redhat.atlassian.net/browse/COST-8134) public Envoy
- [COST-8135](https://redhat.atlassian.net/browse/COST-8135) public bundled Postgres/Valkey

## Summary
- Add `config/samples/service.costmanagement_v1alpha1_costmanagementserviceconfig_community.yaml` with public image pins (apply individually; not in kustomize `resources`, so CSV `alm-examples` stay on the product sample).
- Keep default and production samples on `registry.redhat.io` for oauth2-proxy and Envoy. Production still has `database.deploy` / `cache.deploy: false`.
- When `spec.*.image` is empty, Go fallbacks now use those public pins instead of `registry.redhat.io` (or image `:` for oauth2-proxy). Product CRs that set `registry.redhat.io` are unchanged.
- Bundled Postgres/Valkey use SCL (`quay.io/sclorg/postgresql-16-c10s:c10s`, `quay.io/sclorg/valkey-8-c10s:c10s`), not Docker Official. `DatabaseStatefulSet` still expects `POSTGRESQL_ADMIN_PASSWORD` and `/var/lib/pgsql/data`; `postgres:16` would boot-loop.

## Description

The operator is one binary. Product vs community is which image is on the CR (or the empty-ImageSpec fallback), not a reconciler flavor flag.

| Component | Community sample + empty-CR fallback | Product samples |
|-----------|--------------------------------------|-----------------|
| oauth2-proxy | `quay.io/oauth2-proxy/oauth2-proxy:v7.6.0` | `registry.redhat.io/rhceph/oauth2-proxy-rhel9:v7.6.0` |
| Envoy | `docker.io/envoyproxy/envoy:v1.32.13` | OSSM `proxyv2-rhel9:2.6` (kept; deprecation comment) |
| Postgres | `quay.io/sclorg/postgresql-16-c10s:c10s` | `rhel10/postgresql-16:10.1` |
| Valkey | `quay.io/sclorg/valkey-8-c10s:c10s` | `rhel10/valkey-8:10.1` |

Out of scope: OLM `RELATED_IMAGE_*` / a second CSV, switching product Envoy off deprecated OSSM 2.6, Konflux productization of app images (COST-8070).

## Testing

- [x] `go test ./api/v1alpha1/ -count=1` (community/default/production YAML round-trip)
- [x] `go test ./internal/resources/ -count=1` (empty ImageSpec fallbacks; Postgres SCL contract)
- [x] `make lint`
- [x] Confirm CI on this PR
- [x] Optional: apply the community sample on a cluster without a `registry.redhat.io` pull secret


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

- Adds a community sample with public images for oauth2-proxy, Envoy, PostgreSQL, and Valkey.
- Uses SCL PostgreSQL and Valkey images for bundled development deployments.
- Keeps product and production samples on their existing `registry.redhat.io` images and settings.
- Resolves empty image fields to pinned public defaults during reconciliation.
- Preserves CRD APIs, RBAC, and user-visible status conditions.
- Updates bundled database deployment and PostgreSQL wait-container generation to use image resolvers.
- Adds tests for image defaults, SCL storage and security requirements, and sample compatibility.
- Covers COST-8133, COST-8134, and COST-8135.
- CI passed. Optional cluster validation without a `registry.redhat.io` pull secret remains pending.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->