### PR TITLE
[COST-8202] Pass --cookie-refresh to the UI oauth2-proxy

### DIFF
--- a/api/v1alpha1/costmanagementserviceconfig_types.go
+++ b/api/v1alpha1/costmanagementserviceconfig_types.go
@@ -599,6 +599,12 @@ type OAuthProxySpec struct {
 	// Cookie session expiration (e.g. "720h").
 	// +kubebuilder:default:="720h"
 	CookieExpire string `json:"cookieExpire,omitempty"`
+	// How often oauth2-proxy refreshes the access token from Keycloak using the
+	// refresh token (e.g. "4m"). Must be shorter than the Keycloak access-token
+	// lifespan (default 5m); otherwise oauth2-proxy forwards an expired token to
+	// Envoy, which returns 401 and the RBAC UI reload-loops. Chart parity: "4m".
+	// +kubebuilder:default:="4m"
+	CookieRefresh string `json:"cookieRefresh,omitempty"`
 }
 
 type UIAppSpec struct {

--- a/bundle/manifests/service.costmanagement.openshift.io_costmanagementserviceconfigs.yaml
+++ b/bundle/manifests/service.costmanagement.openshift.io_costmanagementserviceconfigs.yaml
@@ -2672,6 +2672,14 @@ spec:
                         default: 720h
                         description: Cookie session expiration (e.g. "720h").
                         type: string
+                      cookieRefresh:
+                        default: 4m
+                        description: |-
+                          How often oauth2-proxy refreshes the access token from Keycloak using the
+                          refresh token (e.g. "4m"). Must be shorter than the Keycloak access-token
+                          lifespan (default 5m); otherwise oauth2-proxy forwards an expired token to
+                          Envoy, which returns 401 and the RBAC UI reload-loops. Chart parity: "4m".
+                        type: string
                       image:
                         properties:
                           pullPolicy:

--- a/config/crd/bases/service.costmanagement.openshift.io_costmanagementserviceconfigs.yaml
+++ b/config/crd/bases/service.costmanagement.openshift.io_costmanagementserviceconfigs.yaml
@@ -2672,6 +2672,14 @@ spec:
                         default: 720h
                         description: Cookie session expiration (e.g. "720h").
                         type: string
+                      cookieRefresh:
+                        default: 4m
+                        description: |-
+                          How often oauth2-proxy refreshes the access token from Keycloak using the
+                          refresh token (e.g. "4m"). Must be shorter than the Keycloak access-token
+                          lifespan (default 5m); otherwise oauth2-proxy forwards an expired token to
+                          Envoy, which returns 401 and the RBAC UI reload-loops. Chart parity: "4m".
+                        type: string
                       image:
                         properties:
                           pullPolicy:

--- a/internal/resources/ui.go
+++ b/internal/resources/ui.go
@@ -207,6 +207,11 @@ func UIDeployment(cfg *costv1alpha1.CostManagementServiceConfig) *appsv1.Deploym
 		"--email-domain=*",
 		"--cookie-secure=true",
 		"--cookie-expire=" + spec.OAuthProxy.CookieExpire,
+		// Refresh the access token from Keycloak in the background before it
+		// expires. Without this, oauth2-proxy keeps forwarding the expired
+		// ~5m Keycloak token to Envoy, which 401s, and the RBAC UI reload-
+		// loops instead of re-authenticating (COST-8202).
+		"--cookie-refresh=" + spec.OAuthProxy.CookieRefresh,
 		"--provider-ca-file=/etc/keycloak-ca/ca.crt",
 	}
 	// Public Keycloak Routes use the OpenShift router cert, not the service CA

--- a/internal/resources/ui_test.go
+++ b/internal/resources/ui_test.go
@@ -24,7 +24,8 @@ func uiTestCfg() *costv1alpha1.CostManagementServiceConfig {
 				Repository: "registry.redhat.io/rhceph/oauth2-proxy-rhel9",
 				Tag:        "v7.6.0",
 			},
