### PR TITLE
[COST-8190] Set ROLE_CREATE_ALLOW_LIST on RBAC env

### DIFF
--- a/internal/resources/rbac.go
+++ b/internal/resources/rbac.go
@@ -53,6 +53,13 @@ func rbacEnv(cfg *costv1alpha1.CostManagementServiceConfig) []corev1.EnvVar {
 		EnvVal("DJANGO_LOG_FORMATTER", "simple"),
 		EnvVal("DJANGO_LOG_HANDLERS", "console"),
 		EnvVal("ACCESS_CACHE_ENABLED", "True"),
+		// Applications whose permissions may back custom roles. insights-rbac
+		// parses this as `os.environ.get("ROLE_CREATE_ALLOW_LIST", "").split(",")`,
+		// so leaving it unset yields [""], which makes the custom-role wizard's
+		// GET /permissions/?allowed_only=true return nothing (empty Application
+		// filter). Seed data ships permissions/roles for cost-management and
+		// sources only, so those are the meaningful entries on-prem.
+		EnvVal("ROLE_CREATE_ALLOW_LIST", "cost-management,sources"),
 	}
 	if cfg.Spec.Cache.Auth.Enabled && cfg.Spec.Cache.Auth.SecretName != "" {
 		env = append(env,

--- a/internal/resources/rbac_test.go
+++ b/internal/resources/rbac_test.go
@@ -44,6 +44,29 @@ func TestRBACEnvAPIPathPrefix(t *testing.T) {
 	}
 }
 
+// TestRBACEnvRoleCreateAllowList verifies ROLE_CREATE_ALLOW_LIST is set
+// non-empty. insights-rbac does `get("ROLE_CREATE_ALLOW_LIST", "").split(",")`,
+// so an unset var becomes [""] and the custom-role wizard's
+// GET /permissions/?allowed_only=true returns nothing (COST-8190).
+func TestRBACEnvRoleCreateAllowList(t *testing.T) {
+	cfg := &costv1alpha1.CostManagementServiceConfig{}
+	cfg.Name = "cost-onprem"
+	cfg.Namespace = "cost-tests"
+
+	found := false
+	for _, e := range rbacEnv(cfg) {
+		if e.Name == "ROLE_CREATE_ALLOW_LIST" {
+			found = true
+			if e.Value != "cost-management,sources" {
+				t.Fatalf("ROLE_CREATE_ALLOW_LIST = %q, want cost-management,sources", e.Value)
+			}
+		}
+	}
+	if !found {
+		t.Fatal("ROLE_CREATE_ALLOW_LIST not set on RBAC env (would evaluate to [\"\"] in insights-rbac)")
+	}
+}
+
 // TestRBACEnvUsesConfiguredCachePort verifies that RBAC pods use the cache
 // port from spec.cache.port rather than a hardcoded 6379. Users running
 // Redis/Valkey on a non-default port would silently get the wrong connection.


### PR DESCRIPTION
## Problem

The custom-role creation wizard in the RBAC UI shows an empty **Permissions**
and **Application** filter (Step 2), and role creation fails with *"Custom roles
cannot be created for cost-management"*.

### Root cause

`internal/resources/rbac.go` `rbacEnv()` never set `ROLE_CREATE_ALLOW_LIST`.
insights-rbac parses it as:

```python
# rbac/rbac/settings.py:468
ROLE_CREATE_ALLOW_LIST = ENVIRONMENT.get_value("ROLE_CREATE_ALLOW_LIST", default="").split(",")
```

Unset → `"".split(",")` → **`[""]`** (a list with one empty string, not an empty
list). Then:

```python
# rbac/management/permission/view.py:71  (GET /api/rbac/v1/permissions/?allowed_only=true)
queryset = queryset.filter(application__in=settings.ROLE_CREATE_ALLOW_LIST)   # application__in=[""]
```

→ zero rows. `rbac/management/role/view.py:685` (`if app not in
settings.ROLE_CREATE_ALLOW_LIST`) likewise blocks the create.

### Chart vs operator

Not new to the operator port — it inherited the chart's default:

- Upstream SaaS **does** set it: `insights-rbac/deploy/rbac-clowdapp.yml` ships
  `ROLE_CREATE_ALLOW_LIST=cost-management,remediations,inventory,…,ros,…`.
- `cost-onprem-chart` exposes `rbac.roleCreateAllowList` but defaults it to `""`,
  and `templates/rbac/deployment-api.yaml` wraps the env var in
  `{{- if .Values.rbac.roleCreateAllowList }}` — so a default install **omits**
  the var and hits the same `[""]` bug (its `docs/operations/rbac-setup.md`
  documents this as a manual workaround).
- The operator mirrored that default: no var, no knob.

## Fix

Set `ROLE_CREATE_ALLOW_LIST=cost-management,sources` in `rbacEnv()`.
`internal/resources/rbac_seed/data/` ships permissions/roles for `cost-management`
and `sources` only, so those are the meaningful on-prem entries. Applied via
`rbacEnv()` to every RBAC container (API, worker, migrate/seed, keycloak-sync) —
a read-only Django setting, kept consistent everywhere; only the API deployment
actually needs it.

## Test

`TestRBACEnvRoleCreateAllowList` asserts the var is present and non-empty
(catches the `[""]` regression). `go test ./internal/resources/...`,
`go vet`, `golangci-lint` all green.

## Follow-up (not here)

`get_value(..., default="").split(",")` yielding `[""]` is a footgun in
insights-rbac itself — worth an upstream note to filter empty entries so "unset"
means "no allow-list" rather than "allow-list of one empty app".


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Set `ROLE_CREATE_ALLOW_LIST=cost-management,sources` for all RBAC containers.
- Restore custom role creation for cost-management and sources permissions.
- Add test coverage for the configured allow list.

## Operator impact

- No CRD API or reconcile-phase changes.
- RBAC now returns permissions for `cost-management` and `sources`.
- No user-visible status condition changes.

## Validation

- `go test ./internal/resources/...`
- `go vet`
- `golangci-lint`

<!-- end of auto-generated comment: release notes by coderabbit.ai -->