### PR TITLE
[COST-7592] Add flush-rbac-cache script for immediate RBAC cache invalidation

### DIFF
--- a/docs/install/README.md
+++ b/docs/install/README.md
@@ -19,6 +19,7 @@ namespace** as the CR (OwnNamespace). See [quickstart.md](quickstart.md#install-
 | [Production](production.md) | You are sizing, hardening TLS, and planning backup for a lasting deploy |
 | [Uninstall](uninstall.md) | You need to remove a CR, the operator, or the namespace without getting stuck in `Terminating` |
 | [CMMO](cmmo.md) | You need reporting clusters to upload metrics into this instance |
+| [RBAC cache flush](../operations/rbac-cache.md) | Permission changes need immediate effect (skip 300s TTL) |
 
 Each guide is self-contained. The quickstart clock starts **after**
 prerequisites and the operator are in place.

--- a/docs/operations/rbac-cache.md
+++ b/docs/operations/rbac-cache.md
@@ -3,10 +3,11 @@
 After RBAC permission changes (role assignments, group membership, policy
 updates), permission checks may stay stale until caches expire.
 
-| Cache | Where | Default TTL | Effect |
-|-------|-------|-------------|--------|
-| insights-rbac Django cache | RBAC API pod | varies | Stale RBAC query results |
-| Koku RBAC response cache | Valkey/Redis | 300s (`RBAC_CACHE_TIMEOUT`) | Stale `/access/` responses |
+| Cache | Where | Redis DB | Default TTL | Effect |
+|-------|-------|----------|-------------|--------|
+| insights-rbac **AccessCache** | Valkey/Redis | **DB 1** (`rbac::policy::...`) | 600s | Stale authorization policy data |
+| insights-rbac Django `CACHES` | Valkey/Redis | **DB 2** | varies | Stale ORM/query cache |
+| Koku RBAC response cache | Valkey/Redis | shared instance | 300s (`RBAC_CACHE_TIMEOUT`) | Stale `/access/` responses |
 
 For most operations the TTL is enough. Flush manually only when you need
 **immediate** effect (revocation, demo, troubleshooting).
@@ -36,17 +37,37 @@ Options:
 
 ## What the script does
 
-1. **Django cache** — `kubectl exec` into the `rbac-api` pod and run
-   `cache.clear()` via `manage.py shell`.
-2. **Valkey cache** — `valkey-cli FLUSHALL` in the bundled cache pod
+1. **Django-side flush** — `kubectl exec` into the `rbac-api` pod and run:
+   - `cache.clear()` — Django `CACHES` (Redis DB 2)
+   - `purge_cache_for_all_tenants()` from `management.seeds` — AccessCache (Redis DB 1)
+
+   This matches pytest/bootstrap for `cache.clear()` and adds the AccessCache
+   purge that matters when Valkey is not reachable from the namespace.
+
+2. **Valkey flush** — `valkey-cli FLUSHALL` in the bundled cache pod
    (`app.kubernetes.io/component=cache`, with fallback to `valkey` for older
-   installs).
+   installs). `FLUSHALL` clears **all** Redis databases on that instance,
+   including AccessCache (DB 1) and Koku RBAC responses.
+
+### When `--django-only` is not enough
+
+`--django-only` runs the Django-side flush above but does **not** call Koku's
+cached `/access/` responses (300s TTL) unless you also flush Valkey. On bundled
+dev/CI installs, use the full script (default) so `FLUSHALL` covers DB 1 and
+Koku.
+
+On BYOI (`spec.cache.deploy: false`), Valkey often lives in another namespace
+(for example `cost-byoi-infra`). The script exits 0 after the Django flush and
+prints manual instructions — you must flush the external endpoint for immediate
+Koku effect.
 
 ## External cache (BYOI / production)
 
