### PR TITLE
docs: add CR-first uninstall guide and drop closed review follow-ups

### DIFF
--- a/docs/development/clusterbot-operator-pytest.md
+++ b/docs/development/clusterbot-operator-pytest.md
@@ -410,6 +410,10 @@ Full order and recovery: [uninstall.md](../install/uninstall.md).
 ```bash
 # Wait for the finalizer (ConsoleLink cleanup) while the operator is still up
 oc delete cmsc -n cost-onprem --all --timeout=180s --ignore-not-found
+if oc get cmsc -n cost-onprem --no-headers 2>/dev/null | grep -q .; then
+  echo "CMSC still present; not deleting the namespace. See uninstall.md recovery." >&2
+  exit 1
+fi
 oc delete ns cost-onprem s4-test kafka keycloak --ignore-not-found
 ```
 

--- a/docs/development/clusterbot-operator-pytest.md
+++ b/docs/development/clusterbot-operator-pytest.md
@@ -398,8 +398,13 @@ TTL ~2h, single worker overload. **Fix:** MCE, ≥2 workers, run infra first.
 
 ## Tear down
 
+Delete the CR **first** and wait until it is gone. The operator lives in
+`cost-onprem`; deleting the namespace first leaves the CR finalizer stuck.
+Full order and recovery: [uninstall.md](../install/uninstall.md).
+
 ```bash
-oc delete cmsc -n cost-onprem --all --ignore-not-found
+# Wait for the finalizer (ConsoleLink cleanup) while the operator is still up
+oc delete cmsc -n cost-onprem --all --timeout=180s --ignore-not-found
 oc delete ns cost-onprem s4-test kafka keycloak --ignore-not-found
 ```
 

--- a/docs/development/clusterbot.md
+++ b/docs/development/clusterbot.md
@@ -141,8 +141,13 @@ NAMESPACE=cost-onprem IMG=quay.io/project-koku/koku-service-operator:v0.0.1 make
 
 ## Tear down
 
+Delete the CR **first** and wait until it is gone. The operator lives in
+`cost-byoi`; deleting the namespace first leaves the CR finalizer stuck.
+Full order and recovery: [uninstall.md](../install/uninstall.md).
+
 ```bash
-oc delete cmsc -n cost-byoi --all --ignore-not-found
+# Wait for the finalizer (ConsoleLink cleanup) while the operator is still up
+oc delete cmsc -n cost-byoi --all --timeout=180s --ignore-not-found
 oc delete ns cost-byoi cost-byoi-infra --ignore-not-found
 # If you used AMQ Streams / Keycloak instead of the smoke path:
 #   ./config/samples/byoi/deploy-kafka.sh cleanup

--- a/docs/development/clusterbot.md
+++ b/docs/development/clusterbot.md
@@ -148,6 +148,10 @@ Full order and recovery: [uninstall.md](../install/uninstall.md).
 ```bash
 # Wait for the finalizer (ConsoleLink cleanup) while the operator is still up
 oc delete cmsc -n cost-byoi --all --timeout=180s --ignore-not-found
+if oc get cmsc -n cost-byoi --no-headers 2>/dev/null | grep -q .; then
+  echo "CMSC still present; not deleting the namespace. See uninstall.md recovery." >&2
+  exit 1
+fi
 oc delete ns cost-byoi cost-byoi-infra --ignore-not-found
 # If you used AMQ Streams / Keycloak instead of the smoke path:
 #   ./config/samples/byoi/deploy-kafka.sh cleanup

--- a/docs/development/olm-bundle-testing.md
+++ b/docs/development/olm-bundle-testing.md
@@ -104,7 +104,7 @@ oc apply -n cost-onprem \
   -f config/samples/service.costmanagement_v1alpha1_costmanagementserviceconfig.yaml
 
 oc get cmsc -n cost-onprem
-oc describe cmsc cost-management -n cost-onprem
+oc describe cmsc cost-onprem -n cost-onprem
 ```
 
 Still requires external Kafka / OIDC / object storage for a full Ready stack.
@@ -134,8 +134,9 @@ the operator and leaves the CR finalizer stuck. Full order and recovery:
 [uninstall.md](../install/uninstall.md).
 
 ```bash
-oc delete cmsc cost-management -n cost-onprem --timeout=180s --ignore-not-found
-if oc -n cost-onprem get cmsc cost-management >/dev/null 2>&1; then
+# --all covers both samples in this file (bundled `cost-onprem`, BYOI `cost-management`)
+oc delete cmsc -n cost-onprem --all --timeout=180s --ignore-not-found
+if oc get cmsc -n cost-onprem --no-headers 2>/dev/null | grep -q .; then
   echo "CMSC still present; not running bundle-cleanup. See uninstall.md recovery." >&2
   exit 1
 fi

