### PR TITLE
[COST-8143] Fix deploy-test-cost-onprem.sh lab install and image push

### DIFF
--- a/hack/deploy-incluster.sh
+++ b/hack/deploy-incluster.sh
@@ -89,7 +89,7 @@ spec:
       containers:
       - name: manager
         image: ${IMG}
-        imagePullPolicy: Always
+        imagePullPolicy: IfNotPresent
         command: ["/manager"]
         args:
         - --leader-elect
@@ -130,7 +130,19 @@ spec:
           secretName: ${WEBHOOK_SECRET}
 EOF
 
-oc -n "$NS" rollout status deploy/koku-service-operator --timeout=180s
+# Ceiling only — rollout status returns as soon as the replica is Available.
+# 180s missed this cluster's node-reboot + registry-on-same-node recovery
+# (~5m). Override with DEPLOY_INCLUSTER_TIMEOUT if needed.
+ROLLOUT_TIMEOUT="${DEPLOY_INCLUSTER_TIMEOUT:-300s}"
+echo "[in-cluster] Waiting for Deployment rollout (${ROLLOUT_TIMEOUT})..."
+if ! oc -n "$NS" rollout status deploy/koku-service-operator --timeout="$ROLLOUT_TIMEOUT"; then
+  echo "[ERROR] Operator Deployment did not become ready in ${NS}" >&2
+  oc -n "$NS" get pods -l app.kubernetes.io/name=koku-service-operator -o wide 2>/dev/null || true
+  oc -n "$NS" describe deploy/koku-service-operator 2>/dev/null | tail -50 || true
+  echo "--- recent events ---"
+  oc -n "$NS" get events --sort-by='.lastTimestamp' 2>/dev/null | tail -30 || true
+  exit 1
+fi
 
 echo ""
 echo "Operator is running in ${NS}."

--- a/scripts/deploy-test-cost-onprem.sh
+++ b/scripts/deploy-test-cost-onprem.sh
@@ -26,6 +26,9 @@ set -euo pipefail
 #   --skip-rhbk               Skip Red Hat Build of Keycloak (RHBK) deployment
 #   --skip-kafka              Skip Kafka/AMQ Streams deployment
 #   --skip-helm               Skip COST Helm chart installation
+#   --build                   Build and push the operator image from this checkout.
+#                             Default is to pull quay.io/project-koku/koku-service-operator:v0.0.1
+#                             (or IMG / DEFAULT_OPERATOR_IMG if set).
 #   --skip-tls                Skip TLS certificate setup
 #   --skip-image-override     Skip creating custom values file for image override
 #   --deploy-s4               Deploy S4 (Super Simple Storage Service) for S3-compatible storage
@@ -109,6 +112,9 @@ set -euo pipefail
 #   # Skip RHBK if already deployed
 #   ./deploy-test-cost-onprem.sh --skip-rhbk
 #
+#   # Build and push the operator from this checkout (default is pull only)
+#   ./deploy-test-cost-onprem.sh --build
+#
 #   # Dry run to preview what would execute
 #   ./deploy-test-cost-onprem.sh --dry-run --verbose
 #
@@ -184,6 +190,7 @@ SIZING_PROFILE="${SIZING_PROFILE:-}"
 SKIP_RHBK=false  # Red Hat Build of Keycloak
 SKIP_KAFKA=false
 SKIP_HELM=false
+BUILD_IMAGE="${BUILD_IMAGE:-false}"
 SKIP_TLS=false
 SKIP_TEST=false
 SKIP_GRAFANA_LINKS=${SKIP_GRAFANA_LINKS:-true}  # Skip Grafana snapshot/links (default: skip, local Grafana rarely accessible)
@@ -703,6 +710,7 @@ deploy_helm_chart() {
     export JWT_AUTH_ENABLED="true"
     export USE_LOCAL_CHART="${USE_LOCAL_CHART}"
     export USE_HELM_DEVEL="${USE_HELM_DEVEL}"
+    export BUILD_IMAGE="${BUILD_IMAGE}"
     [[ -n "${CHART_VERSION}" ]] && export CHART_VERSION="${CHART_VERSION}"
     # Note: S3 setup behavior depends on values.yaml configuration:
     # - If objectStorage.endpoint is set: Script skips S3 auto-detection and bucket creation
@@ -1028,6 +1036,13 @@ print_summary() {
     [[ "${SKIP_KAFKA}" == "false" ]] && echo "  ✓ Deploy Kafka/AMQ Streams" || echo "  ✗ Deploy Kafka/AMQ Streams (SKIPPED)"
     [[ "${DEPLOY_S4}" == "true" ]] && echo "  ✓ Deploy S4 Storage (namespace: ${S4_NAMESPACE})" || echo "  ✗ Deploy S4 Storage (OPTIONAL)"
     [[ "${SKIP_HELM}" == "false" ]] && echo "  ✓ Deploy Cost On-Prem Helm Chart" || echo "  ✗ Deploy Cost On-Prem Helm Chart (SKIPPED)"
+    if [[ "${SKIP_HELM}" == "false" ]]; then
+        if [[ "${BUILD_IMAGE}" == "true" ]]; then
+            echo "       operator image: build and push (--build)"
+        else
+            echo "       operator image: pull (pass --build to compile from this checkout)"
+        fi
+    fi
     [[ "${SKIP_TLS}" == "false" ]] && echo "  ✓ Setup TLS Certificates" || echo "  ✗ Setup TLS Certificates (SKIPPED)"
     [[ "${SKIP_TEST}" == "false" ]] && echo "  ✓ Run Chart Tests" || echo "  ✗ Run Chart Tests (SKIPPED)"
     if [[ "${DEPLOY_OBSERVABILITY}" == "true" ]]; then
@@ -1087,6 +1102,10 @@ main() {
                 ;;
             --skip-helm)
                 SKIP_HELM=true
+                shift
+                ;;
+            --build)
+                BUILD_IMAGE=true
                 shift
                 ;;
             --skip-tls)

