### PR TITLE
demo-preprod: --crc profile for local arm64 CRC

### DIFF
--- a/docs/development/crc-testing.md
+++ b/docs/development/crc-testing.md
@@ -3,8 +3,17 @@
 CRC provides a single-node OpenShift cluster for local development. The
 operator runs locally (out-of-cluster) and talks to CRC via kubeconfig.
 
-**Scope:** use CRC for **operator + koku API/celery** iteration. For full UI,
-Kafka, Keycloak, and nginx timeout E2E, prefer [clusterbot.md](clusterbot.md).
+Two paths:
+
+| Path | What it exercises | Section |
+|------|-------------------|---------|
+| **`./hack/demo-preprod.sh --crc`** | Full BYOI stack (AMQ Streams + Keycloak + koku + RBAC + ingress + Envoy + UI) with the **in-cluster** operator — the same flow as the `clusterbot` demo, on the local arm64 node | [Full BYOI demo on CRC](#full-byoi-demo-on-crc) |
+| **`make run` + a bundled sample CR** | Operator out-of-cluster, operator-provisioned Postgres/Valkey, no Kafka/Keycloak | rest of this document |
+
+**Scope:** use the minimal koku-only path for **operator + koku API/celery**
+iteration. For full UI, Kafka, Keycloak, and nginx timeout E2E, use the
+[Full BYOI demo on CRC](#full-byoi-demo-on-crc) below or
+[clusterbot.md](clusterbot.md).
 
 ## Quick start (minimal koku-only)
 
@@ -39,6 +48,54 @@ docker build --platform linux/arm64 -t default-route-openshift-image-registry.ap
 # patch spec.costManagement.api/masu.image in the CR, then:
 oc delete job -n cost-onprem cost-management-koku-migrate --ignore-not-found
 ```
+
+## Full BYOI demo on CRC
+
+`./hack/demo-preprod.sh --crc` runs the [pre-prod demo](pre-prod-install.md)
+against local CRC. It layers `hack/demo-preprod.crc.env` under the normal
+settings:
+
+- `KUBE_CONTEXT=crc` (create it once — see below)
+- `BUILD_MODE=openshift` — the operator image is built **on** the CRC node, so
+  it is natively arm64 (no cross build, no external registry)
+- **arm64 workload image overrides** — the BYOI sample pins amd64-only builds of
+  koku, `insights-rbac`, ingress and `koku-ui-onprem` that segfault / fail to
+  pull on the arm64 node; the profile points them at arm64 rebuilds under
+  `quay.io/martin_povolny/*`. Envoy (`proxyv2-rhel9`) and `oauth2-proxy-rhel9`
+  are Red Hat multi-arch and are left as-is.
+- **1+1 Kafka** (`KAFKA_BROKER_REPLICAS`/`KAFKA_CONTROLLER_REPLICAS=1`,
+  10Gi/5Gi PVCs) instead of 3+3 / 360Gi, which never binds on the single CRC
+  disk.
+
+The amd64 / `clusterbot` path is unaffected: without `--crc` the profile file is
+never read and the rendered CR is byte-identical to before.
+
+### One-time: create the `crc` kube context
+
+```bash
+crc start -p ~/.crc-secret.json
+oc login -u kubeadmin -p "$(crc console --credentials | sed -n 's/.*-p \([^ ]*\).*/\1/p' | tail -1)" \
+    https://api.crc.testing:6443 --insecure-skip-tls-verify=true
+oc config set-context crc --cluster=api-crc-testing:6443 \
+    --user=kubeadmin/api-crc-testing:6443 --namespace=default
+```
+
+`oc login` refreshes the token; re-run it (not `set-context`) if the context
+later reports `Unauthorized`.
+
+### Run it
+
+```bash
+# needs the sibling cost-onprem-chart checkout for scripts/deploy-rhbk.sh
+./hack/demo-preprod.sh --crc --dry-run     # show the plan
+./hack/demo-preprod.sh --crc               # tmux: steps + two klock panes
+./hack/demo-preprod.sh --crc --reset       # tear the four namespaces down first
+```
+
+Override any image from the profile with a matching env var, e.g.
+`DEMO_KOKU_IMAGE=quay.io/you/koku DEMO_KOKU_TAG=arm64 ./hack/demo-preprod.sh --crc`.
+Rebuilding the arm64 workload images: see
+[the profile file](../../hack/demo-preprod.crc.env) for the source repos.
 
 ## Prerequisites
 

--- a/docs/development/pre-prod-install.md
+++ b/docs/development/pre-prod-install.md
@@ -331,6 +331,7 @@ oc delete ns "$NAMESPACE" "$INFRA_NAMESPACE" --ignore-not-found
 ## Related docs
 
 - [ownnamespace.md](ownnamespace.md) — install/watch model and RBAC shape
-- [crc-testing.md](crc-testing.md) — local CRC / out-of-cluster `make run`
+- [crc-testing.md](crc-testing.md) — local CRC: this same BYOI flow via
+  `./hack/demo-preprod.sh --crc` (arm64), or the out-of-cluster `make run` path
 - [uninstall.md](../install/uninstall.md) — CR-first uninstall and stuck-namespace recovery
 - [config/samples/byoi/README.md](../../config/samples/byoi/README.md) — fixture details, monitoring, teardown

--- a/hack/demo-preprod.crc.env
+++ b/hack/demo-preprod.crc.env
@@ -1,0 +1,55 @@
+# CRC (OpenShift Local) profile for ./hack/demo-preprod.sh --crc.
+#
+# A single-node *arm64* cluster. This file overrides the shipped amd64 defaults
+# in hack/demo-preprod.env.example, but is itself overridden by anything you
+# export or put in hack/demo-preprod.local.env. Precedence:
+#   real env > hack/demo-preprod.local.env > this file > hack/demo-preprod.env.example
+# The amd64 / clusterbot path never reads this file.
+#
+# One-time host setup — start CRC and register a context named `crc`
+# (full guide: docs/development/crc-testing.md):
+#
+#   crc start -p ~/.crc-secret.json
+#   oc login -u kubeadmin -p "$(crc console --credentials | sed -n 's/.*-p \([^ ]*\).*/\1/p' | tail -1)" \
+#       https://api.crc.testing:6443 --insecure-skip-tls-verify=true
+#   oc config set-context crc --cluster=api-crc-testing:6443 \
+#       --user=kubeadmin/api-crc-testing:6443 --namespace=default
+#
+# Then: ./hack/demo-preprod.sh --crc
+
+KUBE_CONTEXT=crc
+
+# Operator image: in-cluster OpenShift docker-strategy build runs on the CRC
+# node, so it is natively arm64 — no cross build, no external registry push.
+BUILD_MODE=openshift
+
+# Workload image overrides. The BYOI sample pins amd64-only builds (koku,
+# insights-rbac, ingress, koku-ui-onprem) that will not run on the arm64 node;
+# these arm64 rebuilds are consumed by render_preprod_cr (hack/lib/demo-preprod.bash).
+# envoy (proxyv2-rhel9) and oauth2-proxy-rhel9 are Red Hat multi-arch and are
+# left untouched.
+#
+# How the arm64 rebuilds are produced (all: docker buildx build --platform
+# linux/arm64 -t quay.io/martin_povolny/<img>:<tag> --push .):
+#   koku                -> project-koku/koku            (arch-neutral UBI Dockerfile)
+#   insights-rbac       -> RedHatInsights/insights-rbac (arch-neutral UBI Dockerfile)
+#   insights-ingress-go -> insights-onprem/insights-ingress-go
+#   koku-ui-onprem      -> cross-arch: FROM --platform=linux/amd64 the published
+#                          amd64 image AS bundle; COPY its static /opt/app-root/src
+#                          onto registry.access.redhat.com/ubi9/nginx-126 (arm64).
+DEMO_KOKU_IMAGE=quay.io/martin_povolny/koku
+DEMO_KOKU_TAG=latest
+DEMO_RBAC_IMAGE=quay.io/martin_povolny/insights-rbac
+DEMO_RBAC_TAG=crc-arm64
+DEMO_INGRESS_IMAGE=quay.io/martin_povolny/insights-ingress-go
+DEMO_INGRESS_TAG=crc-arm64
+DEMO_UI_IMAGE=quay.io/martin_povolny/koku-ui-onprem
+DEMO_UI_TAG=crc-arm64
+
+# Single node + one backing disk: shrink AMQ Streams from 3+3 nodes / 360Gi of
+# PVCs to 1+1 / 15Gi (deploy-kafka.sh honours these; replication factor and
+# min.insync follow the broker count, so 1 is self-consistent).
+KAFKA_BROKER_REPLICAS=1
+KAFKA_CONTROLLER_REPLICAS=1
+KAFKA_BROKER_STORAGE=10Gi
+KAFKA_CONTROLLER_STORAGE=5Gi

--- a/hack/demo-preprod.crc.env
+++ b/hack/demo-preprod.crc.env
@@ -38,13 +38,19 @@ BUILD_MODE=openshift
 #                          amd64 image AS bundle; COPY its static /opt/app-root/src
 #                          onto registry.access.redhat.com/ubi9/nginx-126 (arm64).
 DEMO_KOKU_IMAGE=quay.io/martin_povolny/koku
-DEMO_KOKU_TAG=latest
+DEMO_KOKU_TAG=768be82-arm64
 DEMO_RBAC_IMAGE=quay.io/martin_povolny/insights-rbac
 DEMO_RBAC_TAG=crc-arm64
 DEMO_INGRESS_IMAGE=quay.io/martin_povolny/insights-ingress-go
 DEMO_INGRESS_TAG=crc-arm64
 DEMO_UI_IMAGE=quay.io/martin_povolny/koku-ui-onprem
 DEMO_UI_TAG=crc-arm64
+
+# RHBK / Keycloak operator: deploy-rhbk.sh pins channel stable-v22, whose
+# operator + server images are amd64-only. stable-v26 is the first arm64-capable
+# RHBK channel. demo-preprod.sh --crc pre-creates the Subscription on this
+# channel so deploy-rhbk.sh reuses it.
+DEMO_RHBK_CHANNEL=stable-v26
 
 # Single node + one backing disk: shrink AMQ Streams from 3+3 nodes / 360Gi of
 # PVCs to 1+1 / 15Gi (deploy-kafka.sh honours these; replication factor and

--- a/hack/demo-preprod.crc.env
+++ b/hack/demo-preprod.crc.env
@@ -29,14 +29,17 @@ BUILD_MODE=openshift
 # envoy (proxyv2-rhel9) and oauth2-proxy-rhel9 are Red Hat multi-arch and are
 # left untouched.
 #
-# How the arm64 rebuilds are produced (all: docker buildx build --platform
-# linux/arm64 -t quay.io/martin_povolny/<img>:<tag> --push .):
-#   koku                -> project-koku/koku            (arch-neutral UBI Dockerfile)
-#   insights-rbac       -> RedHatInsights/insights-rbac (arch-neutral UBI Dockerfile)
+# How the arm64 rebuilds are produced (all with `docker buildx build --platform
+# linux/arm64` on an Apple-Silicon host, then `--push`; the quay repos must be
+# public, like quay.io/martin_povolny/koku already is):
+#   koku                -> project-koku/koku @ 768be82  (arch-neutral UBI Dockerfile)
+#   insights-rbac       -> RedHatInsights/insights-rbac  (arch-neutral UBI Dockerfile)
 #   insights-ingress-go -> insights-onprem/insights-ingress-go
 #   koku-ui-onprem      -> cross-arch: FROM --platform=linux/amd64 the published
 #                          amd64 image AS bundle; COPY its static /opt/app-root/src
 #                          onto registry.access.redhat.com/ubi9/nginx-126 (arm64).
+#                          NB: only `docker buildx` honours the per-stage platform
+#                          here; an OpenShift in-cluster build yields an amd64 image.
 DEMO_KOKU_IMAGE=quay.io/martin_povolny/koku
 DEMO_KOKU_TAG=768be82-arm64
 DEMO_RBAC_IMAGE=quay.io/martin_povolny/insights-rbac

--- a/hack/demo-preprod.env.example
+++ b/hack/demo-preprod.env.example
@@ -20,3 +20,7 @@ IMAGE_TAG=preprod
 TMUX_SESSION=koku-demo-preprod
 WATCHER=klock
 LOG_LEVEL=INFO
+
+# Local CRC (arm64, single node): run `./hack/demo-preprod.sh --crc`. That layers
+# hack/demo-preprod.crc.env (KUBE_CONTEXT=crc, arm64 workload image overrides,
+# 1+1 Kafka) under these settings. See docs/development/crc-testing.md.

--- a/hack/demo-preprod.sh
+++ b/hack/demo-preprod.sh
@@ -444,7 +444,98 @@ ui_deploy_ready() {
   [[ "$("$KUBECTL" -n "$NAMESPACE" get deploy "${CR_NAME}-ui" -o jsonpath='{.status.availableReplicas}' 2>/dev/null || echo 0)" != "0" ]]
 }
 
+# RHBK / Keycloak operator: the channel deploy-rhbk.sh pins (stable-v22) ships
+# amd64-only operator images. On the arm64 CRC node we pre-create the
+# Subscription on an arm64-capable channel (stable-v26); deploy-rhbk.sh then
+# finds it and skips its own create. No-op on amd64 / clusterbot.
+ensure_rhbk_channel() {
+  local ns="$1" channel="$2"
+  need_ns "$ns"
+  "$KUBECTL" apply -f - >/dev/null <<EOF
+apiVersion: operators.coreos.com/v1
+kind: OperatorGroup
+metadata:
+  name: rhbk-operator-group
+  namespace: ${ns}
+spec:
+  targetNamespaces:
+  - ${ns}
+EOF
+  local cur
+  cur="$("$KUBECTL" -n "$ns" get subscription rhbk-operator -o jsonpath='{.spec.channel}' 2>/dev/null || true)"
+  if [[ -z "$cur" ]]; then
+    echo "  creating RHBK Subscription on channel ${channel} (arm64)"
+    "$KUBECTL" apply -f - >/dev/null <<EOF
+apiVersion: operators.coreos.com/v1alpha1
+kind: Subscription
+metadata:
+  name: rhbk-operator
+  namespace: ${ns}
+spec:
+  channel: ${channel}
+  installPlanApproval: Automatic
+  name: rhbk-operator
+  source: redhat-operators
+  sourceNamespace: openshift-marketplace
+EOF
+  elif [[ "$cur" != "$channel" ]]; then
+    echo "  repointing RHBK Subscription ${cur} -> ${channel} (arm64)"
+    "$KUBECTL" -n "$ns" patch subscription rhbk-operator --type=merge \
+      -p "{\"spec\":{\"channel\":\"${channel}\"}}" >/dev/null
+    "$KUBECTL" -n "$ns" delete csv -l "operators.coreos.com/rhbk-operator.${ns}" --ignore-not-found >/dev/null 2>&1 || true
+  else
+    echo "  RHBK Subscription already on channel ${channel}"
+  fi
+  echo "  waiting for deployment/rhbk-operator to be Available…"
+  local end=$((SECONDS + 300))
+  while (( SECONDS < end )); do
+    if [[ "$("$KUBECTL" -n "$ns" get deploy rhbk-operator -o jsonpath='{.status.readyReplicas}' 2>/dev/null || echo 0)" == "1" ]]; then
+      ok "RHBK operator ready (channel ${channel})"
+      return 0
+    fi
+    sleep 5
+  done
+  echo "error: RHBK operator (channel ${channel}) did not become ready in 5m" >&2
+  "$KUBECTL" -n "$ns" get csv,subscription,installplan,pods >&2 || true
+  exit 1
+}
+
+# RHBK >= v24 uses Hostname v2: spec.hostname.hostname / .admin must be full
+# URLs. deploy-rhbk.sh (written for v22) sets bare hostnames, which makes
+# keycloak-0 CrashLoop on the newer channel. This runs in the background while
+# deploy-rhbk.sh creates + waits on the Keycloak CR: as soon as the CR shows a
+# bare hostname, rewrite it to https:// and delete keycloak-0 so the StatefulSet
+# rolls a pod with the fixed config. Exits on its own; a no-op if the value is
+# already a URL. --crc only.
+crc_fix_keycloak_hostname_v2() {
+  local ns="$1" end=$((SECONDS + 600)) h
+  while (( SECONDS < end )); do
+    h="$("$KUBECTL" -n "$ns" get keycloak keycloak -o jsonpath='{.spec.hostname.hostname}' 2>/dev/null || true)"
+    if [[ -n "$h" ]]; then
+      case "$h" in
+        http://*|https://*) return 0 ;;
+        *)
+          echo "  [crc] rewriting Keycloak hostname '${h}' -> 'https://${h}' (RHBK Hostname v2)"
+          if ! "$KUBECTL" -n "$ns" patch keycloak keycloak --type=merge \
+            -p "{\"spec\":{\"hostname\":{\"hostname\":\"https://${h}\",\"admin\":\"https://${h}\"}}}" >/dev/null 2>&1; then
+            echo "  [crc] Keycloak hostname patch failed; retrying"
+            sleep 5
+            continue
+          fi
+          "$KUBECTL" -n "$ns" delete pod keycloak-0 --ignore-not-found >/dev/null 2>&1 || true
+          return 0 ;;
+      esac
+    fi
+    sleep 5
+  done
+  echo "  [crc] WARNING: timed out before Keycloak hostname was rewritten to a v2 URL" >&2
+  return 1
+}
+
 step "BYOI dependencies (Kafka, Postgres, Valkey, MinIO, Keycloak)"
+if [[ "$DEMO_CRC" == "1" ]] && ! keycloak_ready; then
+  ensure_rhbk_channel "$KEYCLOAK_NAMESPACE" "${DEMO_RHBK_CHANNEL:-stable-v26}"
+fi
 SKIP_KAFKA=0 SKIP_INFRA=0 SKIP_KEYCLOAK=0 SKIP_OAUTH_MIRROR=0
 kafka_ready && SKIP_KAFKA=1 && skip "Kafka ${KAFKA_CLUSTER_NAME} already Ready"
 infra_ready && SKIP_INFRA=1 && skip "infra in ${INFRA_NAMESPACE} already rolled out"
@@ -454,7 +545,13 @@ if [[ "${SKIP_KAFKA}${SKIP_INFRA}${SKIP_KEYCLOAK}${SKIP_OAUTH_MIRROR}" == "1111"
   skip "all BYOI stages healthy"
 else
   export SKIP_KAFKA SKIP_INFRA SKIP_KEYCLOAK SKIP_OAUTH_MIRROR
+  KC_FIX_PID=""
+  if [[ "$DEMO_CRC" == "1" && "$SKIP_KEYCLOAK" != "1" ]]; then
+    crc_fix_keycloak_hostname_v2 "$KEYCLOAK_NAMESPACE" &
+    KC_FIX_PID=$!
+  fi
   ./hack/deploy-byoi.sh
+  [[ -n "$KC_FIX_PID" ]] && wait "$KC_FIX_PID" 2>/dev/null || true
 fi
 ok "BYOI ready"
 

--- a/hack/demo-preprod.sh
+++ b/hack/demo-preprod.sh
@@ -7,9 +7,10 @@
 #   ./hack/demo-preprod.sh --reset          # delete app/infra/kafka/keycloak NS first
 #   ./hack/demo-preprod.sh --no-tmux
 #   ./hack/demo-preprod.sh --rebuild        # force operator image rebuild
+#   ./hack/demo-preprod.sh --crc            # target local CRC (arm64, single node)
 #
 # Settings: env vars, then hack/demo-preprod.local.env, then
-# hack/demo-preprod.env.example. See the example file.
+# hack/demo-preprod.env.example (and hack/demo-preprod.crc.env with --crc).
 #
 # tmux (default): left pane = numbered steps; top-right = kubectl klock pods
 # in NAMESPACE; bottom-right = kubectl klock pods in KAFKA_NAMESPACE.
@@ -29,6 +30,7 @@ DEMO_DRY_RUN="${DEMO_DRY_RUN:-0}"
 DEMO_NO_TMUX="${DEMO_NO_TMUX:-0}"
 DEMO_REBUILD="${DEMO_REBUILD:-0}"
 DEMO_NO_OPEN="${DEMO_NO_OPEN:-0}"
+DEMO_CRC="${DEMO_CRC:-0}"
 
 usage() {
   sed -n '2,18p' "$SCRIPT" | sed 's/^# \{0,1\}//'
@@ -41,6 +43,7 @@ while [[ $# -gt 0 ]]; do
     --no-tmux) DEMO_NO_TMUX=1 ;;
     --rebuild) DEMO_REBUILD=1 ;;
     --no-open) DEMO_NO_OPEN=1 ;;
+    --crc) DEMO_CRC=1 ;;
     -h|--help) usage; exit 0 ;;
     *)
       echo "error: unknown flag $1" >&2
