### PR TITLE
[COST-8136] fix(pytest): skip ROS tests when ros.enabled is false (COST-8136)

### DIFF
--- a/docs/development/clusterbot-operator-pytest.md
+++ b/docs/development/clusterbot-operator-pytest.md
@@ -359,6 +359,11 @@ of unrelated bugs:
 | **E2E pipeline** | manifest/masu timeout after upload | Cluster-bot processing slow or backlog |
 | **infra migration log** | missing string `Migrations completed successfully` | Brittle log assertion vs current koku wording |
 | **tagging skips** | no tags in DB | Expected without full ingestion |
+| **ROS recommendations API** | 404 on `/recommendations/openshift` | Expected when `spec.ros.enabled: false` (beta default). Pytest skips `suites/ros/` and E2E `test_09` when ROS is off — not product failures |
+
+**ROS API coverage:** Beta cluster-bot runs use `ros.enabled: false` on the CMSC
+sample. Recommendations API tests require `spec.ros.enabled: true` plus ROS/Kruize
+images and reconciliation — out of G0 beta scope.
 
 ## Optional — UI login (`Phase=Ready`)
 

--- a/test/pytest/conftest.py
+++ b/test/pytest/conftest.py
@@ -21,6 +21,7 @@ import requests
 import urllib3
 
 
+from ros_feature import detect_ros_enabled, ROS_DISABLED_SKIP_REASON
 from utils import (
     check_pod_exists,
     exec_in_pod,
@@ -169,6 +170,23 @@ def cluster_config() -> ClusterConfig:
         keycloak_namespace=os.environ.get("KEYCLOAK_NAMESPACE", "keycloak"),
         platform=os.environ.get("PLATFORM", "openshift"),
     )
+
+
+@pytest.fixture(scope="session")
+def ros_enabled(cluster_config: ClusterConfig) -> bool:
+    """Whether ROS/Kruize are enabled for the target stack (CMSC spec or workload)."""
+    return detect_ros_enabled(
+        namespace=cluster_config.namespace,
+        cr_name=cluster_config.helm_release_name,
+        helm_release_name=cluster_config.helm_release_name,
+    )
+
+
+@pytest.fixture(scope="session")
+def require_ros_enabled(ros_enabled: bool) -> None:
+    """Skip the test when ROS is disabled (Cost-only beta default)."""
+    if not ros_enabled:
+        pytest.skip(ROS_DISABLED_SKIP_REASON)
 
 
 @pytest.fixture(scope="session")

--- a/test/pytest/ros_feature.py
+++ b/test/pytest/ros_feature.py
@@ -68,6 +68,10 @@ def detect_ros_enabled(
 ) -> bool:
     """Detect ROS enablement from CMSC spec/condition or ros-api workload."""
     env_override = os.environ.get("ROS_ENABLED")
+    env_enabled = parse_ros_enabled_env(env_override)
+    if env_enabled is not None:
+        return env_enabled
+
     cmsc_name = os.environ.get("CMSC_NAME", cr_name or helm_release_name)
 
     cmsc_found = False

