### PR TITLE
[COST-8187] Add required oauth2-proxy cookieRefresh for UI sessions

### DIFF
--- a/api/v1alpha1/costmanagementserviceconfig_types.go
+++ b/api/v1alpha1/costmanagementserviceconfig_types.go
@@ -599,6 +599,11 @@ type OAuthProxySpec struct {
 	// Cookie session expiration (e.g. "720h").
 	// +kubebuilder:default:="720h"
 	CookieExpire string `json:"cookieExpire,omitempty"`
+	// Interval for silently refreshing the OIDC access token (e.g. "4m").
+	// Must be shorter than the Keycloak accessTokenLifespan so sessions survive
+	// past the first access-token expiry (cost-onprem-chart: ui.oauthProxy.cookie.refresh).
+	// +kubebuilder:validation:Required
+	CookieRefresh string `json:"cookieRefresh"`
 }
 
 type UIAppSpec struct {

--- a/bundle/manifests/koku-service-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/koku-service-operator.clusterserviceversion.yaml
@@ -145,6 +145,7 @@ metadata:
                 }
               },
               "oauthProxy": {
+                "cookieRefresh": "4m",
                 "image": {
                   "repository": "registry.redhat.io/rhceph/oauth2-proxy-rhel9",
                   "tag": "v7.6.0"
@@ -156,7 +157,7 @@ metadata:
         }
       ]
     capabilities: Basic Install
-    createdAt: "2026-09-03T14:07:27Z"
+    createdAt: "2026-09-07T10:43:52Z"
     operators.operatorframework.io/builder: operator-sdk-v1.42.3
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v4
   name: koku-service-operator.v0.0.1

--- a/bundle/manifests/service.costmanagement.openshift.io_costmanagementserviceconfigs.yaml
+++ b/bundle/manifests/service.costmanagement.openshift.io_costmanagementserviceconfigs.yaml
@@ -2672,6 +2672,12 @@ spec:
                         default: 720h
                         description: Cookie session expiration (e.g. "720h").
                         type: string
+                      cookieRefresh:
+                        description: |-
+                          Interval for silently refreshing the OIDC access token (e.g. "4m").
+                          Must be shorter than the Keycloak accessTokenLifespan so sessions survive
+                          past the first access-token expiry (cost-onprem-chart: ui.oauthProxy.cookie.refresh).
+                        type: string
                       image:
                         properties:
                           pullPolicy:
@@ -2747,6 +2753,8 @@ spec:
                               More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                             type: object
                         type: object
+                    required:
+                    - cookieRefresh
                     type: object
                   replicaCount:
                     default: 1

--- a/config/crd/bases/service.costmanagement.openshift.io_costmanagementserviceconfigs.yaml
+++ b/config/crd/bases/service.costmanagement.openshift.io_costmanagementserviceconfigs.yaml
@@ -2672,6 +2672,12 @@ spec:
                         default: 720h
                         description: Cookie session expiration (e.g. "720h").
                         type: string
+                      cookieRefresh:
+                        description: |-
+                          Interval for silently refreshing the OIDC access token (e.g. "4m").
+                          Must be shorter than the Keycloak accessTokenLifespan so sessions survive
+                          past the first access-token expiry (cost-onprem-chart: ui.oauthProxy.cookie.refresh).
+                        type: string
                       image:
                         properties:
                           pullPolicy:
@@ -2747,6 +2753,8 @@ spec:
                               More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                             type: object
                         type: object
+                    required:
+                    - cookieRefresh
                     type: object
                   replicaCount:
                     default: 1

--- a/config/samples/byoi/app/costmanagementserviceconfig-smoke.yaml
+++ b/config/samples/byoi/app/costmanagementserviceconfig-smoke.yaml
@@ -118,6 +118,7 @@ spec:
         repository: quay.io/insights-onprem/koku-ui-onprem
         tag: "2f23c646581028bd385856b6713e6bf367baf953"
     oauthProxy:
+      cookieRefresh: "4m"
       image:
         repository: registry.redhat.io/rhceph/oauth2-proxy-rhel9
         tag: "v7.6.0"

--- a/config/samples/byoi/app/costmanagementserviceconfig.yaml
+++ b/config/samples/byoi/app/costmanagementserviceconfig.yaml
@@ -126,6 +126,7 @@ spec:
         repository: quay.io/insights-onprem/koku-ui-onprem
         tag: "2f23c646581028bd385856b6713e6bf367baf953"
     oauthProxy:
+      cookieRefresh: "4m"
       image:
         repository: registry.redhat.io/rhceph/oauth2-proxy-rhel9
         tag: "v7.6.0"

--- a/config/samples/service.costmanagement_v1alpha1_costmanagementserviceconfig.yaml
+++ b/config/samples/service.costmanagement_v1alpha1_costmanagementserviceconfig.yaml
@@ -119,6 +119,7 @@ spec:
     # oauthClientSecretRef:
     #   name: cost-management-ui-oauth-client
     oauthProxy:
+      cookieRefresh: "4m"
       image:
         repository: registry.redhat.io/rhceph/oauth2-proxy-rhel9
         tag: "v7.6.0"

