### PR TITLE
[COST-8173] e2e-iqe: use bare numeric org_id and pre-provision koku tenant + RBAC

### DIFF
--- a/scripts/deploy-rhbk.sh
+++ b/scripts/deploy-rhbk.sh
@@ -834,14 +834,14 @@ create_kubernetes_realm() {
     fi
 
     # Derive operator client org_id from first orgAdmin realmUser entry
-    local OPERATOR_ORG_ID="org1234567"
+    local OPERATOR_ORG_ID="1234567"
     local OPERATOR_ACCOUNT_NUMBER="7890123"
     local _users_json
     _users_json=$(get_realm_users_json 2>/dev/null) || _users_json='[]'
     local _admin_entry
     _admin_entry=$(echo "$_users_json" | jq -c '[.[] | select(.orgAdmin == true)] | .[0] // empty')
     if [ -n "$_admin_entry" ]; then
-        OPERATOR_ORG_ID=$(echo "$_admin_entry" | jq -r '.orgId // "org1234567"')
+        OPERATOR_ORG_ID=$(echo "$_admin_entry" | jq -r '.orgId // "1234567"')
         OPERATOR_ACCOUNT_NUMBER=$(echo "$_admin_entry" | jq -r '.accountNumber // "7890123"')
     fi
     echo_info "Operator client identity: org_id=$OPERATOR_ORG_ID, account_number=$OPERATOR_ACCOUNT_NUMBER"
@@ -1690,7 +1690,7 @@ json.dump(users, sys.stdout)
 
     # Default: single admin user matching historical behavior
     cat <<'DEFAULT_USERS'
-[{"username":"admin","password":"admin","email":"admin@test.com","firstName":"Admin","lastName":"User","orgId":"org1234567","accountNumber":"7890123","orgAdmin":true}]
+[{"username":"admin","password":"admin","email":"admin@test.com","firstName":"Admin","lastName":"User","orgId":"1234567","accountNumber":"7890123","orgAdmin":true}]
 DEFAULT_USERS
 }
 
