### PR TITLE
Add RBAC API metrics scraping

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,7 +4,7 @@
 *.dll
 *.so
 *.dylib
-bin/*
+/bin
 Dockerfile.cross
 
 # Test binary, built with `go test -c`

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,18 @@
+# Agent instructions
+
+Read [CLAUDE.md](CLAUDE.md) before making changes. It is the authoritative
+guide for repository conventions, testing, and review requirements.
+
+## Worktrees and tests
+
+New Git worktrees do not include the ignored `bin/` directory. Before running
+repository tooling or controller integration tests in a worktree, create the
+machine-local symlink documented in `CLAUDE.md`:
+
+```sh
+ln -s <main-checkout>/bin <worktree>/bin
+```
+
+Use `make test` for the full Go test suite. It selects the envtest assets via
+`KUBEBUILDER_ASSETS`; running the controller package directly without that
+environment can fall back to a missing global Kubebuilder installation.

--- a/docs/helm-vs-operator-comparison.md
+++ b/docs/helm-vs-operator-comparison.md
@@ -1,6 +1,6 @@
 # Helm Chart vs Operator Comparison Report
 
-Updated: 2026-08-25 (remaining gaps only; closed items from 2026-08-21 dropped)
+Updated: 2026-08-30 (remaining gaps only; closed items dropped)
 
 Systematic comparison of `cost-onprem-chart/cost-onprem/` (Helm chart) against
 `koku-service-operator` (operator). Both deploy the same Cost Management
@@ -19,7 +19,6 @@ on-premise stack. This document tracks **open** deviations only.
 | ROS API ServiceMonitor | yes | **MISSING** | **gap** |
 | ROS Processor/Poller ServiceMonitors | yes | **MISSING** | **gap** (need Services first) |
 | Kruize ServiceMonitor | yes (`http` / `/q/metrics`) | builder only, **not applied** | **gap** (COST-8054) |
-| RBAC ServiceMonitor | yes (`http` / `/metrics`) | **MISSING** | **gap** |
 
 ROS API already has a Service with a named `metrics` port and a NetworkPolicy
 that allows gateway (8000) plus OpenShift monitoring (9000). Processor and
@@ -54,14 +53,13 @@ Chart ServiceMonitors still unmatched:
 
 | Target | Chart | Operator |
 |--------|-------|----------|
-| `rbac-api` | port `http`, `/metrics` | none. `RBACAPIService` is `http` only; `RBACAPINetworkPolicy` has no monitoring peer |
 | `ros-api` | port `metrics`, `/metrics` | not in `AppServiceMonitor` (Cost-core SM is API / Masu / Ingress) |
 | `ros-processor` / `ros-recommendation-poller` | port `metrics`, `/metrics` | none (no Services) |
 | `kruize` / `ros-optimization` | port `http`, `/q/metrics` | builder matches chart; not applied until COST-8054. `KruizeNetworkPolicy` has no monitoring peer (chart same), so apply-only will not scrape under default-deny |
 
 Cost-core scrape that **does** work: Koku API, Masu, Ingress (`AppServiceMonitor`
 port `metrics`), Gateway (Envoy admin `/stats/prometheus`), Celery workers,
-operator. Those are not listed as gaps.
+RBAC API (`http` / `/metrics`), and operator. Those are not listed as gaps.
 
 `MonitoringConfig` is still only `Enabled *bool`; scrape interval is hardcoded
 `30s` (chart has `monitoring.scrapeInterval`).
@@ -84,8 +82,7 @@ custom roles.
 
 ## 4. Remaining fixes (priority order)
 
-1. **Add RBAC ServiceMonitor + monitoring peer** on `RBACAPINetworkPolicy` (Cost-core leftover; chart scrapes `http` `/metrics`)
-2. **Add ROS Processor + Poller Services** (prerequisite for scrape; COST-8054)
-3. **Add processor-metrics and poller-metrics NetworkPolicies** (COST-8054)
-4. **Apply ROS API / processor / poller / Kruize ServiceMonitors** when ROS is on (COST-8054; Kruize builder already uses `http` `/q/metrics`). Applying the Kruize SM still will not scrape in a default-deny namespace: `KruizeNetworkPolicy` has no monitoring peer (the chart has the same gap).
-5. **Expose `roleCreateAllowList`** in the RBAC CR section if REST custom roles are required
+1. **Add ROS Processor + Poller Services** (prerequisite for scrape; COST-8054)
+2. **Add processor-metrics and poller-metrics NetworkPolicies** (COST-8054)
+3. **Apply ROS API / processor / poller / Kruize ServiceMonitors** when ROS is on (COST-8054; Kruize builder already uses `http` `/q/metrics`). Applying the Kruize SM still will not scrape in a default-deny namespace: `KruizeNetworkPolicy` has no monitoring peer (the chart has the same gap).
+4. **Expose `roleCreateAllowList`** in the RBAC CR section if REST custom roles are required

--- a/internal/controller/costmanagementserviceconfig_controller.go
+++ b/internal/controller/costmanagementserviceconfig_controller.go
@@ -1036,6 +1036,7 @@ func (r *CostManagementServiceConfigReconciler) reconcileMonitoring(ctx context.
 		resources.GatewayServiceMonitor(cfg),
 		resources.OperatorServiceMonitor(cfg),
 		resources.CeleryServiceMonitor(cfg),
+		resources.RBACServiceMonitor(cfg),
 		resources.PrometheusRules(cfg),
 	}
 

--- a/internal/controller/monitoring_test.go
+++ b/internal/controller/monitoring_test.go
@@ -119,13 +119,14 @@ func TestMonitoringAppliesServiceMonitorAndPrometheusRule(t *testing.T) {
 	if _, err := r.reconcileMonitoring(context.Background(), cfg); err != nil {
 		t.Fatalf("reconcileMonitoring: %v", err)
 	}
-	if len(patchKinds) != 5 ||
+	if len(patchKinds) != 6 ||
 		patchKinds[0] != "ServiceMonitor" ||
 		patchKinds[1] != "ServiceMonitor" ||
 		patchKinds[2] != "ServiceMonitor" ||
 		patchKinds[3] != "ServiceMonitor" ||
-		patchKinds[4] != "PrometheusRule" {
-		t.Errorf("expected App+Gateway+Operator+Celery ServiceMonitors then PrometheusRule, got %v", patchKinds)
+		patchKinds[4] != "ServiceMonitor" ||
+		patchKinds[5] != "PrometheusRule" {
+		t.Errorf("expected App+Gateway+Operator+Celery+RBAC ServiceMonitors then PrometheusRule, got %v", patchKinds)
 	}
 }
 
@@ -175,6 +176,8 @@ func TestMonitoringDisabledDeletesManagedResources(t *testing.T) {
 		testCRName + "-app-metrics":      false,
 		testCRName + "-gateway-metrics":  false,
 		testCRName + "-operator-metrics": false,
+		testCRName + "-celery-metrics":   false,
+		testCRName + "-rbac-metrics":     false,
 		testCRName + "-alerts":           false,
 		testCRName + "-kruize-metrics":   false, // not applied yet (COST-8054); cleanup on disable
 	}

--- a/internal/resources/monitoring.go
+++ b/internal/resources/monitoring.go
@@ -109,6 +109,12 @@ func CeleryServiceMonitor(cfg *costv1alpha1.CostManagementServiceConfig) *unstru
 	return serviceMonitor(cfg, cfg.Name+"-celery-metrics", "metrics", "/metrics", []string{"celery-worker"})
 }
 
+// RBACServiceMonitor scrapes the RBAC API Prometheus endpoint through its
+// existing http Service port.
+func RBACServiceMonitor(cfg *costv1alpha1.CostManagementServiceConfig) *unstructured.Unstructured {
+	return serviceMonitor(cfg, cfg.Name+"-rbac-metrics", "http", "/metrics", []string{"rbac-api"})
+}
+
 // PrometheusRules returns UWM-evaluable alert rules (COST-8108 option B gauges +
 // App/operator scrape series). Condition alerts use costmanagement_condition.
 // Deferred until emit paths exist: SecretRotated / DriftCorrected (COST-7694 / G4).

--- a/internal/resources/monitoring_test.go
+++ b/internal/resources/monitoring_test.go
@@ -317,6 +317,41 @@ func TestCeleryServiceMonitor(t *testing.T) {
 	}
 }
 
+func TestRBACServiceMonitor(t *testing.T) {
+	sm := RBACServiceMonitor(testMonitoringCFG())
+	if sm.GetName() != "cost-management-rbac-metrics" {
+		t.Errorf("name: got %q", sm.GetName())
+	}
+
+	endpoints, found, err := unstructured.NestedSlice(sm.Object, "spec", "endpoints")
+	if err != nil || !found || len(endpoints) != 1 {
+		t.Fatalf("endpoints: found=%v len=%d err=%v", found, len(endpoints), err)
+	}
+	ep, ok := endpoints[0].(map[string]any)
+	if !ok {
+		t.Fatalf("endpoint type %T", endpoints[0])
+	}
+	if ep["port"] != "http" {
+		t.Errorf("port: got %v want http", ep["port"])
+	}
+	if ep["path"] != "/metrics" {
+		t.Errorf("path: got %v want /metrics", ep["path"])
+	}
+
+	exprs, found, err := unstructured.NestedSlice(sm.Object, "spec", "selector", "matchExpressions")
+	if err != nil || !found || len(exprs) != 1 {
+		t.Fatalf("matchExpressions: found=%v len=%d err=%v", found, len(exprs), err)
+	}
+	expr, ok := exprs[0].(map[string]any)
+	if !ok {
+		t.Fatalf("expression type %T", exprs[0])
+	}
+	values, ok := expr["values"].([]any)
+	if !ok || len(values) != 1 || values[0] != "rbac-api" {
+		t.Fatalf("selector values = %v, want [rbac-api]", values)
+	}
+}
+
 func TestPrometheusRules_CeleryBacklogIdentifiesQueue(t *testing.T) {
 	pr := PrometheusRules(testMonitoringCFG())
 

--- a/internal/resources/networkpolicies.go
+++ b/internal/resources/networkpolicies.go
@@ -136,13 +136,15 @@ func KruizeNetworkPolicy(cfg *costv1alpha1.CostManagementServiceConfig) *network
 // -----------------------------------------------------------------------------
 
 // RBACAPINetworkPolicy allows the gateway, koku-api, masu, and ros-api to
-// call the RBAC service for authorization checks.
+// call the RBAC service for authorization checks, and Prometheus to scrape
+// its metrics endpoint.
 func RBACAPINetworkPolicy(cfg *costv1alpha1.CostManagementServiceConfig) *networkingv1.NetworkPolicy {
 	return netpol(cfg, cfg.Name+"-rbac-api", "rbac-api", []networkingv1.NetworkPolicyIngressRule{
 		podFrom(cfg, "gateway", rbacAPIPort),
 		podFrom(cfg, "cost-management-api", rbacAPIPort),
 		podFrom(cfg, "cost-processor", rbacAPIPort),
 		podFrom(cfg, "ros-api", rbacAPIPort),
+		monitoringFrom(rbacAPIPort),
 	})
 }
 

--- a/internal/resources/networkpolicies.go
+++ b/internal/resources/networkpolicies.go
@@ -74,6 +74,34 @@ func monitoringFrom(port int32) networkingv1.NetworkPolicyIngressRule {
 	}
 }
 
+// prometheusFrom allows only the OpenShift platform and user-workload
+// Prometheus pods to scrape a port. Use this for a metrics endpoint that
+// shares its listener with application routes, because NetworkPolicy cannot
+// restrict access by HTTP path.
+func prometheusFrom(port int32) networkingv1.NetworkPolicyIngressRule {
+	return networkingv1.NetworkPolicyIngressRule{
+		From: []networkingv1.NetworkPolicyPeer{
+			{
+				NamespaceSelector: &metav1.LabelSelector{
+					MatchLabels: map[string]string{"kubernetes.io/metadata.name": "openshift-monitoring"},
+				},
+				PodSelector: &metav1.LabelSelector{
+					MatchLabels: map[string]string{"app.kubernetes.io/name": "prometheus"},
+				},
+			},
+			{
+				NamespaceSelector: &metav1.LabelSelector{
+					MatchLabels: map[string]string{"kubernetes.io/metadata.name": "openshift-user-workload-monitoring"},
+				},
+				PodSelector: &metav1.LabelSelector{
+					MatchLabels: map[string]string{"app.kubernetes.io/name": "prometheus"},
+				},
+			},
+		},
+		Ports: []networkingv1.NetworkPolicyPort{tcpPort(port)},
+	}
+}
+
 // -----------------------------------------------------------------------------
 // Gateway (Envoy JWT proxy)
 // -----------------------------------------------------------------------------
@@ -144,7 +172,7 @@ func RBACAPINetworkPolicy(cfg *costv1alpha1.CostManagementServiceConfig) *networ
 		podFrom(cfg, "cost-management-api", rbacAPIPort),
 		podFrom(cfg, "cost-processor", rbacAPIPort),
 		podFrom(cfg, "ros-api", rbacAPIPort),
-		monitoringFrom(rbacAPIPort),
+		prometheusFrom(rbacAPIPort),
 	})
 }
 

--- a/internal/resources/networkpolicies_test.go
+++ b/internal/resources/networkpolicies_test.go
@@ -90,7 +90,7 @@ func TestRBACAPINetworkPolicy(t *testing.T) {
 	var monitoring *networkingv1.NetworkPolicyIngressRule
 	for i := range np.Spec.Ingress {
 		rule := &np.Spec.Ingress[i]
-		if ruleHasNamespaceLabel(*rule, "network.openshift.io/policy-group", "monitoring") {
+		if ruleHasNamespaceLabel(*rule, "kubernetes.io/metadata.name", "openshift-user-workload-monitoring") {
 			monitoring = rule
 			break
 		}
@@ -101,8 +101,31 @@ func TestRBACAPINetworkPolicy(t *testing.T) {
 	if !ingressRuleAllowsPort(*monitoring, rbacAPIPort) {
 		t.Errorf("monitoring rule missing RBAC API port %d", rbacAPIPort)
 	}
-	if len(monitoring.From) != 3 {
-		t.Fatalf("expected 3 monitoring namespace peers, got %d", len(monitoring.From))
+	if len(monitoring.From) != 2 {
+		t.Fatalf("expected 2 Prometheus peers, got %d", len(monitoring.From))
+	}
+	wantNamespaces := map[string]bool{
+		"openshift-monitoring":               false,
+		"openshift-user-workload-monitoring": false,
+	}
+	for _, peer := range monitoring.From {
+		if peer.NamespaceSelector == nil || peer.PodSelector == nil {
+			t.Fatal("monitoring peer must select both a namespace and Prometheus pods")
+		}
+		if peer.PodSelector.MatchLabels["app.kubernetes.io/name"] != "prometheus" {
+			t.Errorf("monitoring pod selector = %v, want app.kubernetes.io/name=prometheus", peer.PodSelector.MatchLabels)
+		}
+		namespace := peer.NamespaceSelector.MatchLabels["kubernetes.io/metadata.name"]
+		if _, ok := wantNamespaces[namespace]; !ok {
+			t.Errorf("unexpected monitoring namespace selector %v", peer.NamespaceSelector.MatchLabels)
+			continue
+		}
+		wantNamespaces[namespace] = true
+	}
+	for namespace, found := range wantNamespaces {
+		if !found {
+			t.Errorf("missing Prometheus peer for namespace %q", namespace)
+		}
 	}
 }
 

--- a/internal/resources/networkpolicies_test.go
+++ b/internal/resources/networkpolicies_test.go
@@ -86,6 +86,24 @@ func TestRBACAPINetworkPolicy(t *testing.T) {
 			t.Errorf("missing peer component %q", comp)
 		}
 	}
+
+	var monitoring *networkingv1.NetworkPolicyIngressRule
+	for i := range np.Spec.Ingress {
+		rule := &np.Spec.Ingress[i]
+		if ruleHasNamespaceLabel(*rule, "network.openshift.io/policy-group", "monitoring") {
+			monitoring = rule
+			break
+		}
+	}
+	if monitoring == nil {
+		t.Fatal("missing monitoring ingress rule")
+	}
+	if !ingressRuleAllowsPort(*monitoring, rbacAPIPort) {
+		t.Errorf("monitoring rule missing RBAC API port %d", rbacAPIPort)
+	}
+	if len(monitoring.From) != 3 {
+		t.Fatalf("expected 3 monitoring namespace peers, got %d", len(monitoring.From))
+	}
 }
 
 func TestMasuNetworkPolicy(t *testing.T) {


### PR DESCRIPTION
## Jira

Follow-up to closed [COST-7692](https://redhat.atlassian.net/browse/COST-7692). No separate Jira ticket exists yet for this code-gap correction.

## Summary

- add a ServiceMonitor for the RBAC API `http` port at `/metrics`
- reconcile and clean up that ServiceMonitor with the existing monitoring resources
- allow platform and user-workload Prometheus to reach RBAC on port 8080
- update the Helm-versus-operator gap report to mark RBAC metrics scraping complete
- document worktree `bin/` setup for envtest and ignore the local symlink

## Test plan

- [x] `go test ./internal/resources`
- [x] `go test ./internal/controller -run "^TestMonitoring"`
- [x] `make test` (generation, formatting, vetting, envtest setup, and all non-e2e Go tests)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Add an RBAC API `ServiceMonitor` for the `http` port at `/metrics`.
- Reconcile the `ServiceMonitor` when monitoring is enabled and remove it when monitoring is disabled.
- Allow platform and user-workload Prometheus pods to access the RBAC API on port 8080.
- Restrict RBAC API monitoring ingress to Prometheus pods in the supported monitoring namespaces.
- Update the Helm-versus-operator comparison for the completed COST-7692 work.
- No CRD API or user-visible status condition changes.
- Document the worktree `bin/` symlink required for envtest and update `.gitignore`.

Tests completed: `go test ./internal/resources`, monitoring controller tests, and `make test`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->