-			CookieExpire: "720h",
+			CookieExpire:  "720h",
+			CookieRefresh: "4m",
 		},
 		App: costv1alpha1.UIAppSpec{
 			Image: costv1alpha1.ImageSpec{
@@ -90,6 +91,19 @@ func TestUIDeploymentOAuthProxyHonorsInsecureSkipVerify(t *testing.T) {
 	proxySecure := containerByName(t, depSecure.Spec.Template.Spec.Containers, "oauth-proxy")
 	if slices.Contains(proxySecure.Args, skipVerifyArg) {
 		t.Fatal("oauth-proxy must not set --ssl-insecure-skip-verify when insecureSkipVerify=false")
+	}
+}
+
+// TestUIDeploymentOAuthProxyCookieRefresh verifies oauth2-proxy is told to
+// refresh the Keycloak access token before it expires. Without --cookie-refresh
+// the expired ~5m token is forwarded to Envoy, which 401s, and the RBAC UI
+// reload-loops instead of re-authenticating (COST-8202).
+func TestUIDeploymentOAuthProxyCookieRefresh(t *testing.T) {
+	cfg := uiTestCfg()
+	cfg.Spec.UI.OAuthProxy.CookieRefresh = "3m"
+	proxy := containerByName(t, UIDeployment(cfg).Spec.Template.Spec.Containers, "oauth-proxy")
+	if !slices.Contains(proxy.Args, "--cookie-refresh=3m") {
+		t.Fatalf("oauth-proxy args missing --cookie-refresh=3m\ngot %q", proxy.Args)
 	}
 }
 


### PR DESCRIPTION
## Problem

On the RBAC page, once the Keycloak access token expires (~5 min) the browser
enters an **infinite page-reload loop** instead of re-authenticating.

### Root cause

`OAuthProxySpec` (`api/v1alpha1/costmanagementserviceconfig_types.go`) was ported
from `cost-onprem-chart` with only `cookieExpire`. The chart's
`templates/ui/deployment.yaml` set **both**:

```yaml
- --cookie-expire={{ .Values.ui.oauthProxy.cookie.expire }}    # "720h"
- --cookie-refresh={{ .Values.ui.oauthProxy.cookie.refresh }}  # "4m"
```

`--cookie-refresh` was never carried over — `internal/resources/ui.go` builds the
oauth-proxy args with `--cookie-expire=` but nothing else about token lifetime.

So oauth2-proxy treats the 720h cookie as valid and keeps forwarding the expired
~5 m Keycloak access token to Envoy. Envoy returns `401`. `insights-rbac-ui`'s
`handle401Error` interceptor (`browser.tsx`, upstream `RedHatInsights/insights-rbac-ui`,
a git submodule in `koku-ui`) responds to a 401 by calling
`window.location.reload()` — which just resends the same dead cookie. Loop.

Upstream designed `reload()` for the SaaS Chrome shell, where it triggers silent
SSO renewal. On-prem behind oauth2-proxy it only works if the proxy owns the
token lifecycle — i.e. `--cookie-refresh` is set.

## Fix

- `OAuthProxySpec.CookieRefresh string`, `+kubebuilder:default:="4m"` (chart
  parity; must be shorter than the Keycloak access-token lifespan).
- `ui.go`: append `--cookie-refresh=<CookieRefresh>` to the oauth-proxy args.
- Regenerated `config/crd/bases/…` and `bundle/manifests/…` CRDs.

With this, oauth2-proxy refreshes the access token in the background before it
expires (no 401 during active use), and when the SSO session itself has truly
expired the page reload gets a `302` to Keycloak login. No fork of
`insights-rbac-ui` needed.

## Test

`TestUIDeploymentOAuthProxyCookieRefresh` asserts `--cookie-refresh=<value>` is
on the oauth-proxy container. `make test`, `go vet`, `make bundle` validate all
pass.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

Adds `OAuthProxySpec.CookieRefresh` with a default value of `4m`.

The operator passes `--cookie-refresh=<value>` to the UI `oauth2-proxy` deployment. This refreshes Keycloak access tokens before expiration and avoids the RBAC page reload loop.

## Operator impact

- Adds a backward-compatible CRD field. Existing resources use the `4m` default.
- Updates the UI deployment during reconciliation. The generated container arguments include the configured refresh interval.
- Does not change RBAC permissions.
- Does not add or change user-visible status conditions.
- Adds deployment coverage for the generated argument.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->