@@ -1706,7 +1706,7 @@ create_or_update_user() {
     local email=$(echo "$user_json" | jq -r '.email // (.username + "@noreply.local")')
     local first_name=$(echo "$user_json" | jq -r '.firstName // "User"')
     local last_name=$(echo "$user_json" | jq -r '.lastName // ""')
-    local org_id=$(echo "$user_json" | jq -r '.orgId // "org1234567"')
+    local org_id=$(echo "$user_json" | jq -r '.orgId // "1234567"')
     local account_number=$(echo "$user_json" | jq -r '.accountNumber // "7890123"')
 
     echo_info "Creating user '$username' (org_id=$org_id)..."
@@ -1938,7 +1938,7 @@ create_org_groups() {
 
     # Discover distinct orgIds and their account numbers
     local orgs_json
-    orgs_json=$(echo "$USERS_JSON" | jq -c '[group_by((.orgId // "org1234567")) | .[] | {orgId: (.[0].orgId // "org1234567"), accountNumber: (.[0].accountNumber // "7890123")}]')
+    orgs_json=$(echo "$USERS_JSON" | jq -c '[group_by((.orgId // "1234567")) | .[] | {orgId: (.[0].orgId // "1234567"), accountNumber: (.[0].accountNumber // "7890123")}]')
 
     local org_count
     org_count=$(echo "$orgs_json" | jq 'length')
@@ -2042,7 +2042,7 @@ create_org_groups() {
         local u=0
         while [ $u -lt "$user_count" ]; do
             local u_org u_name u_admin
-            u_org=$(echo "$USERS_JSON" | jq -r ".[$u].orgId // \"org1234567\"")
+            u_org=$(echo "$USERS_JSON" | jq -r ".[$u].orgId // \"1234567\"")
             u_name=$(echo "$USERS_JSON" | jq -r ".[$u].username")
             u_admin=$(echo "$USERS_JSON" | jq -r ".[$u].orgAdmin // false")
 
@@ -2142,7 +2142,7 @@ display_summary() {
     while [ $u -lt "$u_count" ]; do
         local u_name u_org u_acct u_admin
         u_name=$(echo "$USERS_JSON" | jq -r ".[$u].username")
-        u_org=$(echo "$USERS_JSON" | jq -r ".[$u].orgId // \"org1234567\"")
+        u_org=$(echo "$USERS_JSON" | jq -r ".[$u].orgId // \"1234567\"")
         u_acct=$(echo "$USERS_JSON" | jq -r ".[$u].accountNumber // \"7890123\"")
         u_admin=$(echo "$USERS_JSON" | jq -r ".[$u].orgAdmin // false")
         local role_info=""
@@ -2154,7 +2154,7 @@ display_summary() {
     echo_info "  Organization Groups (for multi-org RBAC sync):"
     local ORG_GROUP_PREFIX="${ORG_GROUP_PREFIX:-org-}"
     local orgs_json
-    orgs_json=$(echo "$USERS_JSON" | jq -c "[group_by((.orgId // \"org1234567\")) | .[] | (.[0].orgId // \"org1234567\")]" 2>/dev/null) || orgs_json='[]'
+    orgs_json=$(echo "$USERS_JSON" | jq -c "[group_by((.orgId // \"1234567\")) | .[] | (.[0].orgId // \"1234567\")]" 2>/dev/null) || orgs_json='[]'
     local org_list
     org_list=$(echo "$orgs_json" | jq -r '.[]' 2>/dev/null)
     for org_id in $org_list; do

--- a/scripts/run-iqe-tests-local.sh
+++ b/scripts/run-iqe-tests-local.sh
@@ -471,7 +471,7 @@ extract_cluster_config() {
     export DYNACONF_users__cost_onprem_user__auth__client_id="$DYNACONF_ONPREM_CLIENT_ID"
     export DYNACONF_users__cost_onprem_user__auth__client_secret="$DYNACONF_ONPREM_CLIENT_SECRET"
     # Read org_id and account_number from Keycloak (canonical source: jwtAuth.realmUsers)
-    local iqe_org_id="org1234567"
+    local iqe_org_id="1234567"
     local iqe_acct="7890123"
     local kc_host
     kc_host=$(kubectl get route keycloak -n "$KEYCLOAK_NS" -o jsonpath='{.spec.host}' 2>/dev/null || echo "")

--- a/scripts/run-iqe-tests.sh
+++ b/scripts/run-iqe-tests.sh
@@ -779,8 +779,9 @@ if kubectl exec --request-timeout=300s -n "${NAMESPACE}" "deploy/${HELM_RELEASE_
         python /opt/koku/koku/manage.py shell -c "${KOKU_PROVISION_SCRIPT}"; then
     echo "✓ koku tenant schema '${KOKU_SCHEMA}' ready"
 else
-    echo "⚠ WARNING: Could not pre-provision koku tenant schema '${KOKU_SCHEMA}'."
-    echo "  The data-retention session fixture may 503 and error the IQE run."
+    echo "⚠ ERROR: Could not pre-provision koku tenant schema '${KOKU_SCHEMA}'."
+    echo "  The data-retention session fixture will 503 and error the IQE run; aborting."
+    exit 1
 fi
 
 # -----------------------------------------------------------------------------
@@ -833,14 +834,15 @@ if kubectl exec --request-timeout=120s -n "${NAMESPACE}" "deploy/${HELM_RELEASE_
         python /opt/rbac/rbac/manage.py shell -c "${RBAC_BOOTSTRAP_SCRIPT}"; then
     echo "✓ RBAC roles granted"
 else
-    echo "⚠ WARNING: RBAC role grant failed. Source-create and ingest tests may fail."
+    echo "⚠ ERROR: RBAC role grant failed. Source-create and ingest tests will fail; aborting."
+    exit 1
 fi
 
 # RBAC V2 tenant bootstrap (TenantMapping, workspaces, role bindings). Without
 # this RBAC can return 400 on /access/ queries. Mirrors e2e-pytest.
 kubectl exec --request-timeout=120s -n "${NAMESPACE}" "deploy/${HELM_RELEASE_NAME}-rbac-api" -- \
     python /opt/rbac/rbac/manage.py bootstrap_tenants --org-id "${ORG_ID}" --force \
-    || echo "⚠ WARNING: RBAC V2 bootstrap_tenants failed; /access/ queries may 400."
+    || { echo "⚠ ERROR: RBAC V2 bootstrap_tenants failed; /access/ queries will 400; aborting."; exit 1; }
 
 echo ""
 echo "Creating IQE test pod..."

--- a/scripts/run-iqe-tests.sh
+++ b/scripts/run-iqe-tests.sh
@@ -348,7 +348,7 @@ OAUTH_URL="https://${KEYCLOAK_HOST}/realms/kubernetes/protocol/openid-connect"
 # Get org_id and account_number from Keycloak admin user.
 # Canonical source of truth: jwtAuth.realmUsers in values.yaml — these values
 # are provisioned into Keycloak by deploy-rhbk.sh and read back here dynamically.
-ORG_ID="org1234567"
+ORG_ID="1234567"
 ACCOUNT_NUMBER="7890123"
 if [ -n "$KEYCLOAK_HOST" ]; then
     KEYCLOAK_ADMIN_USER=$(kubectl get secret keycloak-initial-admin -n keycloak -o jsonpath='{.data.username}' 2>/dev/null | base64 -d || echo "")
@@ -738,6 +738,109 @@ spec:
         - port: ${MASU_PORT}
           protocol: TCP
 EOF
+
+# -----------------------------------------------------------------------------
+# Pre-provision the koku tenant schema for the IQE test org.
+# -----------------------------------------------------------------------------
+# koku creates a customer's tenant schema lazily, and only on a *write* request
+# (IdentityHeaderMiddleware.create_customer persists on non-GET/HEAD). IQE's
+# session-scoped autouse fixtures issue GETs first — notably the data-retention
+# settings fixture (GET /account-settings/data-retention/) — which resolve to
+# the tenant schema but never create it. Without the schema, the retention view
+# raises UndefinedTable on tenant_settings and returns 503, erroring the entire
+# IQE session.
+#
+# The schema name is derived exactly as koku does (create_schema_name(org_id) =
+# "org<org_id>"). ORG_ID must be a bare numeric (e.g. 1234567) so this yields
+# the expected "org1234567" — not the doubled "orgorg1234567" produced when the
+# identity's org_id is already "org"-prefixed.
+#
+# Creating the tenant also builds template0 (running all migrations once) and
+# clones it, pre-empting the "gateway timeout on first source create" that
+# otherwise occurs when the clone runs inline during the first ingest test.
+# Idempotent: get_or_create + create_schema(check_if_exists=True).
+KOKU_SCHEMA="org${ORG_ID}"
+echo ""
+echo "Pre-provisioning koku tenant schema '${KOKU_SCHEMA}' (org_id=${ORG_ID})..."
+KOKU_PROVISION_SCRIPT="$(cat <<PYEOF
+from api.iam.models import Customer, Tenant
+from api.iam.serializers import create_schema_name
+org_id = "${ORG_ID}"
+account = "${ACCOUNT_NUMBER}"
+schema = create_schema_name(org_id)
+cust, c_created = Customer.objects.get_or_create(
+    org_id=org_id, defaults={"account_id": account, "schema_name": schema})
+tenant, t_created = Tenant.objects.get_or_create(schema_name=schema)
+tenant.create_schema(check_if_exists=True)
+print(f"koku tenant provisioned: schema={schema} customer_created={c_created} tenant_created={t_created}")
+PYEOF
+)"
+if kubectl exec --request-timeout=300s -n "${NAMESPACE}" "deploy/${HELM_RELEASE_NAME}-koku-api" -c koku-api -- \
+        python /opt/koku/koku/manage.py shell -c "${KOKU_PROVISION_SCRIPT}"; then
+    echo "✓ koku tenant schema '${KOKU_SCHEMA}' ready"
+else
+    echo "⚠ WARNING: Could not pre-provision koku tenant schema '${KOKU_SCHEMA}'."
+    echo "  The data-retention session fixture may 503 and error the IQE run."
+fi
+
+# -----------------------------------------------------------------------------
+# Grant RBAC roles to the IQE service account principal.
+# -----------------------------------------------------------------------------
+# IQE authenticates via client_credentials as ${KEYCLOAK_CLIENT_ID}; koku sees
+# the principal as "cost-mgmt-operator" (the operator client's hardcoded
+# preferred_username mapper) with is_org_admin=false. Without explicit RBAC it
+# cannot create sources or write cost data, so the ingest smoke tests fail.
+# Grants Cost Administrator (cost-management:*:*) + Sources administrator
+# (sources:*:*); the latter is required for source-create writes. Mirrors the
+# e2e-pytest _rbac_bootstrap fixture (test/pytest/conftest.py). Idempotent.
+echo ""
+echo "Granting RBAC roles to IQE service account (org_id=${ORG_ID})..."
+RBAC_BOOTSTRAP_SCRIPT="$(cat <<PYEOF
+from api.models import Tenant
+from management.models import Group, Policy, Role, Principal
+from django.core.cache import cache
+
+sa_usernames = ["cost-mgmt-operator", "service-account-${KEYCLOAK_CLIENT_ID}", "admin"]
+org_id = "${ORG_ID}"
+acct_number = "${ACCOUNT_NUMBER}"
+
+public_tenant = Tenant.objects.get(tenant_name="public")
+role_names = ["Cost Administrator", "Sources administrator"]
+roles = [Role.objects.filter(name=n, tenant=public_tenant).first() for n in role_names]
+roles = [r for r in roles if r]
+if not roles:
+    print("RBAC bootstrap: no target roles found; skipping")
+else:
+    tenant, created = Tenant.objects.get_or_create(
+        org_id=org_id, defaults={"tenant_name": "acct" + acct_number, "ready": True})
+    grp, _ = Group.objects.get_or_create(
+        name="CI Test Admin", tenant=tenant,
+        defaults={"admin_default": False, "system": True,
+                  "description": "CI service account admin access"})
+    policy, _ = Policy.objects.get_or_create(
+        name="CI Test Admin Policy", tenant=tenant, group=grp)
+    for r in roles:
+        policy.roles.add(r)
+    for sa_name in sa_usernames:
+        principal, _ = Principal.objects.get_or_create(
+            username=sa_name, tenant=tenant, defaults={"type": "user"})
+        grp.principals.add(principal)
+    cache.clear()
+    print(f"RBAC bootstrap: granted {[r.name for r in roles]} to {sa_usernames} for org_id={org_id}")
+PYEOF
+)"
+if kubectl exec --request-timeout=120s -n "${NAMESPACE}" "deploy/${HELM_RELEASE_NAME}-rbac-api" -- \
+        python /opt/rbac/rbac/manage.py shell -c "${RBAC_BOOTSTRAP_SCRIPT}"; then
+    echo "✓ RBAC roles granted"
+else
+    echo "⚠ WARNING: RBAC role grant failed. Source-create and ingest tests may fail."
+fi
+
+# RBAC V2 tenant bootstrap (TenantMapping, workspaces, role bindings). Without
+# this RBAC can return 400 on /access/ queries. Mirrors e2e-pytest.
+kubectl exec --request-timeout=120s -n "${NAMESPACE}" "deploy/${HELM_RELEASE_NAME}-rbac-api" -- \
+    python /opt/rbac/rbac/manage.py bootstrap_tenants --org-id "${ORG_ID}" --force \
+    || echo "⚠ WARNING: RBAC V2 bootstrap_tenants failed; /access/ queries may 400."
 
 echo ""
 echo "Creating IQE test pod..."

--- a/scripts/setup-test-data.sh
+++ b/scripts/setup-test-data.sh
@@ -455,7 +455,7 @@ def main():
             koku_api_url,
             jwt_token.identity_header,
             cluster_id,
-            "org1234567",
+            "1234567",
             source_name,
         )
         

--- a/test/pytest/conftest.py
+++ b/test/pytest/conftest.py
@@ -52,7 +52,7 @@ install_route_dns_retries()
 
 # Fallback identity values when Keycloak is unreachable.
 # Canonical source: jwtAuth.realmUsers in cost-onprem/values.yaml.
-_DEFAULT_ORG_ID = "org1234567"
+_DEFAULT_ORG_ID = "1234567"
 _DEFAULT_ACCOUNT_NUMBER = "7890123"
 
 # OAuth ``scope`` string for password grant. Do **not** include the literal token

--- a/test/pytest/jwt_forge.py
+++ b/test/pytest/jwt_forge.py
@@ -36,7 +36,7 @@ def forge_jwt(claims: Dict[str, Any], *, algorithm: str = "RS256") -> str:
 def forge_expired_jwt(
     *,
     sub: str = "forge-expired",
-    org_id: str = "org1234567",
+    org_id: str = "1234567",
     account_number: str = "7890123",
     skew_seconds: int = 3600,
 ) -> str:
@@ -53,7 +53,7 @@ def forge_expired_jwt(
 
 def forge_jwt_missing_sub(
     *,
-    org_id: str = "org1234567",
+    org_id: str = "1234567",
     ttl_seconds: int = 300,
 ) -> str:
     """JWT without ``sub`` (and without other required identity claims)."""


### PR DESCRIPTION
## Jira

[COST-8173](https://redhat.atlassian.net/browse/COST-8173)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
Updates IQE smoke-test setup for COST-8173.

- Uses bare numeric `org_id` values (`1234567`) across deployment, local test, test-data, and JWT helpers.
- Pre-provisions the Koku tenant schema and RBAC resources before creating the IQE test pod.
- Configures RBAC V2 tenant bootstrap for IQE service accounts.
- Fails setup when tenant or RBAC bootstrap fails.
- No CRD API, reconcile-phase, operator RBAC, or user-visible status-condition changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->