--- a/docs/development/olm-bundle-testing.md
+++ b/docs/development/olm-bundle-testing.md
@@ -129,8 +129,12 @@ That still confirms the operator is reconciling. For a fuller BYOI fixture, see
 
 ## Cleanup
 
+Delete the CR **before** `make bundle-cleanup`. Removing the CSV first kills
+the operator and leaves the CR finalizer stuck. Full order and recovery:
+[uninstall.md](../install/uninstall.md).
+
 ```bash
-oc delete cmsc cost-management -n cost-onprem --ignore-not-found
+oc delete cmsc cost-management -n cost-onprem --timeout=180s --ignore-not-found
 make bundle-cleanup
 ```
 

--- a/docs/development/olm-bundle-testing.md
+++ b/docs/development/olm-bundle-testing.md
@@ -135,6 +135,10 @@ the operator and leaves the CR finalizer stuck. Full order and recovery:
 
 ```bash
 oc delete cmsc cost-management -n cost-onprem --timeout=180s --ignore-not-found
+if oc -n cost-onprem get cmsc cost-management >/dev/null 2>&1; then
+  echo "CMSC still present; not running bundle-cleanup. See uninstall.md recovery." >&2
+  exit 1
+fi
 make bundle-cleanup
 ```
 

--- a/docs/development/ownnamespace.md
+++ b/docs/development/ownnamespace.md
@@ -49,3 +49,11 @@ IMG=quay.io/<you>/koku-service-operator:<tag> ./hack/deploy-incluster.sh cost-on
 
 Do not split operator (`koku-service-operator-system`) and CR (`cost-onprem`) — the
 operator will not reconcile. See [clusterbot-operator-pytest.md](clusterbot-operator-pytest.md).
+
+## Uninstall
+
+Because the manager and the CR share a namespace, delete the
+`CostManagementServiceConfig` and wait until it is gone **before** deleting
+the namespace or the operator Deployment. Otherwise the CR finalizer never
+runs and the namespace stays `Terminating` (ConsoleLink leak). Procedure and
+recovery: [uninstall.md](../install/uninstall.md).

--- a/docs/development/pre-prod-install.md
+++ b/docs/development/pre-prod-install.md
@@ -293,6 +293,10 @@ Delete the CR first while the operator is still running. `hack/demo-preprod.sh -
 
 ```bash
 oc -n "$NAMESPACE" delete cmsc "$CR_NAME" --timeout=180s