@@ -73,10 +76,27 @@ load_env_file() {
   done <"$file"
 }
 
-load_env_file "${ROOT}/hack/demo-preprod.env.example"
-load_env_file "${ROOT}/hack/demo-preprod.local.env"
+if [[ "$DEMO_CRC" == "1" ]]; then
+  # load_env_file only sets vars that are still unset (first file wins), so the
+  # load order below is the precedence:
+  #   real env > .local.env > .crc.env > .env.example
+  # The CRC/arm64 profile overrides the shipped amd64 defaults in .env.example
+  # (KUBE_CONTEXT, BUILD_MODE, Kafka sizing, image overrides) but still yields to
+  # anything you export or put in .local.env.
+  load_env_file "${ROOT}/hack/demo-preprod.local.env"
+  load_env_file "${ROOT}/hack/demo-preprod.crc.env"
+  load_env_file "${ROOT}/hack/demo-preprod.env.example"
+else
+  # amd64 / clusterbot: unchanged, .crc.env is never read.
+  load_env_file "${ROOT}/hack/demo-preprod.env.example"
+  load_env_file "${ROOT}/hack/demo-preprod.local.env"
+fi
 
-KUBE_CONTEXT="${KUBE_CONTEXT:-clusterbot}"
+if [[ "$DEMO_CRC" == "1" ]]; then
+  KUBE_CONTEXT="${KUBE_CONTEXT:-crc}"
+else
+  KUBE_CONTEXT="${KUBE_CONTEXT:-clusterbot}"
+fi
 NAMESPACE="${NAMESPACE:-cost-byoi}"
 CR_NAME="${CR_NAME:-cost-management}"
 INFRA_NAMESPACE="${INFRA_NAMESPACE:-cost-byoi-infra}"