--- a/scripts/install-cmsc.sh
+++ b/scripts/install-cmsc.sh
@@ -1118,6 +1118,32 @@ preflight_validate() {
     return 0
 }
 
+# Wait until the OwnNamespace operator Deployment is Available.
+# hack/deploy-incluster.sh already runs rollout status; this is a second gate
+# before applying the CMSC so a slow image pull cannot race the CR.
+wait_for_operator() {
+    local ns="$1"
+    local timeout_s="${2:-300}"
+    local deploy="koku-service-operator"
+
+    echo_info "Waiting for operator Deployment ${deploy} in ${ns} (timeout ${timeout_s}s)..."
+    if ! kubectl wait --for=condition=Available "deployment/$deploy" -n "$ns" --timeout="${timeout_s}s"; then
+        echo_error "Timed out waiting for operator deployment ${deploy} in ${ns}"
+        kubectl get pods -n "$ns" -l control-plane=controller-manager 2>/dev/null || true
+        kubectl describe "deployment/$deploy" -n "$ns" 2>/dev/null || true
+        return 1
+    fi
+    echo_success "Operator is ready in ${ns}"
+}
+
+# Lab OwnNamespace path does not register admission webhooks. Remove leftover
+# configs from `make deploy` so they cannot block CMSC apply when the
+# koku-service-operator-system manager is absent or watching the wrong NS.
+remove_make_deploy_webhooks() {
+    kubectl delete mutatingwebhookconfiguration koku-service-operator-mutating-webhook-configuration --ignore-not-found=true >/dev/null 2>&1 || true
+    kubectl delete validatingwebhookconfiguration koku-service-operator-validating-webhook-configuration --ignore-not-found=true >/dev/null 2>&1 || true
+}
+
 # Function to deploy Helm chart
 deploy_helm_chart() {
     echo_info "Deploying Cost Management On Premise Helm chart..."
@@ -1127,39 +1153,55 @@ deploy_helm_chart() {
     local crd_name="costmanagementserviceconfigs.service.costmanagement.openshift.io"
     local sample="${project_root}/config/samples/service.costmanagement_v1alpha1_costmanagementserviceconfig.yaml"
 
-    local operator_ns="koku-service-operator-system"
-    local pull_img="${IMG:-image-registry.openshift-image-registry.svc:5000/${operator_ns}/koku-service-operator:latest}"
-    local registry_host
-    registry_host="$(oc get route default-route -n openshift-image-registry -o jsonpath='{.spec.host}' 2>/dev/null || true)"
-    if [ -z "$registry_host" ]; then
-        echo_info "Enabling OpenShift registry default-route"
-        oc patch configs.imageregistry.operator.openshift.io/cluster --type merge -p '{"spec":{"defaultRoute":true}}' >/dev/null
-        local _i
-        for _i in $(seq 1 60); do
-            registry_host="$(oc get route default-route -n openshift-image-registry -o jsonpath='{.spec.host}' 2>/dev/null || true)"
-            [ -n "$registry_host" ] && break
-            sleep 2
-        done
+    # OwnNamespace: operator install NS must equal the CMSC namespace. Do not
+    # use `make deploy` (scaffolds koku-service-operator-system).
+    local cr_ns="${NAMESPACE:-cost-onprem}"
+    local pull_img="${IMG:-}"
+    if [ -z "$pull_img" ]; then
+        local registry_host
+        registry_host="$(oc get route default-route -n openshift-image-registry -o jsonpath='{.spec.host}' 2>/dev/null || true)"
+        if [ -z "$registry_host" ]; then
+            echo_info "Enabling OpenShift registry default-route"
+            oc patch configs.imageregistry.operator.openshift.io/cluster --type merge -p '{"spec":{"defaultRoute":true}}' >/dev/null
+            local _i
+            for _i in $(seq 1 60); do
+                registry_host="$(oc get route default-route -n openshift-image-registry -o jsonpath='{.spec.host}' 2>/dev/null || true)"
+                [ -n "$registry_host" ] && break
+                sleep 2
+            done
+        fi
+        if [ -z "$registry_host" ]; then
+            echo_error "OpenShift registry default-route not available"
+            return 1
+        fi
+        local build_img="${registry_host}/${cr_ns}/koku-service-operator:latest"
+        kubectl get ns "$cr_ns" >/dev/null 2>&1 || kubectl create ns "$cr_ns"
+        echo_info "Building and pushing operator image: $build_img"
+        if ! (cd "$project_root" && make docker-build IMG="$build_img" && { oc registry login --registry="$registry_host" 2>/dev/null || true; } && oc whoami -t | docker login -u "$(oc whoami)" --password-stdin "$registry_host" && make docker-push IMG="$build_img"); then
+            echo_error "Failed to build/push operator image"
+            return 1
+        fi
+        # Pin by digest so apply changes the Deployment spec ( :latest is a
+        # no-op) and kubelet does not default imagePullPolicy to Always.
+        local digest=""
+        digest="$(docker image inspect "$build_img" --format '{{with index .RepoDigests 0}}{{.}}{{end}}' 2>/dev/null | awk -F@ '{print $2}')"
+        if [ -n "$digest" ]; then
+            pull_img="image-registry.openshift-image-registry.svc:5000/${cr_ns}/koku-service-operator@${digest}"
+            echo_info "Pinning in-cluster operator image to ${pull_img}"
+        else
+            pull_img="image-registry.openshift-image-registry.svc:5000/${cr_ns}/koku-service-operator:latest"
+            echo_warning "Could not resolve image digest; using :latest"
+        fi
+    else
+        echo_info "Using pre-set IMG=$pull_img"
     fi
-    if [ -z "$registry_host" ]; then
-        echo_error "OpenShift registry default-route not available"
+
+    echo_info "Deploying OwnNamespace operator into ${cr_ns} (hack/deploy-incluster.sh)"
+    if ! (cd "$project_root" && IMG="$pull_img" ./hack/deploy-incluster.sh "$cr_ns"); then
+        echo_error "Failed to deploy operator via hack/deploy-incluster.sh"
         return 1
     fi
-    local build_img="${registry_host}/${operator_ns}/koku-service-operator:latest"
-    kubectl get ns "$operator_ns" >/dev/null 2>&1 || kubectl create ns "$operator_ns"
-    echo_info "Building and pushing operator image: $build_img"
-    if ! (cd "$project_root" && make docker-build IMG="$build_img" && { oc registry login --registry="$registry_host" 2>/dev/null || true; } && oc whoami -t | docker login -u "$(oc whoami)" --password-stdin "$registry_host" && make docker-push IMG="$build_img"); then
-        echo_error "Failed to build/push operator image"
-        return 1
-    fi
-    echo_info "CMSC CRD not found — deploying operator (make deploy)"
-    if ! (cd "$project_root" && make deploy IMG="$pull_img"); then
-        echo_error "Failed to deploy operator/CRDs via make deploy"
-        return 1
-    fi
-    # TODO: drop once wait-for init images are not pulled from the operator ImageStream across namespaces
-    echo_info "Granting image-puller so ${NAMESPACE} SAs can pull wait-for init image from ${operator_ns}"
-    oc adm policy add-role-to-group system:image-puller "system:serviceaccounts:${NAMESPACE}" -n "$operator_ns" || true
+    remove_make_deploy_webhooks
     echo_success "Operator/CRDs deployed"
 
     if [ ! -f "$sample" ]; then
@@ -1167,12 +1209,23 @@ deploy_helm_chart() {
         return 1
     fi
 
-    # TODO: remove anyuid SCC grant after operator sets compatible securityContext for bundled DB/cache (fsGroup 26 / PodSecurity)
-    echo_info "Granting anyuid SCC for bundled DB/cache pods"
-    oc adm policy add-scc-to-user anyuid -z default -n "${NAMESPACE:-cost-onprem}" 2>/dev/null || true
+    if ! wait_for_operator "$cr_ns"; then
+        echo_error "Operator not ready in ${cr_ns}; refusing to apply CMSC"
+        return 1
+    fi
 
     echo_info "Applying CMSC sample: $sample"
-    if ! kubectl apply -f "$sample"; then
+    local apply_ok=false
+    local attempt
+    for attempt in 1 2 3 4 5; do
+        if kubectl apply -f "$sample"; then
+            apply_ok=true
+            break
+        fi
+        echo_warning "CMSC apply failed (attempt ${attempt}/5); retrying in 5s"
+        sleep 5
+    done
+    if [ "$apply_ok" != "true" ]; then
         echo_error "Failed to apply CMSC"
         return 1
     fi
@@ -1180,15 +1233,18 @@ deploy_helm_chart() {
     # RHBK advertises the public Route as OIDC issuer even when JWKS uses the
     # in-cluster Service URL. Patch issuerURL from the detected Keycloak hostname
     # so oauth2-proxy / Envoy match tokens without hardcoding a cluster URL in the sample.
+    # oauth2-proxy verifies that issuer with the cluster service CA, which does not
+    # trust the router cert — skip-verify is required for lab Route issuers
+    # (prefer spec.auth.keycloak.tls.caCertSecretName in production).
     local cr_name="${CR_NAME:-cost-onprem}"
     if [ -z "${KEYCLOAK_URL:-}" ]; then
         detect_keycloak || true
     fi
     if [ -n "${KEYCLOAK_URL:-}" ]; then
-        echo_info "Patching CMSC ${cr_name} spec.auth.keycloak.issuerURL=${KEYCLOAK_URL}"
+        echo_info "Patching CMSC ${cr_name} issuerURL=${KEYCLOAK_URL} tls.insecureSkipVerify=true"
         if ! kubectl patch cmsc "$cr_name" -n "$NAMESPACE" --type merge \
-            -p "{\"spec\":{\"auth\":{\"keycloak\":{\"issuerURL\":\"${KEYCLOAK_URL}\"}}}}"; then
-            echo_warning "Failed to patch issuerURL; UI OIDC discovery may fail until set manually"
+            -p "{\"spec\":{\"auth\":{\"keycloak\":{\"issuerURL\":\"${KEYCLOAK_URL}\",\"tls\":{\"insecureSkipVerify\":true}}}}}"; then
+            echo_warning "Failed to patch issuerURL/TLS; UI OIDC discovery may fail until set manually"
         fi
     else
         echo_warning "KEYCLOAK_URL unset — skipping issuerURL patch (set auth.keycloak.issuerURL if UI OIDC fails)"
@@ -1423,23 +1479,27 @@ deploy_helm_chart() {
 wait_for_pods() {
     echo_info "Waiting for pods to be ready..."
 
-    # Wait for CMSC Ready (replaces Helm release pod wait)
+    # Conditions are the machine API. Phase stays Progressing until UIReady
+    # (OAuth client Secret + UI Route admitted), which is not required for day-one.
     local cr_name="${CR_NAME:-cost-onprem}"
     local cr_ns="${NAMESPACE:-cost-onprem}"
     local timeout_s="${HELM_TIMEOUT:-900}"
     timeout_s="${timeout_s%s}"
     local end=$((SECONDS + timeout_s))
-    local phase=""
+    local available=""
     while (( SECONDS < end )); do
-        phase="$(kubectl get cmsc "$cr_name" -n "$cr_ns" -o jsonpath='{.status.phase}' 2>/dev/null || true)"
-        if [ "$phase" = "Ready" ]; then
+        available="$(kubectl get cmsc "$cr_name" -n "$cr_ns" \
+            -o jsonpath='{.status.conditions[?(@.type=="Available")].status}' 2>/dev/null || true)"
+        if [ "$available" = "True" ]; then
             break
         fi
-        echo_info "CMSC phase=${phase:-<empty>} (waiting for Ready)"
+        local phase
+        phase="$(kubectl get cmsc "$cr_name" -n "$cr_ns" -o jsonpath='{.status.phase}' 2>/dev/null || true)"
+        echo_info "CMSC Available=${available:-<empty>} phase=${phase:-<empty>} (waiting for Available=True)"
         sleep 10
     done
-    if [ "$phase" != "Ready" ]; then
-        echo_error "CMSC did not become Ready within ${timeout_s}s"
+    if [ "$available" != "True" ]; then
+        echo_error "CMSC did not become Available within ${timeout_s}s"
         kubectl get cmsc "$cr_name" -n "$cr_ns" -o yaml 2>/dev/null || true
         return 1
     fi
@@ -1559,36 +1619,42 @@ run_health_checks() {
     echo_info "Running health checks..."
 
     local failed_checks=0
+    local ros_enabled
+    ros_enabled="$(kubectl get cmsc "${CR_NAME:-cost-onprem}" -n "$NAMESPACE" \
+        -o jsonpath='{.spec.ros.enabled}' 2>/dev/null || true)"
 
     # Test internal service connectivity first (this should always work)
     echo_info "Testing internal service connectivity..."
 
-    # Test ROS API internally
-    local api_pod=$(kubectl get pods -n "$NAMESPACE" -l app.kubernetes.io/component=ros-api -o jsonpath='{.items[0].metadata.name}' 2>/dev/null)
-    if [ -n "$api_pod" ]; then
-        if kubectl exec -n "$NAMESPACE" "$api_pod" -- curl -f -s http://localhost:8000/status >/dev/null 2>&1; then
-            echo_success "✓ ROS API service is healthy (internal)"
+    if [ "$ros_enabled" = "true" ]; then
+        # Test ROS API internally
+        local api_pod=$(kubectl get pods -n "$NAMESPACE" -l app.kubernetes.io/component=ros-api -o jsonpath='{.items[0].metadata.name}' 2>/dev/null)
+        if [ -n "$api_pod" ]; then
+            if kubectl exec -n "$NAMESPACE" "$api_pod" -- curl -f -s http://localhost:8000/status >/dev/null 2>&1; then
+                echo_success "✓ ROS API service is healthy (internal)"
+            else
+                echo_error "✗ ROS API service is not responding (internal)"
+                failed_checks=$((failed_checks + 1))
+            fi
         else
-            echo_error "✗ ROS API service is not responding (internal)"
+            echo_error "✗ ROS API pod not found"
             failed_checks=$((failed_checks + 1))
         fi
     else
-        echo_error "✗ ROS API pod not found"
-        failed_checks=$((failed_checks + 1))
+        echo_info "Skipping ROS API check (spec.ros.enabled is not true)"
     fi
 
     # Test services via port-forwarding
     echo_info "Testing services via port-forwarding..."
 
-    # Test Ingress API via port-forward
-    # Note: The ingress container listens on port 8081. When JWT auth is enabled, Envoy sidecar
-    # listens on port 8080 and requires authentication. For health checks, connect directly to
-    # the ingress container on port 8081 to bypass JWT authentication.
+    # Test Ingress API via port-forward.
+    # Operator ingress listens on 8080 (INGRESS_WEBPORT). JWT is terminated at
+    # the Envoy gateway, not an ingress sidecar (Helm used 8081 for that).
     echo_info "Testing Ingress API via port-forward..."
     local ingress_pod=$(kubectl get pods -n "$NAMESPACE" -l app.kubernetes.io/component=ingress -o jsonpath='{.items[0].metadata.name}' 2>/dev/null)
     if [ -n "$ingress_pod" ]; then
         local ingress_pf_pid=""
-        kubectl port-forward -n "$NAMESPACE" pod/"$ingress_pod" 18081:8081 --request-timeout=90s >/dev/null 2>&1 &
+        kubectl port-forward -n "$NAMESPACE" pod/"$ingress_pod" 18081:8080 --request-timeout=90s >/dev/null 2>&1 &
         ingress_pf_pid=$!
         sleep 3
         if kill -0 "$ingress_pf_pid" 2>/dev/null && curl -f -s --connect-timeout 60 --max-time 90 http://localhost:18081/ >/dev/null 2>&1; then
@@ -1608,23 +1674,25 @@ run_health_checks() {
         failed_checks=$((failed_checks + 1))
     fi
 
-    # Test Kruize API via port-forward
-    echo_info "Testing Kruize API via port-forward..."
-    local kruize_pf_pid=""
-    kubectl port-forward -n "$NAMESPACE" svc/cost-onprem-kruize 18081:8080 --request-timeout=90s >/dev/null 2>&1 &
-    kruize_pf_pid=$!
-    sleep 3
-    if kill -0 "$kruize_pf_pid" 2>/dev/null && curl -f -s --connect-timeout 60 --max-time 90 http://localhost:18081/listPerformanceProfiles >/dev/null 2>&1; then
-        echo_success "✓ Kruize API service is healthy (port-forward)"
+    if [ "$ros_enabled" = "true" ]; then
+        # Test Kruize API via port-forward
+        echo_info "Testing Kruize API via port-forward..."
+        local kruize_pf_pid=""
+        kubectl port-forward -n "$NAMESPACE" svc/cost-onprem-kruize 18081:8080 --request-timeout=90s >/dev/null 2>&1 &
+        kruize_pf_pid=$!
+        sleep 3
+        if kill -0 "$kruize_pf_pid" 2>/dev/null && curl -f -s --connect-timeout 60 --max-time 90 http://localhost:18081/listPerformanceProfiles >/dev/null 2>&1; then
+            echo_success "✓ Kruize API service is healthy (port-forward)"
+        else
+            echo_error "✗ Kruize API service is not responding (port-forward)"
+            failed_checks=$((failed_checks + 1))
+        fi
+        if [ -n "$kruize_pf_pid" ] && kill -0 "$kruize_pf_pid" 2>/dev/null; then
+            kill "$kruize_pf_pid" 2>/dev/null || true
+            sleep 1
+        fi
     else
-        echo_error "✗ Kruize API service is not responding (port-forward)"
-        failed_checks=$((failed_checks + 1))
-    fi
-    # Cleanup kruize port-forward
-    if [ -n "$kruize_pf_pid" ] && kill -0 "$kruize_pf_pid" 2>/dev/null; then
-        kill "$kruize_pf_pid" 2>/dev/null || true
-        # Wait a moment for process to terminate
-        sleep 1
+        echo_info "Skipping Kruize API check (spec.ros.enabled is not true)"
     fi
 
     # Test external route accessibility (informational only - not counted as failure)

--- a/scripts/install-cmsc.sh
+++ b/scripts/install-cmsc.sh
@@ -24,6 +24,9 @@
 #   S3_CLI_IMAGE    - Container image with AWS CLI for bucket creation (default: amazon/aws-cli:latest)
 #   HELM_FORCE_CONFLICTS - When true, pass --force-conflicts to helm upgrade (SSA field ownership;
 #                          use after kubectl set / oc set image on chart-managed resources)
+#   DOCKER_NO_CACHE - When true, build the operator image with --no-cache (default: false)
+#   DOCKER_PUSH_RETRIES - docker-push attempts after a registry 500 (default: 5)
+#   IMAGESTREAM_API_TIMEOUT - Seconds to wait for image.openshift.io (default: 180)
 #
 # Examples:
 #   # Default (clean output with successes/warnings/errors only)
@@ -1144,6 +1147,84 @@ remove_make_deploy_webhooks() {
     kubectl delete validatingwebhookconfiguration koku-service-operator-validating-webhook-configuration --ignore-not-found=true >/dev/null 2>&1 || true
 }
 
+# The integrated registry creates/reads an ImageStream on docker push. When
+# openshift-apiserver is restarting, that GET returns 503 and docker reports
+# "received unexpected HTTP status: 500 Internal Server Error".
+wait_for_imagestream_api() {
+    local ns="$1"
+    local timeout_s="${2:-${IMAGESTREAM_API_TIMEOUT:-180}}"
+    local end=$((SECONDS + timeout_s))
+
+    echo_info "Waiting for ImageStream API in ${ns} (timeout ${timeout_s}s)..."
+    while (( SECONDS < end )); do
+        if oc get imagestreams.image.openshift.io -n "$ns" >/dev/null 2>&1; then
+            echo_success "ImageStream API is reachable in ${ns}"
+            return 0
+        fi
+        sleep 5
+    done
+    echo_error "ImageStream API not reachable in ${ns} within ${timeout_s}s"
+    return 1
+}
+
+registry_docker_login() {
+    local registry_host="$1"
+    oc registry login --registry="$registry_host" 2>/dev/null || true
+    oc whoami -t | docker login -u "$(oc whoami)" --password-stdin "$registry_host"
+}
+
+# Build the operator image and push to the integrated registry. Push is retried
+# because lab clusters often flap image.openshift.io mid-upload.
+build_and_push_operator_image() {
+    local project_root="$1"
+    local registry_host="$2"
+    local cr_ns="$3"
+    local build_img="$4"
+    local ctool="${CONTAINER_TOOL:-docker}"
+    local retries="${DOCKER_PUSH_RETRIES:-5}"
+    local attempt
+
+    if ! wait_for_imagestream_api "$cr_ns"; then
+        return 1
+    fi
+
+    echo_info "Building operator image: $build_img"
+    if [ "${DOCKER_NO_CACHE:-false}" = "true" ]; then
+        echo_info "DOCKER_NO_CACHE=true — rebuilding without layer cache"
+        if ! (cd "$project_root" && "$ctool" build --no-cache -t "$build_img" .); then
+            echo_error "Failed to build operator image"
+            return 1
+        fi
+    else
+        if ! (cd "$project_root" && make docker-build IMG="$build_img"); then
+            echo_error "Failed to build operator image"
+            return 1
+        fi
+    fi
+
+    if ! registry_docker_login "$registry_host"; then
+        echo_error "Failed to log in to registry ${registry_host}"
+        return 1
+    fi
+
+    for attempt in $(seq 1 "$retries"); do
+        echo_info "Pushing operator image (attempt ${attempt}/${retries}): $build_img"
+        if (cd "$project_root" && make docker-push IMG="$build_img"); then
+            echo_success "Operator image pushed"
+            return 0
+        fi
+        echo_warning "docker-push failed (attempt ${attempt}/${retries})"
+        if [ "$attempt" -ge "$retries" ]; then
+            break
+        fi
+        wait_for_imagestream_api "$cr_ns" || true
+        registry_docker_login "$registry_host" || true
+        sleep $((attempt * 5))
+    done
+    echo_error "Failed to push operator image after ${retries} attempts"
+    return 1
+}
+
 # Function to deploy Helm chart
 deploy_helm_chart() {
     echo_info "Deploying Cost Management On Premise Helm chart..."
@@ -1177,7 +1258,7 @@ deploy_helm_chart() {
         local build_img="${registry_host}/${cr_ns}/koku-service-operator:latest"
         kubectl get ns "$cr_ns" >/dev/null 2>&1 || kubectl create ns "$cr_ns"
         echo_info "Building and pushing operator image: $build_img"
-        if ! (cd "$project_root" && make docker-build IMG="$build_img" && { oc registry login --registry="$registry_host" 2>/dev/null || true; } && oc whoami -t | docker login -u "$(oc whoami)" --password-stdin "$registry_host" && make docker-push IMG="$build_img"); then
+        if ! build_and_push_operator_image "$project_root" "$registry_host" "$cr_ns" "$build_img"; then
             echo_error "Failed to build/push operator image"
             return 1
         fi

--- a/scripts/install-cmsc.sh
+++ b/scripts/install-cmsc.sh
@@ -1181,17 +1181,22 @@ deploy_helm_chart() {
             echo_error "Failed to build/push operator image"
             return 1
         fi
-        # Pin by digest so apply changes the Deployment spec ( :latest is a
-        # no-op) and kubelet does not default imagePullPolicy to Always.
+        # Pin by digest so apply changes the Deployment spec. Do not fall back
+        # to :latest: deploy-incluster uses IfNotPresent, and a cached tag can
+        # leave the manager on stale code.
         local digest=""
-        digest="$(docker image inspect "$build_img" --format '{{with index .RepoDigests 0}}{{.}}{{end}}' 2>/dev/null | awk -F@ '{print $2}')"
-        if [ -n "$digest" ]; then
-            pull_img="image-registry.openshift-image-registry.svc:5000/${cr_ns}/koku-service-operator@${digest}"
-            echo_info "Pinning in-cluster operator image to ${pull_img}"
-        else
-            pull_img="image-registry.openshift-image-registry.svc:5000/${cr_ns}/koku-service-operator:latest"
-            echo_warning "Could not resolve image digest; using :latest"
+        local _try
+        for _try in 1 2 3; do
+            digest="$(docker image inspect "$build_img" --format '{{with index .RepoDigests 0}}{{.}}{{end}}' 2>/dev/null | awk -F@ '{print $2}')"
+            [ -n "$digest" ] && break
+            sleep 2
+        done
+        if [ -z "$digest" ]; then
+            echo_error "Could not resolve image digest for ${build_img}; refusing :latest + IfNotPresent"
+            return 1
         fi
+        pull_img="image-registry.openshift-image-registry.svc:5000/${cr_ns}/koku-service-operator@${digest}"
+        echo_info "Pinning in-cluster operator image to ${pull_img}"
     else
         echo_info "Using pre-set IMG=$pull_img"
     fi

--- a/scripts/install-cmsc.sh
+++ b/scripts/install-cmsc.sh
@@ -24,6 +24,9 @@
 #   S3_CLI_IMAGE    - Container image with AWS CLI for bucket creation (default: amazon/aws-cli:latest)
 #   HELM_FORCE_CONFLICTS - When true, pass --force-conflicts to helm upgrade (SSA field ownership;
 #                          use after kubectl set / oc set image on chart-managed resources)
+#   BUILD_IMAGE     - When true, docker-build and push the operator (default: false — pull only)
+#   DEFAULT_OPERATOR_IMG - Image to pull when BUILD_IMAGE is false and IMG is unset
+#                          (default: quay.io/project-koku/koku-service-operator:v0.0.1)
 #   DOCKER_NO_CACHE - When true, build the operator image with --no-cache (default: false)
 #   DOCKER_PUSH_RETRIES - docker-push attempts after a registry 500 (default: 5)
 #   IMAGESTREAM_API_TIMEOUT - Seconds to wait for image.openshift.io (default: 180)
@@ -1225,6 +1228,31 @@ build_and_push_operator_image() {
     return 1
 }
 
+# Pull a published operator image. Sets RESOLVED_OPERATOR_IMG. Used when
+# BUILD_IMAGE is not set.
+pull_operator_image() {
+    local img="$1"
+    local ctool="${CONTAINER_TOOL:-docker}"
+    RESOLVED_OPERATOR_IMG="$img"
+
+    echo_info "Pulling operator image: $img"
+    if ! command -v "$ctool" >/dev/null 2>&1; then
+        echo_warning "${ctool} not found; the cluster will pull ${img} when the pod starts"
+        return 0
+    fi
+    if "$ctool" pull "$img"; then
+        echo_success "Pulled $img"
+        local digest=""
+        digest="$("$ctool" image inspect "$img" --format '{{with index .RepoDigests 0}}{{.}}{{end}}' 2>/dev/null || true)"
+        if [ -n "$digest" ]; then
+            RESOLVED_OPERATOR_IMG="$digest"
+            echo_info "Pinning pulled operator image to ${RESOLVED_OPERATOR_IMG}"
+        fi
+    else
+        echo_warning "Local pull of ${img} failed; the cluster will pull it when the pod starts"
+    fi
+}
+
 # Function to deploy Helm chart
 deploy_helm_chart() {
     echo_info "Deploying Cost Management On Premise Helm chart..."
@@ -1238,7 +1266,10 @@ deploy_helm_chart() {
     # use `make deploy` (scaffolds koku-service-operator-system).
     local cr_ns="${NAMESPACE:-cost-onprem}"
     local pull_img="${IMG:-}"
-    if [ -z "$pull_img" ]; then
+    local default_img="${DEFAULT_OPERATOR_IMG:-quay.io/project-koku/koku-service-operator:v0.0.1}"
+    kubectl get ns "$cr_ns" >/dev/null 2>&1 || kubectl create ns "$cr_ns"
+
+    if [ "${BUILD_IMAGE:-false}" = "true" ]; then
         local registry_host
         registry_host="$(oc get route default-route -n openshift-image-registry -o jsonpath='{.spec.host}' 2>/dev/null || true)"
         if [ -z "$registry_host" ]; then
@@ -1256,8 +1287,7 @@ deploy_helm_chart() {
             return 1
         fi
         local build_img="${registry_host}/${cr_ns}/koku-service-operator:latest"
-        kubectl get ns "$cr_ns" >/dev/null 2>&1 || kubectl create ns "$cr_ns"
-        echo_info "Building and pushing operator image: $build_img"
+        echo_info "BUILD_IMAGE=true — building and pushing operator image: $build_img"
         if ! build_and_push_operator_image "$project_root" "$registry_host" "$cr_ns" "$build_img"; then
             echo_error "Failed to build/push operator image"
             return 1
@@ -1279,7 +1309,12 @@ deploy_helm_chart() {
         pull_img="image-registry.openshift-image-registry.svc:5000/${cr_ns}/koku-service-operator@${digest}"
         echo_info "Pinning in-cluster operator image to ${pull_img}"
     else
-        echo_info "Using pre-set IMG=$pull_img"
+        if [ -z "$pull_img" ]; then
+            pull_img="$default_img"
+        fi
+        echo_info "BUILD_IMAGE unset — pulling operator image (set BUILD_IMAGE=true or pass --build to compile)"
+        pull_operator_image "$pull_img"
+        pull_img="${RESOLVED_OPERATOR_IMG:-$pull_img}"
     fi
 
     echo_info "Deploying OwnNamespace operator into ${cr_ns} (hack/deploy-incluster.sh)"

--- a/scripts/install-cmsc.sh
+++ b/scripts/install-cmsc.sh
@@ -1187,6 +1187,11 @@ build_and_push_operator_image() {
     local retries="${DOCKER_PUSH_RETRIES:-5}"
     local attempt
 
+    if ! [[ "$retries" =~ ^[1-9][0-9]*$ ]]; then
+        echo_warning "DOCKER_PUSH_RETRIES='${retries}' is not a positive integer; using 5"
+        retries=5
+    fi
+
     if ! wait_for_imagestream_api "$cr_ns"; then
         return 1
     fi
@@ -1210,7 +1215,7 @@ build_and_push_operator_image() {
         return 1
     fi
 
-    for attempt in $(seq 1 "$retries"); do
+    for ((attempt = 1; attempt <= retries; attempt++)); do
         echo_info "Pushing operator image (attempt ${attempt}/${retries}): $build_img"
         if (cd "$project_root" && make docker-push IMG="$build_img"); then
             echo_success "Operator image pushed"
@@ -1222,7 +1227,7 @@ build_and_push_operator_image() {
         fi
         wait_for_imagestream_api "$cr_ns" || true
         registry_docker_login "$registry_host" || true
-        sleep $((attempt * 5))
+        sleep "$((attempt * 5))"
     done
     echo_error "Failed to push operator image after ${retries} attempts"
     return 1


### PR DESCRIPTION
## Summary
`./scripts/deploy-test-cost-onprem.sh` installs the operator via `scripts/install-cmsc.sh`. That path failed on workshop clusters: `make deploy` put the manager in `koku-service-operator-system` (OwnNamespace never saw the CR), docker push died with HTTP 500 while the ImageStream API was down, and oauth2-proxy could not verify the public Keycloak Route issuer.

- Deploy with `hack/deploy-incluster.sh` into the CMSC namespace (`cost-onprem`) instead of `make deploy`.
- **Default: pull** `quay.io/project-koku/koku-service-operator:v0.0.1` (or `IMG` / `DEFAULT_OPERATOR_IMG`). Pass **`--build`** to docker-build and push from this checkout.
- When building: pin by digest (fail if inspect cannot resolve one). `imagePullPolicy: IfNotPresent`, 5m rollout wait, diagnostics on timeout.
- Wait for `imagestreams.image.openshift.io` and retry `docker-push` on registry 500. Optional `DOCKER_NO_CACHE=true`.
- Patch lab Keycloak `issuerURL` plus `tls.insecureSkipVerify: true`. Treat CMSC ready as `Available=True`.
- Skip ROS/Kruize health checks when `spec.ros.enabled` is not true; ingress probe uses port 8080.

https://redhat.atlassian.net/browse/COST-8143

## Test plan
- [x] `./scripts/deploy-test-cost-onprem.sh` on a workshop cluster: operator in `cost-onprem`, CMSC `Available=True`
- [ ] Default (no `--build`) pulls the published image and does not `docker-build`
- [ ] `--build` compiles from this checkout and pushes to the integrated registry
- [x] Image push succeeds after ImageStream API wait/retry (or on a clean retry)
- [ ] CMSC has public Route `issuerURL` and `tls.insecureSkipVerify: true`
- [ ] UI pod Ready; `NAMESPACE=cost-onprem ./scripts/run-pytest.sh --ui` reaches Keycloak login
- [ ] After a node reboot, operator rollout succeeds without ImagePullBackOff on `:latest` Always
- [ ] ROS/Kruize health checks are skipped when `spec.ros.enabled` is false