+if oc -n "$NAMESPACE" get cmsc "$CR_NAME" >/dev/null 2>&1; then
+  echo "CMSC still present; not deleting the namespace. See uninstall.md recovery." >&2
+  exit 1
+fi
 oc delete ns "$NAMESPACE" "$INFRA_NAMESPACE" --ignore-not-found
 ```
 

--- a/docs/development/pre-prod-install.md
+++ b/docs/development/pre-prod-install.md
@@ -285,9 +285,20 @@ curl -skI "https://$(oc -n "$NAMESPACE" get route "${CR_NAME}-ui" -o jsonpath='{
 | ImagePullBackOff on amd64 node | arm64-only image | Rebuild with `--platform linux/amd64` |
 | StorageClass list/watch forbidden | Stale cluster role | Re-apply `config/rbac/cluster_access_role.yaml` (`get;list;watch`) |
 | CrashLoop: `open …/serving-certs/tls.crt: no such file` | Webhook server has no TLS mount | Re-run `./hack/deploy-incluster.sh` (creates/mounts `koku-webhook-server-cert`), or mount a Secret with `tls.crt`/`tls.key` at `/tmp/k8s-webhook-server/serving-certs` |
+| Namespace stuck `Terminating` after `oc delete ns` | Operator died before the CR finalizer ran | [uninstall.md](../install/uninstall.md#if-the-namespace-is-already-terminating) |
+
+## Tear down
+
+Delete the CR first while the operator is still running. `hack/demo-preprod.sh --reset` already does this (and strips the finalizer if the operator is gone). Manual order and recovery: [uninstall.md](../install/uninstall.md).
+
+```bash
+oc -n "$NAMESPACE" delete cmsc "$CR_NAME" --timeout=180s
+oc delete ns "$NAMESPACE" "$INFRA_NAMESPACE" --ignore-not-found
+```
 
 ## Related docs
 
 - [ownnamespace.md](ownnamespace.md) — install/watch model and RBAC shape
 - [crc-testing.md](crc-testing.md) — local CRC / out-of-cluster `make run`
+- [uninstall.md](../install/uninstall.md) — CR-first uninstall and stuck-namespace recovery
 - [config/samples/byoi/README.md](../../config/samples/byoi/README.md) — fixture details, monitoring, teardown

--- a/docs/install/README.md
+++ b/docs/install/README.md
@@ -17,6 +17,7 @@ namespace** as the CR (OwnNamespace). See [quickstart.md](quickstart.md#install-
 | [Prerequisites](prerequisites.md) | You need the external services, buckets, Kafka topic, and Secret key names |
 | [Quickstart](quickstart.md) | Prerequisites and the operator are ready; you want a working CR in under 30 minutes |
 | [Production](production.md) | You are sizing, hardening TLS, and planning backup for a lasting deploy |
+| [Uninstall](uninstall.md) | You need to remove a CR, the operator, or the namespace without getting stuck in `Terminating` |
 | [CMMO](cmmo.md) | You need reporting clusters to upload metrics into this instance |
 
 Each guide is self-contained. The quickstart clock starts **after**

--- a/docs/install/production.md
+++ b/docs/install/production.md
@@ -160,6 +160,13 @@ migration Job. Pin tags (and digests when you can).
 on the CR (key `…/pause`, value `true`) halts reconcile (`Paused` condition).
 Remove it to resume.
 
+## Uninstall
+
+Delete the `CostManagementServiceConfig` and wait until it is gone **before**
+deleting the namespace or the operator. The operator lives in the CR namespace;
+killing it first leaves the CR finalizer stuck and leaks the ConsoleLink.
+Full order and recovery: [uninstall.md](uninstall.md).
+
 ## Next
 
 Point reporting clusters at this instance: [cmmo.md](cmmo.md).

--- a/docs/install/quickstart.md
+++ b/docs/install/quickstart.md
@@ -173,3 +173,4 @@ ConsoleLink when the UI Route exists.
 
 - Size and TLS: [production.md](production.md)
 - Point Cost Management Metrics Operator at this instance: [cmmo.md](cmmo.md)
+- Tear down: [uninstall.md](uninstall.md) — delete the CR **before** the namespace or the operator

--- a/docs/install/uninstall.md
+++ b/docs/install/uninstall.md
@@ -19,28 +19,30 @@ Those stay until you remove them.
 
 ## Procedure
 
-Replace the namespace and CR name with yours.
+Replace the namespace and CR name with yours. The `if` gate is required: a
+`--timeout` expiry still returns, and without `set -e` the next command would
+delete the namespace while the finalizer is present.
 
 ```bash
 export NAMESPACE=cost-onprem
 export CR_NAME=cost-management-minimal
 
-# 1. Confirm the operator is still running
+# Confirm the operator is still running
 oc -n "$NAMESPACE" get deploy,pods
 
-# 2. Delete the CR and wait until it is gone (finalizer cleanup)
+# Delete the CR and wait for finalizer cleanup
 oc -n "$NAMESPACE" delete cmsc "$CR_NAME" --timeout=180s
+if oc -n "$NAMESPACE" get cmsc "$CR_NAME" >/dev/null 2>&1; then
+  echo "CMSC still present; not deleting the namespace. See recovery below." >&2
+  exit 1
+fi
 
-# 3. Confirm NotFound before touching the namespace or operator
-oc -n "$NAMESPACE" get cmsc "$CR_NAME"
-
-# 4. Then remove the operator and/or the namespace
+# Then remove the operator and/or the namespace
 oc delete ns "$NAMESPACE"
 ```
 
-Do not run `oc delete ns` until step 3 returns NotFound. If you installed via
-OLM, delete the CR first, then the Subscription / CSV — not the other way
-around.
+If you installed via OLM, delete the CR (and confirm NotFound) **before** the
+Subscription / CSV — not the other way around.
 
 ## If the namespace is already Terminating
 
@@ -54,17 +56,36 @@ export CR_NAME=cost-management-minimal
 oc -n "$NAMESPACE" patch cmsc "$CR_NAME" --type=merge \
   -p '{"metadata":{"finalizers":[]}}'
 oc delete consolelink "${CR_NAME}-cost-management" --ignore-not-found
-
-# Only if ROS / Kruize was enabled:
 oc delete clusterrole,clusterrolebinding \
-  -l "app.kubernetes.io/instance=${CR_NAME}" --ignore-not-found
+  -l app.kubernetes.io/managed-by=koku-service-operator,app.kubernetes.io/instance="${CR_NAME}",app.kubernetes.io/component=ros-optimization \
+  --ignore-not-found
 ```
 
 The namespace should finish terminating within a few seconds.
 