@@ -165,6 +185,7 @@ Pre-prod demo plan
   tmux:        ${TMUX_SESSION}  (NO_TMUX=${DEMO_NO_TMUX})
   reset:       ${DEMO_RESET}
   rebuild:     ${DEMO_REBUILD}
+  crc mode:    ${DEMO_CRC}$([[ "$DEMO_CRC" == "1" ]] && echo "  (arm64 image overrides + single-node Kafka from hack/demo-preprod.crc.env)")
   open UI:     ${OPEN_BROWSER} (NO_OPEN=${DEMO_NO_OPEN})
 
   [1/8] Preflight (context, oc, CHART_ROOT, StorageClass)
@@ -223,7 +244,7 @@ start_tmux() {
   tmux send-keys -t "${TMUX_SESSION}:demo.1" "until ${watch1}; do echo 'watcher retry in 3s…'; sleep 3; done" C-m
   tmux send-keys -t "${TMUX_SESSION}:demo.2" "until ${watch2}; do echo 'watcher retry in 3s…'; sleep 3; done" C-m
 
-  inner="cd $(printf %q "$ROOT") && DEMO_INNER=1 DEMO_RESET=$(printf %q "$DEMO_RESET") DEMO_REBUILD=$(printf %q "$DEMO_REBUILD") DEMO_NO_OPEN=$(printf %q "$DEMO_NO_OPEN") $(printf %q "$ROOT/hack/demo-preprod.sh")"
+  inner="cd $(printf %q "$ROOT") && DEMO_INNER=1 DEMO_RESET=$(printf %q "$DEMO_RESET") DEMO_REBUILD=$(printf %q "$DEMO_REBUILD") DEMO_NO_OPEN=$(printf %q "$DEMO_NO_OPEN") DEMO_CRC=$(printf %q "$DEMO_CRC") $(printf %q "$ROOT/hack/demo-preprod.sh")"
   tmux send-keys -t "${TMUX_SESSION}:demo.0" "$inner" C-m
   tmux select-pane -t "${TMUX_SESSION}:demo.0"
 
@@ -254,6 +275,16 @@ fi
 "$KUBECTL" config use-context "$KUBE_CONTEXT" >/dev/null
 require_reachable_cluster "$KUBECTL" || exit 1
 ok "using $($KUBECTL config current-context) — $($KUBECTL whoami --show-server)"
+
+if [[ "$DEMO_CRC" == "1" ]]; then
+  NODE_ARCH="$("$KUBECTL" get nodes -o jsonpath='{.items[0].status.nodeInfo.architecture}' 2>/dev/null || true)"
+  if [[ "$NODE_ARCH" != "arm64" ]]; then
+    echo "warning: --crc expects an arm64 node but the cluster reports '${NODE_ARCH:-unknown}'." >&2
+    echo "  The arm64 image overrides in hack/demo-preprod.crc.env may not match this node." >&2
+  else
+    ok "node architecture ${NODE_ARCH} (arm64 image overrides from hack/demo-preprod.crc.env)"
+  fi
+fi
 
 if [[ ! -x "${CHART_ROOT}/scripts/deploy-rhbk.sh" ]]; then
   echo "error: CHART_ROOT has no scripts/deploy-rhbk.sh: ${CHART_ROOT}" >&2

--- a/hack/lib/demo-preprod.bash
+++ b/hack/lib/demo-preprod.bash
@@ -17,12 +17,22 @@ patch_operator_dockerfile() {
 }
 
 # Fill the BYOI sample CR: apps domain, public Keycloak issuer, lab TLS skip-verify.
+#
+# Optional workload image overrides (used by `demo-preprod.sh --crc` for arm64;
+# unset on the amd64/clusterbot path, so the rendered CR is byte-identical there):
+#   DEMO_KOKU_IMAGE / DEMO_KOKU_TAG              koku api + masu
+#   DEMO_RBAC_IMAGE / DEMO_RBAC_TAG              insights-rbac
+#   DEMO_INGRESS_IMAGE / DEMO_INGRESS_TAG        ingress
+#   DEMO_UI_IMAGE / DEMO_UI_TAG                  koku-ui-onprem
+#   DEMO_ENVOY_IMAGE / DEMO_ENVOY_TAG            envoy / proxyv2
+#   DEMO_OAUTHPROXY_IMAGE / DEMO_OAUTHPROXY_TAG  oauth2-proxy sidecar
 render_preprod_cr() {
   local src="${1:?sample CR path}"
   local dest="${2:?output path}"
   local domain="${3:?cluster apps domain}"
   local issuer="${4:?Keycloak issuer base URL}"
   python3 - "$src" "$dest" "$domain" "$issuer" <<'PY'
+import os
 import sys
 from pathlib import Path
 
@@ -42,6 +52,36 @@ text = text.replace(old_url, new_block, 1)
 text = text.replace('      # issuerURL: "https://keycloak-keycloak.apps.example.com"\n', "")
 text = text.replace("      # tls:\n", "")
 text = text.replace("      #   insecureSkipVerify: true   # dev only when issuer uses a private CA\n", "")
+
+# Optional per-workload image overrides. Each needle is the verbatim line from
+# config/samples/byoi/app/costmanagementserviceconfig.yaml; when the matching
+# env var is empty the line is left untouched (amd64 path renders unchanged).
+_overrides = [
+    ("DEMO_KOKU_IMAGE",       "repository: quay.io/redhat-services-prod/cost-mgmt-dev-tenant/koku"),
+    ("DEMO_KOKU_TAG",         'tag: "768be82"'),
+    ("DEMO_RBAC_IMAGE",       "repository: quay.io/redhat-services-prod/hcc-accessmanagement-tenant/insights-rbac"),
+    ("DEMO_RBAC_TAG",         'tag: "73870d8"'),
+    ("DEMO_INGRESS_IMAGE",    "repository: quay.io/iop/ingress"),
+    ("DEMO_INGRESS_TAG",      'tag: "master"'),
+    ("DEMO_UI_IMAGE",         "repository: quay.io/insights-onprem/koku-ui-onprem"),
+    ("DEMO_UI_TAG",           'tag: "2f23c646581028bd385856b6713e6bf367baf953"'),
+    ("DEMO_ENVOY_IMAGE",      "repository: registry.redhat.io/openshift-service-mesh/proxyv2-rhel9"),
+    ("DEMO_ENVOY_TAG",        'tag: "2.6"'),
+    ("DEMO_OAUTHPROXY_IMAGE", "repository: registry.redhat.io/rhceph/oauth2-proxy-rhel9"),
+    ("DEMO_OAUTHPROXY_TAG",   'tag: "v7.6.0"'),
+]
+for env_key, needle in _overrides:
+    val = os.environ.get(env_key, "").strip()
+    if not val:
+        continue
+    if needle.startswith("repository: "):
+        repl = "repository: " + val
+    else:
+        repl = 'tag: "' + val + '"'
+    if needle not in text:
+        raise SystemExit(f"render_preprod_cr: {env_key} set but sample line not found: {needle}")
+    text = text.replace(needle, repl)
+
 Path(dest).write_text(text)
 PY
 }


### PR DESCRIPTION
## What

`hack/demo-preprod.sh` and the install guides only target the amd64 multi-node
`clusterbot` context. This adds a `--crc` mode so the same BYOI flow
(AMQ Streams + Keycloak + full koku stack + in-cluster operator + UI) runs
end-to-end on a local single-node **arm64** CRC (OpenShift Local).

Without `--crc` nothing changes: the profile file is never read, the rendered CR
is byte-identical, and `hack/demo-preprod_test.sh` / `scripts/deploy-rhbk_test.sh`
pass unchanged.

## Changes

- **`--crc` flag** + **`hack/demo-preprod.crc.env`**, layered under the normal
  settings (real env > `.local.env` > `.env.example` > `.crc.env`):
  - `KUBE_CONTEXT=crc`, `BUILD_MODE=openshift` (operator image built on the node
    → native arm64, no cross-build / external registry)
  - **arm64 workload image overrides** for the amd64-only sample images (koku,
    insights-rbac, ingress, koku-ui-onprem), injected through a new env-gated
    hook in `render_preprod_cr` (`hack/lib/demo-preprod.bash`). Envoy
    (`proxyv2-rhel9`) and `oauth2-proxy-rhel9` are Red Hat multi-arch and left
    as-is.
  - **1+1 Kafka / 15Gi PVCs** instead of 3+3 / 360Gi (never binds on the single
    CRC disk) via the env hooks `deploy-kafka.sh` already exposes.
  - **`ensure_rhbk_channel`** — pre-creates the `rhbk-operator` Subscription on
    `DEMO_RHBK_CHANNEL` (default `stable-v26`, the first arm64-capable RHBK
    channel; v22/v24 operator images are amd64-only) so `deploy-rhbk.sh` reuses
    it.
  - **`crc_fix_keycloak_hostname_v2`** — RHBK ≥ v24 uses Hostname v2 where
    `spec.hostname.hostname`/`.admin` must be full URLs; `deploy-rhbk.sh` writes
    bare hostnames, which CrashLoops `keycloak-0`. Runs in the background during
    `deploy-byoi.sh` and rewrites the Keycloak CR + rolls the pod.
  - Preflight warns if the target node is not arm64.
- **Docs**: new "Full BYOI demo on CRC" section in
  `docs/development/crc-testing.md`; pointer from `pre-prod-install.md`.

## arm64 images

The `--crc` profile points koku / insights-rbac / ingress / koku-ui-onprem at
public arm64 rebuilds under `quay.io/martin_povolny/*` (koku is the exact
`768be82` commit the amd64 sample pins; koku-ui-onprem is a cross-arch rebuild —
arm64 `ubi9/nginx-126` + the published amd64 static bundle). Provenance is
documented in `hack/demo-preprod.crc.env`. Override any of them with the matching
`DEMO_*_IMAGE` / `DEMO_*_TAG` env var.

## Testing

Ran `./hack/demo-preprod.sh --crc` end-to-end on CRC 4.21.8 (Apple Silicon):

- CR `cost-management` → `phase=Ready`, `Available=True (AllComponentsReady)`,
  every condition `True`, `Degraded=False`
- 17 pods Running (operator + koku api/masu/listener, 8 celery workers, rbac
  api/worker, ingress, Envoy gateway, UI 2/2)
- UI route returns `302` → Keycloak OIDC; login `admin` / `admin`

amd64 / `clusterbot` regression:

- `render_preprod_cr` output byte-identical with no `DEMO_*` env
- `hack/demo-preprod_test.sh`, `scripts/deploy-rhbk_test.sh` green
- `./hack/demo-preprod.sh --dry-run` (no `--crc`) unchanged apart from a new
  `crc mode: 0` line

https://claude.ai/code/session_01PdbPCKvsAEAev5XommMAJm


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

- Add `--crc` support for the full BYOI flow on single-node arm64 OpenShift Local.
- Add CRC-specific arm64 image overrides, reduced Kafka and PVC requirements, and RHBK `stable-v26` selection.
- Update Keycloak hostname handling for RHBK v26 compatibility.
- Add optional per-workload image overrides to `render_preprod_cr`.
- Add CRC installation, testing, and arm64 image provenance documentation.
- Preserve existing amd64 clusterbot behavior and rendered output without `--crc`.

## Operator impact

- No CRD API changes.
- CRC mode prepares the RHBK `Subscription` and selects an arm64-capable channel.
- A watcher updates the Keycloak CR hostname and restarts `keycloak-0` so the corrected configuration reconciles.
- No RBAC changes.
- End-to-end CRC testing produced a Ready `cost-management` CR, 17 running pods, and successful UI OIDC redirection.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->