--- a/test/pytest/ros_feature.py
+++ b/test/pytest/ros_feature.py
@@ -1,0 +1,121 @@
+"""Detect whether ROS/Kruize are enabled for pytest skip logic."""
+
+import os
+from dataclasses import dataclass
+from typing import Optional
+
+from utils import check_pod_exists, run_oc_command
+
+ROS_DISABLED_SKIP_REASON = (
+    "ROS is disabled (spec.ros.enabled=false or ROSEnabled=False); "
+    "recommendations API and ROS workloads are not deployed on the Cost-only beta path. "
+    "Set spec.ros.enabled=true (and ROS/Kruize images) to run ROS API tests."
+)
+
+
+@dataclass
+class RosEnablementSignals:
+    """Inputs used to decide whether ROS workloads should be considered active."""
+
+    env_override: Optional[str] = None
+    spec_enabled: Optional[str] = None
+    condition_status: Optional[str] = None
+    ros_api_present: bool = False
+    cmsc_found: bool = False
+
+
+def parse_ros_enabled_env(value: Optional[str]) -> Optional[bool]:
+    """Parse ROS_ENABLED (or similar) environment override."""
+    if value is None:
+        return None
+    normalized = value.strip().lower()
+    if not normalized:
+        return None
+    if normalized in ("true", "1", "yes"):
+        return True
+    if normalized in ("false", "0", "no"):
+        return False
+    return None
+
+
+def resolve_ros_enabled(signals: RosEnablementSignals) -> bool:
+    """Resolve ROS enablement from CMSC signals and optional workload fallback."""
+    env = parse_ros_enabled_env(signals.env_override)
+    if env is not None:
+        return env
+
+    if signals.cmsc_found:
+        spec_val = (signals.spec_enabled or "").strip().lower()
+        if spec_val == "true":
+            return True
+        # CRD default is false; omitted field yields empty jsonpath.
+        if spec_val == "false" or spec_val == "":
+            return False
+
+    condition = (signals.condition_status or "").strip()
+    if condition == "True":
+        return True
+    if condition == "False":
+        return False
+
+    return signals.ros_api_present
+
+
+def detect_ros_enabled(
+    namespace: str,
+    cr_name: str,
+    helm_release_name: str,
+) -> bool:
+    """Detect ROS enablement from CMSC spec/condition or ros-api workload."""
+    env_override = os.environ.get("ROS_ENABLED")
+    cmsc_name = os.environ.get("CMSC_NAME", cr_name or helm_release_name)
+
+    cmsc_found = False
+    spec_enabled: Optional[str] = None
+    condition_status: Optional[str] = None
+
+    spec_result = run_oc_command(
+        [
+            "get",
+            "cmsc",
+            cmsc_name,
+            "-n",
+            namespace,
+            "-o",
+            "jsonpath={.spec.ros.enabled}",
+        ],
+        check=False,
+    )
+    if spec_result.returncode == 0:
+        cmsc_found = True
+        spec_enabled = spec_result.stdout.strip()
+
+    condition_result = run_oc_command(
+        [
+            "get",
+            "cmsc",
+            cmsc_name,
+            "-n",
+            namespace,
+            "-o",
+            "jsonpath={.status.conditions[?(@.type=='ROSEnabled')].status}",
+        ],
+        check=False,
+    )
+    if condition_result.returncode == 0:
+        cmsc_found = True
+        condition_status = condition_result.stdout.strip()
+
+    ros_api_present = check_pod_exists(
+        namespace, "app.kubernetes.io/component=ros-api"
+    )
+
+    return resolve_ros_enabled(
+        RosEnablementSignals(
+            env_override=env_override,
+            spec_enabled=spec_enabled,
+            condition_status=condition_status,
+            ros_api_present=ros_api_present,
+            cmsc_found=cmsc_found,
+        )
+    )

--- a/test/pytest/suites/e2e/test_complete_flow.py
+++ b/test/pytest/suites/e2e/test_complete_flow.py
@@ -1357,6 +1357,7 @@ class TestCompleteDataFlow:
 
     def test_09_recommendations_accessible_via_api(
         self,
+        require_ros_enabled,
         gateway_url: str,
         keycloak_config,
         cluster_config,

--- a/test/pytest/suites/ros/conftest.py
+++ b/test/pytest/suites/ros/conftest.py
@@ -7,6 +7,11 @@ import pytest
 from utils import get_pod_by_label, get_secret_value, get_route_url, run_oc_command
 
 
+@pytest.fixture(autouse=True)
+def _skip_ros_suite_when_disabled(require_ros_enabled) -> None:
+    """Skip ROS suite tests when spec.ros.enabled is false (Cost-only beta)."""
+
+
 @pytest.fixture(scope="module")
 def kruize_pod(cluster_config) -> str:
     """Get Kruize pod name."""

--- a/test/pytest/test_ros_feature.py
+++ b/test/pytest/test_ros_feature.py
@@ -1,7 +1,11 @@
 """Unit tests for ROS enablement detection (COST-8136)."""
 
+import os
+from unittest.mock import patch
+
 from ros_feature import (
     RosEnablementSignals,
+    detect_ros_enabled,
     parse_ros_enabled_env,
     resolve_ros_enabled,
 )
@@ -56,3 +60,12 @@ def test_resolve_ros_enabled_condition_false_without_cmsc():
         cmsc_found=False,
     )
     assert resolve_ros_enabled(signals) is False