+If `oc patch` is denied with a webhook timeout, the operator Service is gone
+but the cluster-scoped admission configs remain (`failurePolicy: Fail` on CMSC
+CREATE/UPDATE). That is the OLM path; in-cluster `hack/deploy-incluster.sh`
+does not install those configs. Delete the Cost Management webhook
+configurations (or the CSV, which owns them), then retry the patch:
+
+```bash
+oc get mutatingwebhookconfiguration,validatingwebhookconfiguration -o name \
+  | grep costmanagementserviceconfig
+# oc delete mutatingwebhookconfiguration/<name> validatingwebhookconfiguration/<name>
+```
+
+Then retry the `oc patch` above, then ConsoleLink / Kruize RBAC.
+
 ## Lab reset
 
-`hack/demo-preprod.sh --reset` and `scripts/install-cmsc.sh` cleanup already
-delete the CR first (and strip the finalizer if the operator is already gone).
+`hack/demo-preprod.sh --reset` deletes the CR first while the operator is
+Available, and strips the finalizer (plus ConsoleLink / Kruize RBAC) if the
+operator is already gone.
+
+`scripts/install-cmsc.sh` cleanup also deletes the CR first, but it does **not**
+strip a stuck finalizer — if the operator is down, that path can still leave
+the namespace `Terminating`. Use the recovery steps above.
+
 Cluster Bot tear-down in [clusterbot.md](../development/clusterbot.md) follows
-the same order.
+the CR-first order.

--- a/docs/install/uninstall.md
+++ b/docs/install/uninstall.md
@@ -1,0 +1,70 @@
+# Uninstall
+
+Remove the `CostManagementServiceConfig` **before** the operator or the
+namespace.
+
+The CR carries a finalizer
+(`costmanagementserviceconfigs.service.costmanagement.openshift.io/cleanup`)
+that deletes cluster-scoped objects the operator created: the ConsoleLink, and
+(only if ROS was enabled) the Kruize ClusterRole and ClusterRoleBinding. That
+cleanup runs **only while the operator pod is still running**.
+
+The operator is installed in the **same namespace as the CR**. Deleting that
+namespace (or the operator Deployment / CSV) first kills the manager before it
+can strip the finalizer. The namespace then stays `Terminating` and the
+ConsoleLink leaks cluster-wide.
+
+This does **not** delete your PostgreSQL, Kafka, object storage, or Keycloak.
+Those stay until you remove them.
+
+## Procedure
+
+Replace the namespace and CR name with yours.
+
+```bash
+export NAMESPACE=cost-onprem
+export CR_NAME=cost-management-minimal
+
+# 1. Confirm the operator is still running
+oc -n "$NAMESPACE" get deploy,pods
+
+# 2. Delete the CR and wait until it is gone (finalizer cleanup)
+oc -n "$NAMESPACE" delete cmsc "$CR_NAME" --timeout=180s
+
+# 3. Confirm NotFound before touching the namespace or operator
+oc -n "$NAMESPACE" get cmsc "$CR_NAME"
+
+# 4. Then remove the operator and/or the namespace
+oc delete ns "$NAMESPACE"
+```
+
+Do not run `oc delete ns` until step 3 returns NotFound. If you installed via
+OLM, delete the CR first, then the Subscription / CSV — not the other way
+around.
+
+## If the namespace is already Terminating
+
+The operator is gone and the finalizer is stuck. Strip it, then delete the
+leaked cluster-scoped objects:
+
+```bash
+export NAMESPACE=cost-onprem
+export CR_NAME=cost-management-minimal
+
+oc -n "$NAMESPACE" patch cmsc "$CR_NAME" --type=merge \
+  -p '{"metadata":{"finalizers":[]}}'
+oc delete consolelink "${CR_NAME}-cost-management" --ignore-not-found
+
+# Only if ROS / Kruize was enabled:
+oc delete clusterrole,clusterrolebinding \
+  -l "app.kubernetes.io/instance=${CR_NAME}" --ignore-not-found
+```
+
+The namespace should finish terminating within a few seconds.
+
+## Lab reset
+
+`hack/demo-preprod.sh --reset` and `scripts/install-cmsc.sh` cleanup already
+delete the CR first (and strip the finalizer if the operator is already gone).
+Cluster Bot tear-down in [clusterbot.md](../development/clusterbot.md) follows
+the same order.

--- a/docs/review-follow-ups.md
+++ b/docs/review-follow-ups.md
@@ -1,19 +1,8 @@
 # Review Follow-ups
 