-When `spec.cache.deploy: false`, there is no Valkey pod in the namespace. The
-script clears the Django cache and prints instructions to flush the external
-Redis/Valkey endpoint yourself:
+When `spec.cache.deploy: false`, there is no Valkey pod in the application
+namespace. The script:
+
+1. Clears Django cache + AccessCache via the rbac-api pod
+2. Prints instructions to flush the external Redis/Valkey endpoint
 
 ```bash
 # Read password from the cache Secret — do not pass it via -a (exposes in shell history/ps)
@@ -60,6 +81,19 @@ unset REDISCLI_AUTH
 
 Use credentials from `spec.cache.auth.secretName` (key `redis-password`). Add
 TLS flags when `spec.cache.tls.enabled` is true.
+
+If you cannot run `FLUSHALL` on a shared production Valkey, wait for TTL expiry
+(AccessCache 600s, Koku RBAC 300s) or coordinate a maintenance window.
+
+## Exit codes
+
+| Outcome | Exit code |
+|---------|-----------|
+| Both steps succeeded | 0 |
+| Django flush failed | 1 |
+| Bundled Valkey pod found but `FLUSHALL` failed | 1 |
+| BYOI — no bundled Valkey pod (manual flush required) | 0 (warning printed) |
+| `--valkey-only` with no bundled pod | 0 (manual instructions printed) |
 
 ## Warning: FLUSHALL
 
@@ -78,7 +112,7 @@ RBAC_POD=$(oc get pod -l app.kubernetes.io/component=rbac-api -n <namespace> \
 
 oc exec -n <namespace> "$RBAC_POD" -- \
   python manage.py shell -c \
-  "from django.core.cache import cache; cache.clear(); print('RBAC cache cleared')"
+  "from django.core.cache import cache; from management.seeds import purge_cache_for_all_tenants; cache.clear(); purge_cache_for_all_tenants(); print('RBAC and AccessCache cleared')"
 
 VALKEY_POD=$(oc get pod -l app.kubernetes.io/component=cache -n <namespace> \
   -o jsonpath='{.items[0].metadata.name}')

--- a/docs/operations/rbac-cache.md
+++ b/docs/operations/rbac-cache.md
@@ -1,0 +1,86 @@
+# RBAC cache flush
+
+After RBAC permission changes (role assignments, group membership, policy
+updates), permission checks may stay stale until caches expire.
+
+| Cache | Where | Default TTL | Effect |
+|-------|-------|-------------|--------|
+| insights-rbac Django cache | RBAC API pod | varies | Stale RBAC query results |
+| Koku RBAC response cache | Valkey/Redis | 300s (`RBAC_CACHE_TIMEOUT`) | Stale `/access/` responses |
+
+For most operations the TTL is enough. Flush manually only when you need
+**immediate** effect (revocation, demo, troubleshooting).
+
+## One-command flush (recommended)
+
+From the repository root, with `oc` or `kubectl` logged into the cluster:
+
+```bash
+./scripts/flush-rbac-cache.sh cost-onprem
+```
+
+Operator-managed stacks often set `app.kubernetes.io/instance` to the CMSC name.
+When multiple CMSCs share a namespace, pass `--instance`:
+
+```bash
+./scripts/flush-rbac-cache.sh cost-onprem --instance cost-onprem
+```
+
+Options:
+
+```bash
+./scripts/flush-rbac-cache.sh cost-onprem --dry-run
+./scripts/flush-rbac-cache.sh cost-onprem --django-only
+./scripts/flush-rbac-cache.sh cost-onprem --valkey-only
+```
+
+## What the script does
+
+1. **Django cache** — `kubectl exec` into the `rbac-api` pod and run
+   `cache.clear()` via `manage.py shell`.
+2. **Valkey cache** — `valkey-cli FLUSHALL` in the bundled cache pod
+   (`app.kubernetes.io/component=cache`, with fallback to `valkey` for older
+   installs).
+
+## External cache (BYOI / production)
+
+When `spec.cache.deploy: false`, there is no Valkey pod in the namespace. The
+script clears the Django cache and prints instructions to flush the external
+Redis/Valkey endpoint yourself:
+
+```bash
+valkey-cli -h <host> -p <port> -a '<password>' FLUSHALL
+```
+
+Use credentials from `spec.cache.auth.secretName` (key `redis-password`). Add
+TLS flags when `spec.cache.tls.enabled` is true.
+
+## Warning: FLUSHALL
+
+`FLUSHALL` removes **all** keys in the Valkey database, including Celery task
+metadata. This is acceptable for the bundled dev/CI cache (dedicated to the
+Cost stack). For shared production Valkey, prefer waiting for TTL expiry or
+coordinate a maintenance window.
+
+## Manual fallback
+
+If the script is unavailable:
+
+```bash
+RBAC_POD=$(oc get pod -l app.kubernetes.io/component=rbac-api -n <namespace> \
+  -o jsonpath='{.items[0].metadata.name}')
+
+oc exec -n <namespace> "$RBAC_POD" -- \
+  python manage.py shell -c \
+  "from django.core.cache import cache; cache.clear(); print('RBAC cache cleared')"
+
+VALKEY_POD=$(oc get pod -l app.kubernetes.io/component=cache -n <namespace> \
+  -o jsonpath='{.items[0].metadata.name}')
+
+oc exec -n <namespace> "$VALKEY_POD" -- valkey-cli FLUSHALL
+```
+
+## Related
+
+- [COST-7592](https://redhat.atlassian.net/browse/COST-7592) — dedicated flush script
+- Chart equivalent: `cost-onprem-chart` `docs/operations/rbac-setup.md`

--- a/docs/operations/rbac-cache.md
+++ b/docs/operations/rbac-cache.md
@@ -49,7 +49,13 @@ script clears the Django cache and prints instructions to flush the external
 Redis/Valkey endpoint yourself:
 
 ```bash