+
+
+@patch("ros_feature.check_pod_exists")
+@patch("ros_feature.run_oc_command")
+def test_detect_ros_enabled_env_override_skips_cluster_probes(mock_run_oc, mock_check_pod):
+    with patch.dict(os.environ, {"ROS_ENABLED": "false"}, clear=False):
+        assert detect_ros_enabled("cost-onprem", "cost-onprem", "cost-onprem") is False
+    mock_run_oc.assert_not_called()
+    mock_check_pod.assert_not_called()

--- a/test/pytest/test_ros_feature.py
+++ b/test/pytest/test_ros_feature.py
@@ -1,0 +1,58 @@
+"""Unit tests for ROS enablement detection (COST-8136)."""
+
+from ros_feature import (
+    RosEnablementSignals,
+    parse_ros_enabled_env,
+    resolve_ros_enabled,
+)
+
+
+def test_parse_ros_enabled_env():
+    assert parse_ros_enabled_env("true") is True
+    assert parse_ros_enabled_env("FALSE") is False
+    assert parse_ros_enabled_env("  yes ") is True
+    assert parse_ros_enabled_env("") is None
+    assert parse_ros_enabled_env(None) is None
+
+
+def test_resolve_ros_enabled_env_override_wins():
+    signals = RosEnablementSignals(
+        env_override="false",
+        spec_enabled="true",
+        condition_status="True",
+        ros_api_present=True,
+        cmsc_found=True,
+    )
+    assert resolve_ros_enabled(signals) is False
+
+
+def test_resolve_ros_enabled_spec_false():
+    signals = RosEnablementSignals(
+        spec_enabled="false",
+        ros_api_present=True,
+        cmsc_found=True,
+    )
+    assert resolve_ros_enabled(signals) is False
+
+
+def test_resolve_ros_enabled_spec_omitted_defaults_false():
+    signals = RosEnablementSignals(
+        spec_enabled="",
+        ros_api_present=True,
+        cmsc_found=True,
+    )
+    assert resolve_ros_enabled(signals) is False
+
+
+def test_resolve_ros_enabled_falls_back_to_workload():
+    signals = RosEnablementSignals(ros_api_present=True, cmsc_found=False)
+    assert resolve_ros_enabled(signals) is True
+
+
+def test_resolve_ros_enabled_condition_false_without_cmsc():
+    signals = RosEnablementSignals(
+        condition_status="False",
+        ros_api_present=True,
+        cmsc_found=False,
+    )
+    assert resolve_ros_enabled(signals) is False


### PR DESCRIPTION
## Summary
- Detect ROS enablement from `ROS_ENABLED` env, CMSC `spec.ros.enabled`, `ROSEnabled` condition, or `ros-api` workload fallback
- Skip the full `suites/ros/` suite and E2E `test_09_recommendations_accessible_via_api` when ROS is off (Cost-only beta default)
- Document cluster-bot expectation in the operator pytest runbook

## Test plan
- [x] `cd test/pytest && python -m pytest test_ros_feature.py -v` (6 unit tests)
- [ ] Cluster-bot with `ros.enabled: false`: `./scripts/run-pytest.sh --no-ui -v` — no 404 failures on recommendations API; ROS tests show SKIPPED
- [ ] Optional: `ros.enabled: true` — `./scripts/run-pytest.sh --ros -v suites/ros/test_recommendations.py` still runs

## Jira
https://redhat.atlassian.net/browse/COST-8136


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Skip ROS pytest suites and the recommendations API test when ROS is disabled.
- Detect ROS enablement from `ROS_ENABLED`, `spec.ros.enabled`, `ROSEnabled`, or the `ros-api` workload.
- Add unit tests for detection and precedence rules.
- Document the expected recommendations API `404` for Cost-only beta installations.

## Operator impact

- No CRD API, reconcile behavior, RBAC, or user-visible status condition changes.
- ROS recommendations API tests require `spec.ros.enabled: true` and available ROS/Kruize workloads.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->