-Non-blocking follow-up items from code reviews. Each item is pre-existing
-or deferred — not a blocker for the PR that surfaced it.
-
----
-
-## 1. ~~`ResolveBootstrapAdmin` silently substitutes test-fixture IDs~~ — **CLOSED**
-
-**Source:** [inline comment on migration.go:359](https://github.com/project-koku/koku-service-operator/pull/22#discussion_r2940893206)
-
-**Fixed:** `ResolveBootstrapAdmin` no longer exists. `AdminBootstrapJob`
-now reads org-id/account-number from a Secret via `EnvFromSecret` and
-returns `nil` when `secretRef.name` is empty. No fallback to
-`org1234567`/`7890123`. The code path is gated by
-`ba.Enabled && ba.SecretRef.Name != ""`.
+Open, non-blocking items from code reviews. Closed entries are removed.
+IDs are stable (gaps are intentional) so existing `#12` / `#13` links keep
+working.
 
 ---
 
@@ -36,8 +25,10 @@ Images constructed at runtime in `internal/resources/*.go` (Postgres,
 Valkey, Kruize, Koku, ROS, RBAC…) are not captured in the CSV
 `relatedImages` list, so airgapped/`oc-mirror` deployments cannot
 discover them. Needs a `RELATED_IMAGE_*` env-var convention on the
-manager Deployment + bundle generation integration. Tracked under
-COST-7695.
+manager Deployment + bundle generation integration.
+
+COST-7695 (bundle CSV/CRD/RBAC) is Closed; this airgap gap did not land
+with it.
 
 ---
 
@@ -52,43 +43,6 @@ an audit asks. Recommended fix: custom Django management commands in
 `insights-rbac`. Long-term: versioned REST/gRPC API. Requires
 `insights-rbac` maintainer buy-in. See [Jordi's comment](https://github.com/project-koku/koku-service-operator/pull/22#issuecomment-5257084580)
 for full analysis including dropped alternatives.
-
----
-
-## 5. Controller does not watch StorageClasses
-
-**Source:** [PR #34 review](https://github.com/project-koku/koku-service-operator/pull/34) — pre-existing, not introduced by the OwnNamespace change.
-
-**Problem:** The discovery phase reads the default StorageClass via
-`discoverDefaultStorageClass()` (a one-shot `List` call), but the
-controller's `SetupWithManager` does not `Watches()` StorageClass
-resources. If the cluster's default StorageClass changes after initial
-discovery, the operator won't notice until the next 5-minute drift
-requeue — and even then, `reconcileDiscovery` only runs the StorageClass
-lookup when `spec.global.storageClass` is empty AND
-`status.discoveredConfig.storageClass` is empty, so it won't pick up
-a change to an already-discovered value.
-
-**Impact:** Low. StorageClass changes are rare day-2 events, and the
-operator only uses the discovered StorageClass for bundled (dev-only)
-PVCs. Production (BYOI) users set `spec.global.storageClass` explicitly.
-
-**Suggested fix:** Add a cluster-scoped `Watches()` on StorageClasses
-with a `GenerationChangedPredicate` filter, or accept as low-priority
-given the dev-only use case.
-
----
-
-## 6. ~~Add manifest test for role.yaml scope~~ — **CLOSED**
-
-**Source:** [PR #34 review — jordigilh](https://github.com/project-koku/koku-service-operator/pull/34#discussion_r2948488270)
-
-**Fixed:** `TestManagerRole_NoClusterScopedResources` parses `role.yaml`
-and CSV namespaced `permissions` and fails if they grant `consolelinks`,
-`clusterroles`, `clusterrolebindings`, `storageclasses`,
-`config.openshift.io/ingresses`, a `noobaa-admin` resourceName, or a
-`resources: ["*"]` grant on those API groups. Those rules belong in
-`cluster_access_role.yaml`.
 
 ---
 
@@ -112,98 +66,36 @@ as a workaround, defeating TLS verification.
 **Suggested fix:** Mount the Keycloak CA Secret (or the combined CA bundle
 from CACombineInitContainer) and set `SSL_CERT_FILE` in the container env.
 Follow the same pattern used by the Envoy gateway and oauth2-proxy.
-
-Envoy itself already trusts this CA (COST-7688 R2; follow-up #18). This
-item is the CronJob-only remaining gap.
-
----
-
-## 8. ~~Keycloak sync: enable/disable lifecycle test~~ — **CLOSED**
-
-**Source:** Code review finding.
-
-**Fixed:** `TestKeycloakSyncDeletedWhenDisabled` exists at
-`internal/controller/keycloak_sync_disable_test.go:21`, following the
-same pattern as `TestKruizeCronJobDeletedWhenDisabled`.
+Envoy already trusts this CA (COST-7688 R2); this item is the CronJob-only
+remaining gap.
 
 ---
 
-## 9. ~~S3 TLS fields are probe-only — not wired to app pods~~ — **CLOSED**
-
-**Source:** Code review of PR #71 (validation follow-ups).
-
-**Fixed:** `userCAFiles` includes `objectStorage.caCertSecretName` as
-`object-storage-ca.crt`. `CACombineInitContainer` merges it into the
-combined bundle. Koku/Masu set `AWS_CA_BUNDLE` and `REQUESTS_CA_BUNDLE`
-to that bundle (`internal/resources/env.go`). Covered by
-`internal/resources/volumes_test.go`.
-
----
-
-## 10. OwnNamespace + CR finalizer: namespace delete sticks in Terminating
+## 10. OwnNamespace + CR finalizer: OLM uninstall still kills the manager first
 
 **Source:** Cluster Bot pre-prod install (`hack/demo-preprod.sh --reset`), 2026-08-15.
-Cluster `chat-bot-jyn4z-xta9nw`; namespace `cost-byoi` stayed `Terminating` after
-`kubectl delete ns`.
 
-**Problem:** The CR finalizer
+The CR finalizer
 `costmanagementserviceconfigs.service.costmanagement.openshift.io/cleanup`
-is required: ConsoleLink and Kruize ClusterRole/Binding are cluster-scoped, so
-they cannot use `ownerReferences`. `reconcileDelete()` deletes those objects
-then strips the finalizer. That path is correct **when the CR is deleted and
-the manager is still running**.
+deletes cluster-scoped ConsoleLink and Kruize ClusterRole/Binding, then
+strips itself. That path is correct **when the CR is deleted and the
+manager is still running**.
 
-OwnNamespace puts the manager Deployment in the **same namespace as the CR**.
-Deleting the namespace (or tearing down the operator CSV/Deployment first)
-kills the operator pod before it can process the CR's `deletionTimestamp`.
-The finalizer is never removed.
+The operator lives in the **same namespace as the CR**. Deleting the
+namespace (or the CSV/Deployment) first kills the manager before it can
+process `deletionTimestamp`. The namespace stays `Terminating` and
+ConsoleLink leaks.
 
-Observed on clusterbot:
+**Documented:** [uninstall.md](install/uninstall.md) — delete the CR, wait
+until it is gone, then the namespace or operator. Lab
+`hack/demo-preprod.sh --reset` and `scripts/install-cmsc.sh` cleanup already
+do this (strip the finalizer only if the operator is already gone).
 
-- Namespace condition `NamespaceFinalizersRemaining`:
-  `costmanagementserviceconfigs.service.costmanagement.openshift.io/cleanup`
-  on 1 resource
-- `NamespaceContentRemaining`: the CMSC instance still present
-- Operator pods already gone (`No resources found`)
-- ConsoleLink `cost-management-cost-management` still present (cluster leak)
-
-Unstick: patch `metadata.finalizers: []` on the CMSC and delete the ConsoleLink.
-The namespace then finished terminating in seconds.
-
-**Impact:** Medium for lab/uninstall. Any `oc delete ns <cr-ns>`, Cluster Bot
-teardown, or OLM uninstall that removes the operator before the CR will leave
-the namespace stuck and leak ConsoleLink (and Kruize cluster RBAC if ROS was
-enabled). Production uninstall without a documented CR-first procedure hits
-the same trap. Not a bug in `reconcileDelete` itself.
-
-**Suggested fix (in order):**
-
-1. **Document uninstall order** (pre-prod / ownnamespace / OLM): delete the
-   `CostManagementServiceConfig`, wait until it is gone, *then* delete the
-   namespace or the operator. Lab `--reset` must do the same while the
-   operator is still Available; only strip the finalizer if the operator is
-   already gone.
-2. **OLM / COST-7695:** uninstall bundle should delete (or block on) the CR
-   before removing the CSV. AllNamespaces / a dedicated operator namespace
-   would also avoid killing the manager when the operand namespace is deleted.
-3. Optional hardening (probably not worth it for beta): a webhook that warns
-   or blocks namespace deletion while a CMSC with this finalizer exists.
-
-**Not a COST-7688 gap** — surfaced while exercising the pre-prod path on this
-branch.
-
----
-
-## 11. ~~`jwksProbe` ignores `caCertSecretName` — false `AuthenticationReady: False`~~ — **CLOSED**
-
-**Source:** PR #74 review (Jordi)
-
-**Fixed:** `reconcileValidation` now delegates Keycloak CA loading to
-`keycloakCACertPool`, which reads `ca.crt` from
-`auth.keycloak.tls.caCertSecretName` and passes a custom `x509.CertPool` to
-`jwksProbe`. Missing or invalid CA data reports `OIDCCACertInvalid`. When
-`insecureSkipVerify=true`, the operator skips CA Secret loading and honors the
-explicit insecure setting.
+**Still open:** OLM uninstall that removes the CSV before the CR still hits
+the trap. A bundle that deletes (or blocks on) the CR first would close it.
+The CSV advertises AllNamespaces, but install still colocates operator and
+CR. A webhook that blocks namespace deletion while this finalizer exists
+is not worth it for beta.
 
 ---
 
@@ -219,7 +111,9 @@ only (`IngressReady` / `GatewayReady` / `UIReady`) and never start that
 clock.
 
 Kruize is **not** in this gap — it is on the core wait list and uses
-`notReadyWait`.
+`notReadyWait`. UI is worse than Ingress/Envoy: `UIReady=True` is set
+when the OAuth client Secret exists; the UI Deployment is never
+readiness-gated.
 
 **Impact:** A stuck Ingress/Envoy/UI Deployment leaves `Progressing=True`
 and requeues every 30s indefinitely. `Available` may stay `True`
@@ -230,7 +124,8 @@ for those components.
 
 **Suggested fix:** Route Ingress (and optionally Envoy/UI) through
 `notReadyWait` with dedicated wait reasons, same as ROS API. Add tests
-that a 6-minute Ingress wait degrades and names the component.
+that a 6-minute Ingress wait degrades and names the component. Gate UI
+on Deployment readiness, not only the OAuth Secret.
 
 **Out of scope for PR #105** — COST-7686 G2/G3 cover the ticket-owned
 app Deployments (Koku API, Masu, Listener, optional Kruize/ROS). Ingress
@@ -252,19 +147,12 @@ the current ReplicaSet has zero available pods. Pre-existing; this PR
 only added more callers (Masu, Listener, Kruize, ROS API/Processor).
 
 **Suggested fix:** Require observed generation + updated + available
-replicas. Update `TestIsDeploymentReady` and `markDeploymentReady`; add
-a stale-replica case.
+replicas (same contract as `isStatefulSetReady`). Update
+`TestIsDeploymentReady` and `markDeploymentReady`; add a stale-replica
+case.
 
 **Out of scope for PR #105** — changes every existing gate (RBAC, Koku
 API, Ingress, Envoy, Valkey), not just COST-7686.
-
----
-
-## 14. No test that ROS Processor alone blocks worker readiness — **closed in PR #105**
-
-**Source:** [PR #105 CodeRabbit](https://github.com/project-koku/koku-service-operator/pull/105); João's [request-changes review](https://github.com/project-koku/koku-service-operator/pull/105#issuecomment-5354975468).
-
-**Closed:** `TestReconcileWorkers_ROSProcessorNotReady_BlocksProgress` marks Ingress + ROS API ready, leaves Processor down, and asserts `Available=False` `WaitingForROSProcessor`.
 
 ---
 
@@ -287,42 +175,3 @@ reasons `WaitingForRBAC` / component `"RBAC API"`). Leave the RBAC
 worker as condition-only (it does not block `Available` today).
 
 **Out of scope for PR #105** — COST-7689 leftover, not a COST-7686 AC.
-
----
-
-## 16. ~~Custom CA `RootCAs` replaced the system pool~~ — **CLOSED**
-
-**Source:** [PR #121 review](https://github.com/project-koku/koku-service-operator/pull/121#pullrequestreview-5000508819) (bacciotti).
-
-**Fixed:** `certPoolFromPEM` starts from `x509.SystemCertPool()` and
-appends the custom CA. JWKS and S3 probes share it so a custom CA no
-longer drops public roots. `TestCertPoolFromPEM_AppendsToSystemPool`
-guards the replace-vs-append contract.
-
----
-
-## 17. ~~Edge overwrites `AuthenticationReady` with `GatewayReady`~~ — **CLOSED**
-
-**Source:** [PR #121 review](https://github.com/project-koku/koku-service-operator/pull/121#pullrequestreview-5000508819) (stale restatement of D3 / COST-7688 G1).
-
-**Already fixed:** `reconcileEdge` writes `GatewayReady` only.
-`validateOIDC` is the only writer of `AuthenticationReady`.
-`TestReconcileEdge_DoesNotOverwriteOIDCUnreachable` asserts OIDC stays
-`OIDCUnreachable` while Gateway goes True. See
-[COST-7688.md](gap_analysis/COST-7688.md).
-
----
-
-## 18. ~~Envoy ignores Keycloak `caCertSecretName` (D11)~~ — **CLOSED**
-
-**Source:** [PR #121 review](https://github.com/project-koku/koku-service-operator/pull/121#pullrequestreview-5000508819).
-
-D11 was the *operator* JWKS probe ignoring the CA — closed in #11 / PR #121.
-
-Envoy already mounts `auth.keycloak.tls.caCertSecretName` via
-`CACombineInitContainer` (`/ca-extra` → combined bundle) and uses
-`trusted_ca`. `caCertSecretName` wins over `insecureSkipVerify`. Tests:
-`TestEnvoyDeploymentMountsKeycloakCACert`,
-`TestEnvoyYAMLCASecretWinsOverSkipVerify`. See COST-7688 R2.
-
-**Still open:** Keycloak sync CronJob does not mount that Secret — item #7.

--- a/docs/review-follow-ups.md
+++ b/docs/review-follow-ups.md
@@ -46,6 +46,16 @@ for full analysis including dropped alternatives.
 
 ---
 
+## 5. Controller does not watch StorageClasses — **accepted (wontfix)**
+
+No StorageClass `Watches()`. Discovery re-lists the cluster default on every
+reconcile; a default-SC change is picked up on the next CR event or the
+5-minute drift requeue. Production BYOI sets `spec.global.storageClass` or
+creates no PVCs (PVC builders read spec, not discovered status). Not worth a
+cluster-scoped watch.
+
+---
+
 ## 7. Keycloak sync: mount CA bundle for private-CA Keycloak
 
 **Source:** Code review finding.
@@ -87,9 +97,10 @@ process `deletionTimestamp`. The namespace stays `Terminating` and
 ConsoleLink leaks.
 
 **Documented:** [uninstall.md](install/uninstall.md) — delete the CR, wait
-until it is gone, then the namespace or operator. Lab
-`hack/demo-preprod.sh --reset` and `scripts/install-cmsc.sh` cleanup already
-do this (strip the finalizer only if the operator is already gone).
+until it is gone, then the namespace or operator.
+`hack/demo-preprod.sh --reset` strips the finalizer if the operator is already
+gone. `scripts/install-cmsc.sh` cleanup deletes the CR first but does **not**
+recover a stuck finalizer.
 
 **Still open:** OLM uninstall that removes the CSV before the CR still hits
 the trap. A bundle that deletes (or blocks on) the CR first would close it.

--- a/docs/tasks.md
+++ b/docs/tasks.md
@@ -88,7 +88,6 @@ Short version: bundled infra is dev-only (intentional), profile-based sizing for
 | **Image digest pinning** | Tags are mutable; pin to `tag@sha256:digest` for Dependabot tracking. Priority: before GA. See [review follow-ups](review-follow-ups.md#2-image-digest-pinning). |
 | **`relatedImages` in OLM bundle** | Runtime-constructed images not in CSV `relatedImages`; breaks airgapped deployments. COST-7695. See [review follow-ups](review-follow-ups.md#3-relatedimages-in-olm-bundle-cost-7695). |
 | **RBAC migration/bootstrap code provenance** | Heredoc-embedded Django ORM scripts fail code-provenance audit. Needs `insights-rbac` management commands. See [review follow-ups](review-follow-ups.md#4-rbac-migrationbootstrap-code-provenance). |
-| **`ResolveBootstrapAdmin` fallback values** | Silently substitutes test-fixture IDs (`org1234567`) when CR fields are empty. Pre-existing. See [review follow-ups](review-follow-ups.md#1-resolvebootstrapadmin-silently-substitutes-test-fixture-ids). |
 
 ---
 


### PR DESCRIPTION
## Summary
- Add a customer uninstall guide: delete the `CostManagementServiceConfig` and wait until it is gone before deleting the namespace or operator, plus stuck-`Terminating` recovery.
- Lab and Cluster Bot tear-downs follow that order and **do not** proceed to `oc delete ns` / `make bundle-cleanup` unless `oc get cmsc` returns NotFound (a `--timeout` expiry is not confirmation).
- OLM bundle-testing cleanup uses `--all` so both sample names in that file (`cost-onprem` bundled, `cost-management` BYOI) are covered.
- Recovery notes: OLM `failurePolicy: Fail` webhooks can deny the finalizer patch after the operator Service is gone; `install-cmsc.sh` deletes the CR first but does not strip a stuck finalizer (`hack/demo-preprod.sh --reset` does).
- Drop closed review follow-ups from `docs/review-follow-ups.md` (stable IDs kept; #5 restored as accepted/wontfix) and remove the stale `ResolveBootstrapAdmin` row from `docs/tasks.md`.

## Test plan
- [ ] Skim [docs/install/uninstall.md](docs/install/uninstall.md): CR-first order, NotFound gate, OLM webhook recovery, `--reset` vs `install-cmsc.sh`
- [ ] Paste the Cluster Bot / pre-prod / OLM cleanup fences and confirm they `exit 1` if a CMSC remains
- [ ] Confirm remaining follow-up anchors (`#2-image-digest-pinning`, `#5`, `#12`, `#13`) still resolve