### PR TITLE
docs: document Jira branch and PR naming conventions

### DIFF
--- a/.cursor/rules/jira-cost-branches-prs.mdc
+++ b/.cursor/rules/jira-cost-branches-prs.mdc
@@ -1,0 +1,22 @@
+---
+description: Jira COST-#### branch and PR title conventions for this repo
+alwaysApply: true
+---
+
+# Jira branch and PR conventions (COST-####)
+
+When work is tied to a Jira ticket `COST-####` (or the user references one):
+
+| Item | Format |
+|------|--------|
+| Branch | `cost-####-short-kebab-slug` (lowercase, hyphens) |
+| PR title | `[COST-####] Short English description` |
+| Commit (recommended) | `[COST-####] Short English description` |
+
+- Put `[COST-####]` at the **start** of the PR title, not `(COST-####)` at the end.
+- PR body should link: `https://redhat.atlassian.net/browse/COST-####`
+- Creating branches/PRs: `git checkout -b cost-####-slug` and `gh pr create --title "[COST-####] ..."`
+
+Full table: [CONTRIBUTING.md](../../CONTRIBUTING.md).
+
+Chore/docs without a ticket may use `chore/` or `docs/` branch prefixes instead.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,13 @@
+## Jira
+
+[COST-####](https://redhat.atlassian.net/browse/COST-####)
+
+PR title format: `[COST-####] Short English description` (see [CONTRIBUTING.md](../CONTRIBUTING.md)).
+
+## Summary
+
+-
+
+## Test plan
+
+- [ ]

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -112,6 +112,18 @@ Full analysis in [docs/design/design-vs-jira.md](docs/design/design-vs-jira.md).
 
 ## PR review checklist
 
+### Jira branch and PR naming
+
+When opening or updating a PR for a Jira ticket:
+
+| Item | Format |
+|------|--------|
+| Branch | `cost-####-short-kebab-slug` |
+| PR title | `[COST-####] Short English description` |
+
+Put the Jira key at the **start** of the title, not at the end. See
+[CONTRIBUTING.md](CONTRIBUTING.md).
+
 ### Coverage analysis
 
 Before submitting or updating any PR, run coverage on the packages touched

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,28 @@
+# Contributing
+
+## Jira-linked branches and pull requests
+
+Work tied to a Cost Management Jira ticket (`COST-####` on
+[redhat.atlassian.net](https://redhat.atlassian.net)) should use consistent
+branch and PR naming so reviews, release notes, and agent tooling stay aligned.
+
+| Item | Format | Example |
+|------|--------|---------|
+| **Branch** | `cost-####-short-kebab-slug` | `cost-8136-skip-ros-pytest-when-disabled` |
+| **PR title** | `[COST-####] Short English description` | `[COST-8136] Skip ROS pytest when ros.enabled is false` |
+| **Commit** (recommended) | `[COST-####] Short English description` | `[COST-8136] Skip ROS pytest when ros.enabled is false` |
+
+Rules:
+
+- Put the Jira key at the **start** of the PR title (`[COST-####]`), not at the end.
+- Branch slug: lowercase, hyphens, no spaces.
+- Use `redhat.atlassian.net` links in PR bodies (`https://redhat.atlassian.net/browse/COST-####`).
+- Chore/docs without a ticket may use `chore/` or `docs/` prefixes instead of `cost-####`.
+
+Project rules for Cursor users live in [.cursor/rules/jira-cost-branches-prs.mdc](.cursor/rules/jira-cost-branches-prs.mdc).
+Agent context also appears in [CLAUDE.md](CLAUDE.md).
+
+## Development
+
+See [CLAUDE.md](CLAUDE.md) for build, test, reconciler conventions, and the PR
+review checklist.

--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ existing external infrastructure (PostgreSQL, Kafka, S3, OIDC).
 
 | Document | Description |
 |----------|-------------|
+| [CONTRIBUTING.md](CONTRIBUTING.md) | Branch/PR naming with Jira (`COST-####`) |
 | [docs/install/](docs/install/) | **Install and configure** (prerequisites, quickstart, production, CMMO) |
 | [docs/development/clusterbot.md](docs/development/clusterbot.md) | Cluster Bot day-one: Redpanda BYOI → in-cluster operator |
 | [docs/development/pre-prod-install.md](docs/development/pre-prod-install.md) | Pre-prod BYOI → operator → UI install walkthrough |


### PR DESCRIPTION
## Summary
- Add `CONTRIBUTING.md` with `cost-####-*` branches and `[COST-####]` PR titles
- Add GitHub PR template with Jira link block
- Add `.cursor/rules/jira-cost-branches-prs.mdc` for Cursor project rules
- Extend `CLAUDE.md` PR review checklist and link from `README.md`

No CI/automation changes in this PR.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Adds `CONTRIBUTING.md` with Jira branch, pull request, and commit naming conventions.
- Adds a GitHub pull request template with a Jira link block.
- Adds Cursor and `CLAUDE.md` guidance for `COST-####` naming.
- Links the contribution guide from `README.md`.

## Operator impact

- No CRD API changes.
- No reconcile-phase behavior changes.
- No RBAC changes.
- No user-visible status condition changes.
- No CI or automation changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->