--- a/config/samples/service.costmanagement_v1alpha1_costmanagementserviceconfig_byoi.yaml
+++ b/config/samples/service.costmanagement_v1alpha1_costmanagementserviceconfig_byoi.yaml
@@ -156,6 +156,7 @@ spec:
         repository: quay.io/insights-onprem/koku-ui-onprem
         tag: "2f23c646581028bd385856b6713e6bf367baf953"
     oauthProxy:
+      cookieRefresh: "4m"
       image:
         repository: registry.redhat.io/rhceph/oauth2-proxy-rhel9
         tag: "v7.6.0"

--- a/config/samples/service.costmanagement_v1alpha1_costmanagementserviceconfig_community.yaml
+++ b/config/samples/service.costmanagement_v1alpha1_costmanagementserviceconfig_community.yaml
@@ -122,6 +122,7 @@ spec:
     # oauthClientSecretRef:
     #   name: cost-management-ui-oauth-client
     oauthProxy:
+      cookieRefresh: "4m"
       image:
         repository: quay.io/oauth2-proxy/oauth2-proxy
         tag: "v7.6.0"

--- a/config/samples/service.costmanagement_v1alpha1_costmanagementserviceconfig_minimal.yaml
+++ b/config/samples/service.costmanagement_v1alpha1_costmanagementserviceconfig_minimal.yaml
@@ -102,6 +102,7 @@ spec:
         repository: quay.io/insights-onprem/koku-ui-onprem
         tag: "2f23c646581028bd385856b6713e6bf367baf953"
     oauthProxy:
+      cookieRefresh: "4m"
       image:
         repository: registry.redhat.io/rhceph/oauth2-proxy-rhel9
         tag: "v7.6.0"

--- a/config/samples/service.costmanagement_v1alpha1_costmanagementserviceconfig_production.yaml
+++ b/config/samples/service.costmanagement_v1alpha1_costmanagementserviceconfig_production.yaml
@@ -204,6 +204,7 @@ spec:
           cpu: 500m
           memory: 512Mi
     oauthProxy:
+      cookieRefresh: "4m"
       image:
         repository: registry.redhat.io/rhceph/oauth2-proxy-rhel9
         tag: "v7.6.0"

--- a/internal/resources/ui.go
+++ b/internal/resources/ui.go
@@ -207,6 +207,7 @@ func UIDeployment(cfg *costv1alpha1.CostManagementServiceConfig) *appsv1.Deploym
 		"--email-domain=*",
 		"--cookie-secure=true",
 		"--cookie-expire=" + spec.OAuthProxy.CookieExpire,
+		"--cookie-refresh=" + spec.OAuthProxy.CookieRefresh,
 		"--provider-ca-file=/etc/keycloak-ca/ca.crt",
 	}
 	// Public Keycloak Routes use the OpenShift router cert, not the service CA

--- a/internal/resources/ui_test.go
+++ b/internal/resources/ui_test.go
@@ -24,7 +24,8 @@ func uiTestCfg() *costv1alpha1.CostManagementServiceConfig {
 				Repository: "registry.redhat.io/rhceph/oauth2-proxy-rhel9",
 				Tag:        "v7.6.0",
 			},
-			CookieExpire: "720h",
+			CookieExpire:  "720h",
+			CookieRefresh: "4m",
 		},
 		App: costv1alpha1.UIAppSpec{
 			Image: costv1alpha1.ImageSpec{


### PR DESCRIPTION
## Jira

[COST-8187](https://redhat.atlassian.net/browse/COST-8187)

## Summary

- Add required `spec.ui.oauthProxy.cookieRefresh` to `CostManagementServiceConfig` and wire it to oauth2-proxy `--cookie-refresh`.
- Update all sample CRs to set `cookieRefresh: "4m"` for chart parity with cost-onprem-chart.
- Fixes forced UI logout after ~5 minutes when deployed via the operator; sessions were ending at Keycloak access-token expiry with no silent renewal.

**Why `4m`?** Keycloak’s default `accessTokenLifespan` is 5 minutes. The Helm chart sets `ui.oauthProxy.cookie.refresh: "4m"` so oauth2-proxy silently renews the OIDC token *before* that expiry. Without `--cookie-refresh`, the session dies at the hard 5-minute limit regardless of user activity. Samples use `4m` to match the chart; clusters with a shorter Keycloak token lifespan should set `cookieRefresh` below that value.

## Test plan

- [ ] `go test ./api/v1alpha1/... ./internal/resources/...`
- [ ] Deploy operator with updated CR including `spec.ui.oauthProxy.cookieRefresh: "4m"`
- [ ] Log in to the UI and stay active past 6 minutes — confirm no redirect to Keycloak login
- [ ] Confirm oauth2-proxy args include `--cookie-refresh=4m` on the UI Deployment

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Adds required `spec.ui.oauthProxy.cookieRefresh` to the CRD API.
- Passes the value to oauth2-proxy as `--cookie-refresh`.
- Sets `"4m"` in all sample custom resources.
- Supports silent OIDC token renewal before Keycloak access-token expiry.

## Operator impact

- New or updated custom resources must set `cookieRefresh`.
- Reconciliation updates the UI oauth2-proxy Deployment with the configured value.
- No RBAC changes are included.
- No user-visible status condition changes are included.
- Tests update the UI configuration fixture for the new field.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->