-valkey-cli -h <host> -p <port> -a '<password>' FLUSHALL
+# Read password from the cache Secret — do not pass it via -a (exposes in shell history/ps)
+export REDISCLI_AUTH="$(
+  oc get secret <secret> -n <namespace> \
+    -o jsonpath='{.data.redis-password}' | base64 -d
+)"
+valkey-cli -h <host> -p <port> FLUSHALL
+unset REDISCLI_AUTH
 ```
 
 Use credentials from `spec.cache.auth.secretName` (key `redis-password`). Add

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -13,6 +13,7 @@ Automation scripts for deploying, configuring, and testing the Cost Management O
 | `deploy-rhbk.sh` | Deploy Red Hat Build of Keycloak | OpenShift |
 | `setup-cost-mgmt-tls.sh` | Configure TLS certificates | OpenShift |
 | `query-kruize.sh` | Query Kruize database | All environments |
+| `flush-rbac-cache.sh` | Flush insights-rbac + Koku RBAC caches after permission changes | OpenShift |
 
 ## 🚀 Quick Start
 
@@ -391,6 +392,22 @@ Query Kruize database for experiments and recommendations.
 - Database pod accessible via `oc exec`
 
 **Best for:** Debugging, validating data flow, checking recommendation generation status
+
+---
+
+### `flush-rbac-cache.sh`
+Flush insights-rbac Django cache and Koku RBAC response cache after permission changes.
+
+**Usage:**
+```bash
+./flush-rbac-cache.sh cost-onprem
+./flush-rbac-cache.sh cost-onprem --instance cost-onprem
+./flush-rbac-cache.sh cost-onprem --dry-run
+```
+
+See [docs/operations/rbac-cache.md](../docs/operations/rbac-cache.md) for BYOI/external cache notes.
+
+**Best for:** Immediate effect after RBAC role/group changes (when 300s TTL is too slow)
 
 ---
 

--- a/scripts/flush-rbac-cache.sh
+++ b/scripts/flush-rbac-cache.sh
@@ -137,11 +137,19 @@ flush_django_cache() {
         return 0
     fi
 
-    if ! "$kubecli" exec -n "$NAMESPACE" "$rbac_pod" -- "${manage_py_cmd[@]}"; then
-        log_warn "manage.py not found on default PATH; retrying with /opt/rbac/rbac/manage.py"
-        "$kubecli" exec -n "$NAMESPACE" "$rbac_pod" -- "${fallback_cmd[@]}"
+    if "$kubecli" exec -n "$NAMESPACE" "$rbac_pod" -- "${manage_py_cmd[@]}"; then
+        log_success "insights-rbac Django cache cleared"
+        return 0
     fi
-    log_success "insights-rbac Django cache cleared"
+
+    log_warn "manage.py not found on default PATH; retrying with /opt/rbac/rbac/manage.py"
+    if "$kubecli" exec -n "$NAMESPACE" "$rbac_pod" -- "${fallback_cmd[@]}"; then
+        log_success "insights-rbac Django cache cleared"
+        return 0
+    fi
+
+    log_error "Failed to clear insights-rbac Django cache"
+    return 1
 }
 
 flush_valkey_cache() {
@@ -169,8 +177,13 @@ flush_valkey_cache() {
     fi
 
     log_warn "valkey-cli failed; retrying with redis-cli FLUSHALL"
-    "$kubecli" exec -n "$NAMESPACE" "$valkey_pod" -- redis-cli FLUSHALL
-    log_success "Valkey cache flushed (redis-cli)"
+    if "$kubecli" exec -n "$NAMESPACE" "$valkey_pod" -- redis-cli FLUSHALL; then
+        log_success "Valkey cache flushed (redis-cli)"
+        return 0
+    fi
+
+    log_error "Failed to flush Valkey cache"
+    return 1
 }
 
 parse_args() {

--- a/scripts/flush-rbac-cache.sh
+++ b/scripts/flush-rbac-cache.sh
@@ -58,8 +58,16 @@ Notes:
   - Bundled Valkey is flushed via valkey-cli FLUSHALL in-cluster (dev/CI).
   - External cache (BYOI) has no local pod; the script prints manual instructions.
   - FLUSHALL clears all Valkey keys, including Celery metadata.
+  - Django flush runs cache.clear() and purge_cache_for_all_tenants() (AccessCache).
 EOF
 }
+
+# flush_valkey_cache: 0 = success, 1 = pod found but flush failed, 2 = no bundled pod (BYOI skip)
+readonly VALKEY_OK=0
+readonly VALKEY_FAILED=1
+readonly VALKEY_SKIPPED=2
+
+DJANGO_SHELL_FLUSH='from django.core.cache import cache; from management.seeds import purge_cache_for_all_tenants; cache.clear(); purge_cache_for_all_tenants(); print("RBAC and AccessCache cleared")'
 
 detect_kubecli() {
     if [[ -n "${KUBECLI:-}" ]]; then
@@ -114,12 +122,10 @@ flush_django_cache() {
     local kubecli="$1"
     local rbac_pod
     local manage_py_cmd=(
-        python manage.py shell -c
-        "from django.core.cache import cache; cache.clear(); print('RBAC cache cleared')"
+        python manage.py shell -c "$DJANGO_SHELL_FLUSH"
     )
     local fallback_cmd=(
-        python /opt/rbac/rbac/manage.py shell -c
-        "from django.core.cache import cache; cache.clear(); print('RBAC cache cleared')"
+        python /opt/rbac/rbac/manage.py shell -c "$DJANGO_SHELL_FLUSH"
     )
 
     rbac_pod="$(get_pod_by_component "$kubecli" "rbac-api")"
@@ -138,13 +144,13 @@ flush_django_cache() {
     fi
 
     if "$kubecli" exec -n "$NAMESPACE" "$rbac_pod" -- "${manage_py_cmd[@]}"; then
-        log_success "insights-rbac Django cache cleared"
+        log_success "insights-rbac Django cache and AccessCache cleared"
         return 0
     fi
 
     log_warn "manage.py not found on default PATH; retrying with /opt/rbac/rbac/manage.py"
     if "$kubecli" exec -n "$NAMESPACE" "$rbac_pod" -- "${fallback_cmd[@]}"; then
-        log_success "insights-rbac Django cache cleared"
+        log_success "insights-rbac Django cache and AccessCache cleared"
         return 0
     fi
 
@@ -162,7 +168,7 @@ flush_valkey_cache() {
         echo "  valkey-cli -h <host> -p <port> FLUSHALL"
         echo "  # or: redis-cli -h <host> -p <port> FLUSHALL"
         echo "See docs/operations/rbac-cache.md for details."
-        return 1
+        return "$VALKEY_SKIPPED"
     fi
 
     log_info "Flushing Valkey cache in pod ${valkey_pod} (FLUSHALL)..."
@@ -182,8 +188,8 @@ flush_valkey_cache() {
         return 0
     fi
 
-    log_error "Failed to flush Valkey cache"
-    return 1
+    log_error "Failed to flush Valkey cache in pod ${valkey_pod}"
+    return "$VALKEY_FAILED"
 }
 
 parse_args() {
@@ -270,18 +276,24 @@ main() {
 
     if [[ "$django_status" -ne 0 || "$valkey_status" -ne 0 ]]; then
         if [[ "$VALKEY_ONLY" == "true" ]]; then
+            if [[ "$valkey_status" -eq "$VALKEY_SKIPPED" ]]; then
+                exit 0
+            fi
             exit "$valkey_status"
         fi
         if [[ "$DJANGO_ONLY" == "true" ]]; then
             exit "$django_status"
         fi
-        # Django flush is required; Valkey missing is a warning for BYOI.
         if [[ "$django_status" -ne 0 ]]; then
             exit "$django_status"
         fi
-        if [[ "$valkey_status" -ne 0 ]]; then
-            log_warn "Django cache cleared; Valkey flush skipped or failed (see above)"
+        if [[ "$valkey_status" -eq "$VALKEY_SKIPPED" ]]; then
+            log_warn "Django cache cleared; bundled Valkey not in namespace (flush external cache manually)"
             exit 0
+        fi
+        if [[ "$valkey_status" -eq "$VALKEY_FAILED" ]]; then
+            log_error "Django cache cleared but Valkey FLUSHALL failed — authorization may still be stale"
+            exit 1
         fi
     fi
 

--- a/scripts/flush-rbac-cache.sh
+++ b/scripts/flush-rbac-cache.sh
@@ -1,0 +1,278 @@
+#!/usr/bin/env bash
+#
+# Flush insights-rbac Django cache and Koku RBAC response cache (Valkey).
+#
+# Use after RBAC permission changes when immediate effect is required.
+# For most cases the 300s TTL is enough without manual intervention.
+#
+# Usage:
+#   ./scripts/flush-rbac-cache.sh <namespace> [options]
+#
+# Examples:
+#   ./scripts/flush-rbac-cache.sh cost-onprem
+#   ./scripts/flush-rbac-cache.sh cost-onprem --instance cost-onprem
+#   NAMESPACE=cost-onprem ./scripts/flush-rbac-cache.sh
+#   ./scripts/flush-rbac-cache.sh cost-onprem --django-only
+#
+set -euo pipefail
+
+SCRIPT_NAME="$(basename "$0")"
+NAMESPACE="${NAMESPACE:-}"
+INSTANCE="${INSTANCE:-}"
+DJANGO_ONLY=false
+VALKEY_ONLY=false
+DRY_RUN=false
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+BLUE='\033[0;34m'
+NC='\033[0m'
+
+log_info() { echo -e "${BLUE}[${SCRIPT_NAME}]${NC} $*"; }
+log_success() { echo -e "${GREEN}[${SCRIPT_NAME}]${NC} $*"; }
+log_warn() { echo -e "${YELLOW}[${SCRIPT_NAME}]${NC} $*"; }
+log_error() { echo -e "${RED}[${SCRIPT_NAME}]${NC} $*" >&2; }
+
+usage() {
+    cat <<EOF
+Usage: ${SCRIPT_NAME} [namespace] [options]
+
+Flush insights-rbac Django cache and Koku RBAC response cache in Valkey.
+
+Arguments:
+  namespace             Target namespace (or set NAMESPACE)
+
+Options:
+  --instance <name>     Filter pods by app.kubernetes.io/instance (operator CMSC name)
+  --django-only         Flush only the insights-rbac Django cache
+  --valkey-only         Flush only the Valkey cache
+  --dry-run             Print actions without executing them
+  -h, --help            Show this help
+
+Environment:
+  NAMESPACE             Default namespace when omitted on the command line
+  KUBECLI               kubectl or oc binary (default: auto-detect oc, then kubectl)
+
+Notes:
+  - Bundled Valkey is flushed via valkey-cli FLUSHALL in-cluster (dev/CI).
+  - External cache (BYOI) has no local pod; the script prints manual instructions.
+  - FLUSHALL clears all Valkey keys, including Celery metadata.
+EOF
+}
+
+detect_kubecli() {
+    if [[ -n "${KUBECLI:-}" ]]; then
+        echo "$KUBECLI"
+        return
+    fi
+    if command -v oc >/dev/null 2>&1; then
+        echo "oc"
+        return
+    fi
+    if command -v kubectl >/dev/null 2>&1; then
+        echo "kubectl"
+        return
+    fi
+    log_error "Neither oc nor kubectl found in PATH (set KUBECLI to override)"
+    exit 1
+}
+
+build_label_selector() {
+    local component="$1"
+    local selector="app.kubernetes.io/component=${component}"
+    if [[ -n "$INSTANCE" ]]; then
+        selector="${selector},app.kubernetes.io/instance=${INSTANCE}"
+    fi
+    printf '%s' "$selector"
+}
+
+get_pod_by_component() {
+    local kubecli="$1"
+    local component="$2"
+    local selector
+    selector="$(build_label_selector "$component")"
+    "$kubecli" get pods -n "$NAMESPACE" -l "$selector" \
+        -o jsonpath='{.items[0].metadata.name}' 2>/dev/null || true
+}
+
+find_valkey_pod() {
+    local kubecli="$1"
+    local pod
+
+    for component in cache valkey; do
+        pod="$(get_pod_by_component "$kubecli" "$component")"
+        if [[ -n "$pod" ]]; then
+            printf '%s' "$pod"
+            return 0
+        fi
+    done
+    return 1
+}
+
+flush_django_cache() {
+    local kubecli="$1"
+    local rbac_pod
+    local manage_py_cmd=(
+        python manage.py shell -c
+        "from django.core.cache import cache; cache.clear(); print('RBAC cache cleared')"
+    )
+    local fallback_cmd=(
+        python /opt/rbac/rbac/manage.py shell -c
+        "from django.core.cache import cache; cache.clear(); print('RBAC cache cleared')"
+    )
+
+    rbac_pod="$(get_pod_by_component "$kubecli" "rbac-api")"
+    if [[ -z "$rbac_pod" ]]; then
+        log_error "No rbac-api pod found in namespace '${NAMESPACE}'"
+        if [[ -n "$INSTANCE" ]]; then
+            log_error "Check --instance '${INSTANCE}' or omit it to match any instance"
+        fi
+        return 1
+    fi
+
+    log_info "Flushing insights-rbac Django cache in pod ${rbac_pod}..."
+    if [[ "$DRY_RUN" == "true" ]]; then
+        log_info "[dry-run] ${kubecli} exec -n ${NAMESPACE} ${rbac_pod} -- ${manage_py_cmd[*]}"
+        return 0
+    fi
+
+    if ! "$kubecli" exec -n "$NAMESPACE" "$rbac_pod" -- "${manage_py_cmd[@]}"; then
+        log_warn "manage.py not found on default PATH; retrying with /opt/rbac/rbac/manage.py"
+        "$kubecli" exec -n "$NAMESPACE" "$rbac_pod" -- "${fallback_cmd[@]}"
+    fi
+    log_success "insights-rbac Django cache cleared"
+}
+
+flush_valkey_cache() {
+    local kubecli="$1"
+    local valkey_pod
+
+    if ! valkey_pod="$(find_valkey_pod "$kubecli")"; then
+        log_warn "No bundled Valkey pod found (labels: component=cache or component=valkey)"
+        log_warn "If you use external cache (BYOI), flush manually against your Redis/Valkey endpoint:"
+        echo "  valkey-cli -h <host> -p <port> FLUSHALL"
+        echo "  # or: redis-cli -h <host> -p <port> FLUSHALL"
+        echo "See docs/operations/rbac-cache.md for details."
+        return 1
+    fi
+
+    log_info "Flushing Valkey cache in pod ${valkey_pod} (FLUSHALL)..."
+    if [[ "$DRY_RUN" == "true" ]]; then
+        log_info "[dry-run] ${kubecli} exec -n ${NAMESPACE} ${valkey_pod} -- valkey-cli FLUSHALL"
+        return 0
+    fi
+
+    if "$kubecli" exec -n "$NAMESPACE" "$valkey_pod" -- valkey-cli FLUSHALL; then
+        log_success "Valkey cache flushed"
+        return 0
+    fi
+
+    log_warn "valkey-cli failed; retrying with redis-cli FLUSHALL"
+    "$kubecli" exec -n "$NAMESPACE" "$valkey_pod" -- redis-cli FLUSHALL
+    log_success "Valkey cache flushed (redis-cli)"
+}
+
+parse_args() {
+    while [[ $# -gt 0 ]]; do
+        case "$1" in
+            -h|--help)
+                usage
+                exit 0
+                ;;
+            --instance)
+                INSTANCE="${2:?--instance requires a value}"
+                shift 2
+                ;;
+            --django-only)
+                DJANGO_ONLY=true
+                shift
+                ;;
+            --valkey-only)
+                VALKEY_ONLY=true
+                shift
+                ;;
+            --dry-run)
+                DRY_RUN=true
+                shift
+                ;;
+            --)
+                shift
+                break
+                ;;
+            -*)
+                log_error "Unknown option: $1"
+                usage >&2
+                exit 1
+                ;;
+            *)
+                if [[ -z "$NAMESPACE" ]]; then
+                    NAMESPACE="$1"
+                else
+                    log_error "Unexpected argument: $1"
+                    usage >&2
+                    exit 1
+                fi
+                shift
+                ;;
+        esac
+    done
+}
+
+main() {
+    parse_args "$@"
+
+    if [[ -z "$NAMESPACE" ]]; then
+        log_error "Namespace is required (argument or NAMESPACE env)"
+        usage >&2
+        exit 1
+    fi
+
+    if [[ "$DJANGO_ONLY" == "true" && "$VALKEY_ONLY" == "true" ]]; then
+        log_error "Use only one of --django-only or --valkey-only"
+        exit 1
+    fi
+
+    local kubecli
+    kubecli="$(detect_kubecli)"
+
+    log_info "Namespace: ${NAMESPACE}"
+    if [[ -n "$INSTANCE" ]]; then
+        log_info "Instance filter: ${INSTANCE}"
+    fi
+    if [[ "$DRY_RUN" == "true" ]]; then
+        log_info "Dry run enabled"
+    fi
+
+    local django_status=0
+    local valkey_status=0
+
+    if [[ "$VALKEY_ONLY" != "true" ]]; then
+        flush_django_cache "$kubecli" || django_status=$?
+    fi
+
+    if [[ "$DJANGO_ONLY" != "true" ]]; then
+        flush_valkey_cache "$kubecli" || valkey_status=$?
+    fi
+
+    if [[ "$django_status" -ne 0 || "$valkey_status" -ne 0 ]]; then
+        if [[ "$VALKEY_ONLY" == "true" ]]; then
+            exit "$valkey_status"
+        fi
+        if [[ "$DJANGO_ONLY" == "true" ]]; then
+            exit "$django_status"
+        fi
+        # Django flush is required; Valkey missing is a warning for BYOI.
+        if [[ "$django_status" -ne 0 ]]; then
+            exit "$django_status"
+        fi
+        if [[ "$valkey_status" -ne 0 ]]; then
+            log_warn "Django cache cleared; Valkey flush skipped or failed (see above)"
+            exit 0
+        fi
+    fi
+
+    log_success "RBAC cache flush complete — permission changes are active immediately"
+}
+
+main "$@"


### PR DESCRIPTION
## Jira

[COST-7592](https://redhat.atlassian.net/browse/COST-7592)

## Summary

- Add `scripts/flush-rbac-cache.sh` to clear insights-rbac Django cache and bundled Valkey in one command
- Document usage, BYOI external-cache fallback, and FLUSHALL caveats in `docs/operations/rbac-cache.md`
- Link from install guide and scripts README

Companion PR: https://github.com/insights-onprem/cost-onprem-chart/pull/258

## Test plan

- [ ] `./scripts/flush-rbac-cache.sh cost-onprem --dry-run` on Cluster Bot / CRC with operator stack
- [ ] Full run after RBAC permission change; verify immediate effect without waiting 300s TTL
- [ ] Confirm BYOI path prints external-cache instructions when no Valkey pod exists
- [ ] Confirm script exits non-zero when both primary and fallback exec commands fail

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Adds `scripts/flush-rbac-cache.sh` to clear the insights-rbac Django cache and bundled Valkey cache.
- Supports dry runs, cache-specific modes, namespace and instance selection, and `oc`/`kubectl` detection.
- Documents BYOI external-cache handling and `FLUSHALL` impact.
- Links the guide from the install documentation and scripts README.

## Operator impact

- CRD API compatibility is unchanged.
- Reconcile-phase behavior is unchanged.
- Operators can apply RBAC permission changes immediately without waiting for the 300-second cache TTL.
- The script reports cache command failures through exit statuses. It provides manual instructions when no bundled Valkey pod exists.
- User-visible status conditions are unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->