### PR TITLE
[COST-7866] Document user management and initial admin seeding spike findings

### DIFF
--- a/.cursor/tasks/COST-7866/COST-7866.md
+++ b/.cursor/tasks/COST-7866/COST-7866.md
@@ -228,6 +228,6 @@ operator image is available and the stack reaches `Available=True`.
 
 **Deliverable:** This document.
 
-**Follow-up (out of scope for this PR):** Customer-facing install docs
-(`docs/install/user-access.md` or extension of `keycloak.md`) should explain
-the `org-admin` realm role requirement explicitly.
+**Customer-facing docs:** `docs/install/keycloak.md` now documents the
+`org-admin` realm role requirement (what it does, why it is needed, and how
+it differs from the Keycloak `org-admin` subgroup).

--- a/.cursor/tasks/COST-7866/COST-7866.md
+++ b/.cursor/tasks/COST-7866/COST-7866.md
@@ -1,0 +1,220 @@
+# COST-7866 Spike: User management, org-admin, and initial admin seeding
+
+**Jira:** [COST-7866](https://redhat.atlassian.net/browse/COST-7866)
+**Type:** Spike (QE)
+**Status:** Complete
+**Assignee:** Victor Sizilio
+**Parent:** [COST-7547](https://redhat.atlassian.net/browse/COST-7547)
+**Verified on:** Cluster Bot MCE (`chat-bot-xhem5-43khhc`), 2026-09-08
+
+---
+
+## 1. Executive summary
+
+**User management is Keycloak's job.** The operator never creates or manages
+human users. Customers provision users in RHBK or their corporate IdP.
+
+**The RBAC migration Job seeds the permission catalog** (roles like Cost
+Administrator and User Access administrator) into the insights-rbac database.
+It does **not** assign those roles to any named user.
+
+**The first Cost admin does not need a prior RBAC group membership or User
+Access admin role.** A Keycloak admin creates the user, sets `org_id` and
+`account_number` attributes, and assigns the **`org-admin` realm role**. On
+login, Envoy sets `is_org_admin=true` in `X-Rh-Identity`, and insights-rbac
+applies the **admin_default** role bundle, which includes both
+`cost-management:*:*` and **`rbac:*:*`** (User Access administrator).
+
+**There is no chicken-and-egg for the first admin** when the customer follows
+the Keycloak `org-admin` path.
+
+**Customers should not run lab scripts** (`deploy-rhbk.sh` realmUsers,
+pytest fixtures, Django shell) in production. Ongoing delegation can use
+**Keycloak groups + `spec.rbac.keycloakSync`**, or the **User Access UI**
+after the first org-admin user logs in.
+
+---
+
+## 2. Questions answered
+
+| Question | Answer |
+|----------|--------|
+| Is user management handled by Keycloak? | **Yes.** Operator consumes OIDC only. |
+| What does RBAC migration do? | Seeds roles/permissions; **0 principals** until first login/sync. |
+| How does the first admin get access? | Keycloak `org-admin` realm role → JWT → `is_org_admin` → admin_default. |
+| What does `org-admin: false` mean? | No realm role → `is_org_admin=false` → no admin_default bundle. |
+| Chicken-and-egg for User Access UI? | **No** for first org-admin: admin_default includes User Access administrator (`rbac:*:*`). |
+| Do customers script like QE? | **No.** Keycloak admin + optional operator helpers (`bootstrapAdmin`, `keycloakSync`). |
+| Are operator helpers an alternative to creating the first admin in Keycloak? | **No.** Keycloak user + `org-admin` realm role is always required. Helpers only touch the RBAC DB side. |
+
+---
+
+## 3. Recommended customer flow
+
+### 3.1 Before first login
+
+1. Customer provisions external infrastructure (PostgreSQL, cache, Kafka, S3,
+   Keycloak/RHBK).
+2. Customer installs the operator and applies `CostManagementServiceConfig`.
+3. **Keycloak admin** configures realm, clients, audience mappers, and protocol
+   mappers per `docs/install/keycloak.md`.
+4. Operator runs **RBAC migration** automatically (`{cr}-rbac-migrate` Job).
+   This seeds roles; it does not create users.
+
+### 3.2 First administrator
+
+5. **Keycloak admin** creates user (e.g. `jane@company.com`).
+6. Sets user attributes: `org_id`, `account_number` (exact claim names).
+7. Assigns realm role **`org-admin`**.
+8. Jane logs in via the UI (oauth2-proxy → Keycloak).
+9. Jane receives Cost admin **and** User Access admin through admin_default
+   (no scripting, no prior RBAC principal required).
+
+### 3.3 Optional operator helpers (not alternatives for first admin)
+
+These complement Keycloak; they do **not** replace creating the user or
+assigning the `org-admin` realm role.
+
+| Feature | What it does | First admin? |
+|---------|--------------|--------------|
+| `spec.rbac.bootstrapAdmin` | Seeds an RBAC Principal in the DB at install time (Secret: `org-id`, `account-number`, `username`). User must already exist in Keycloak with matching username. | Complement only |
+| `spec.rbac.keycloakSync` | Syncs Keycloak group membership into RBAC on a schedule. | Ongoing user management |
+
+### 3.4 Ongoing user management (production)
+
+**Primary path:** Keycloak / IdP admin manages users and group membership.
+
+Expected Keycloak layout for keycloakSync:
+
+```
+org-{orgId}/                 attributes: org_id, account_number
+  org-admin/                 subgroup: members get Cost Admin Default in RBAC
+```
+
+Enable `spec.rbac.keycloakSync` on the CR. The CronJob copies group members
+into insights-rbac Principals and groups.
+
+**Secondary path:** First org-admin uses the **User Access UI** in Cost
+Management to assign custom RBAC groups (Payment Viewer, etc.) after login.
+This works because admin_default grants `rbac:*:*`.
+
+### 3.5 What customers should not do
+
+- Run `scripts/deploy-rhbk.sh` realmUsers provisioning in production.
+- Expect the operator to create Keycloak users or passwords.
+- Rely on RBAC migration alone to make someone an admin.
+- Use `bootstrapAdmin` or `keycloakSync` instead of creating the Keycloak user.
+
+---
+
+## 4. Architecture (three layers)
+
+```
+Identity (Keycloak/IdP)  →  Cost auth (JWT + RBAC)  →  Delegation
+──────────────────────     ─────────────────────     ────────────
+Create users               org-admin realm role       Keycloak groups + keycloakSync
+Assign org-admin           is_org_admin in JWT        OR User Access UI (org-admin)
+Set org_id attributes      admin_default roles        bootstrapAdmin (RBAC DB only)
+```
+
+### Two different "org-admin" concepts
+
+| Mechanism | Layer | Purpose |
+|-----------|-------|---------|
+| **`org-admin` realm role** | JWT / Envoy | Sets `is_org_admin=true`; triggers admin_default at runtime |
+| **`org-admin` Keycloak subgroup** | keycloakSync | Group membership synced into RBAC `Cost Admin Default` group |
+
+Labs set both (e.g. `deploy-rhbk.sh`). Production docs must explain when each
+is needed. For JWT gateway auth, the **realm role** is required.
+
+---
+
+## 5. Cluster verification record
+
+**Cluster:** MCE AWS OpenShift, `apps.chat-bot-xhem5-43khhc.crt-mce-aws.devcluster.openshift.com`
+**Namespace:** `cost-onprem`
+**Infra:** `deploy-test-cost-onprem.sh --deploy-s4 --skip-helm`
+**Operator:** Local `./bin/manager --dev` (in-cluster operator image was unavailable;
+reconcile still ran against the cluster API)
+
+### 5.1 Keycloak (identity)
+
+| Check | Result |
+|-------|--------|
+| Realm `kubernetes` users | `admin` (enabled), `viewer` (created for test) |
+| `org-admin` realm role on `admin` | **Yes** |
+| `org-admin` realm role on `viewer` | **No** |
+| Admin JWT `org_id` | `1234567` |
+| Admin JWT `account_number` | `7890123` |
+| Admin JWT `aud` | includes `cost-management-ui` |
+| Keycloak group `org-1234567` | **Present** (keycloakSync layout) |
+
+### 5.2 RBAC migration Job
+
+| Check | Result |
+|-------|--------|
+| Job `cost-onprem-rbac-migrate` | **Succeeded** |
+| Permissions seeded | 20 |
+| Roles seeded | 6 (21 total in DB) |
+| Principals after migrate | **0** |
+| Org tenants after migrate | **0** (only `public`) |
+| `SchemaUpToDate` | **True** |
+
+**admin_default roles** (from Job logs and DB query):
+
+- Cost Administrator (`cost-management:*:*`)
+- User Access administrator (`rbac:*:*`)
+- Sources administrator
+- Notifications administrator
+- Inventory Groups Administrator
+- Inventory Hosts Administrator Local Test
+
+### 5.3 End-to-end gateway tests
+
+| Check | Result | Notes |
+|-------|--------|-------|
+| Envoy + RBAC `/access/` via gateway | **Not run** | Application images `ImagePullBackOff` on cluster; validation probes from laptop cannot resolve in-cluster DNS (expected `make run` limitation) |
+| pytest `test_org_admin_identity.py` | **Not run** | Blocked on gateway readiness |
+
+**Conclusion:** Identity and RBAC migration behavior are verified. Full JWT →
+Envoy → RBAC chain remains covered by existing CI pytest on other clusters;
+re-run when operator image is pushed and stack reaches `Available=True`.
+
+---
+
+## 6. Operator mechanisms (reference)
+
+### RBAC migration (`{cr}-rbac-migrate`)
+
+- **Code:** `internal/resources/migration.go` → `RBACMigrationJob`
+- **Runs:** Django migrate, built-in seeds, cost-management/sources seed,
+  admin_default group template, `bootstrap_tenants`, platform_default cleanup
+- **Does not:** Bind roles to usernames
+
+### bootstrapAdmin (`{cr}-rbac-admin-bootstrap`)
+
+- **CR:** `spec.rbac.bootstrapAdmin.enabled` + Secret (`org-id`,
+  `account-number`, `username`)
+- **Does:** Creates Tenant + Principal; adds user to `Cost Admin Default` group
+- **Does not:** Create Keycloak user or assign `org-admin` realm role
+
+### keycloakSync (CronJob)
+
+- **CR:** `spec.rbac.keycloakSync.enabled` + client Secret
+- **Code:** `internal/resources/scripts/sync_keycloak_principals.py`
+- **Does:** Sync Keycloak `org-{orgId}` / `org-admin` subgroup → RBAC Principals
+
+---
+
+## 7. Spike closure
+
+| Criterion | Status |
+|-----------|--------|
+| Confirm Keycloak owns user management | Done |
+| Document first-admin flow | Done (section 3) |
+| Document `org-admin: false` | Done |
+| Document RBAC migration scope | Done + verified on cluster |
+| Resolve User Access UI vs keycloakSync | Done: both viable; org-admin gets `rbac:*:*` via admin_default |
+| Cluster verification | Partial (identity + migration); gateway deferred |
+
+**Deliverable:** This document.

--- a/.cursor/tasks/COST-7866/COST-7866.md
+++ b/.cursor/tasks/COST-7866/COST-7866.md
@@ -22,8 +22,10 @@ It does **not** assign those roles to any named user.
 Access admin role.** A Keycloak admin creates the user, sets `org_id` and
 `account_number` attributes, and assigns the **`org-admin` realm role**. On
 login, Envoy sets `is_org_admin=true` in `X-Rh-Identity`, and insights-rbac
-applies the **admin_default** role bundle, which includes both
-`cost-management:*:*` and **`rbac:*:*`** (User Access administrator).
+applies the **admin_default** role bundle. That bundle includes
+`cost-management:*:*`, **`rbac:*:*`** (User Access administrator), and
+**Sources administrator** (`sources:*:*`), plus other platform admin roles
+(see section 5.2).
 
 **There is no chicken-and-egg for the first admin** when the customer follows
 the Keycloak `org-admin` path.
@@ -39,13 +41,13 @@ after the first org-admin user logs in.
 
 | Question | Answer |
 |----------|--------|
-| Is user management handled by Keycloak? | **Yes.** Operator consumes OIDC only. |
+| Is user management handled by Keycloak? | **Yes.** Human users remain in Keycloak/IdP. The application uses OIDC; optional `keycloakSync` reads Keycloak group membership through the Keycloak API. |
 | What does RBAC migration do? | Seeds roles/permissions; **0 principals** until first login/sync. |
 | How does the first admin get access? | Keycloak `org-admin` realm role → JWT → `is_org_admin` → admin_default. |
 | What does `org-admin: false` mean? | No realm role → `is_org_admin=false` → no admin_default bundle. |
 | Chicken-and-egg for User Access UI? | **No** for first org-admin: admin_default includes User Access administrator (`rbac:*:*`). |
-| Do customers script like QE? | **No.** Keycloak admin + optional operator helpers (`bootstrapAdmin`, `keycloakSync`). |
-| Are operator helpers an alternative to creating the first admin in Keycloak? | **No.** Keycloak user + `org-admin` realm role is always required. Helpers only touch the RBAC DB side. |
+| Do customers script like QE? | **No.** Keycloak admin + optional `keycloakSync` for ongoing RBAC sync. |
+| Is `keycloakSync` an alternative to creating the first admin in Keycloak? | **No.** Keycloak user + `org-admin` realm role is always required. `keycloakSync` only syncs existing group members into RBAC Principals. |
 
 ---
 
@@ -70,15 +72,18 @@ after the first org-admin user logs in.
 9. Jane receives Cost admin **and** User Access admin through admin_default
    (no scripting, no prior RBAC principal required).
 
-### 3.3 Optional operator helpers (not alternatives for first admin)
+### 3.3 Optional operator helper (not an alternative for first admin)
 
-These complement Keycloak; they do **not** replace creating the user or
-assigning the `org-admin` realm role.
+`spec.rbac.keycloakSync` complements Keycloak; it does **not** replace
+creating the user or assigning the `org-admin` realm role.
 
 | Feature | What it does | First admin? |
 |---------|--------------|--------------|
-| `spec.rbac.bootstrapAdmin` | Seeds an RBAC Principal in the DB at install time (Secret: `org-id`, `account-number`, `username`). User must already exist in Keycloak with matching username. | Complement only |
-| `spec.rbac.keycloakSync` | Syncs Keycloak group membership into RBAC on a schedule. | Ongoing user management |
+| `spec.rbac.keycloakSync` | Syncs top-level `org-{orgId}` group members into RBAC Principals on a schedule (Keycloak API client credentials). Does not create Keycloak users. | Ongoing RBAC synchronization |
+
+> **Note:** `spec.rbac.bootstrapAdmin` and `{cr}-rbac-admin-bootstrap` were
+> removed in COST-8088 (Variant A: JWT `is_org_admin` + public "Default admin
+> access"). Do not document or configure that path.
 
 ### 3.4 Ongoing user management (production)
 
@@ -88,11 +93,14 @@ Expected Keycloak layout for keycloakSync:
 
 ```
 org-{orgId}/                 attributes: org_id, account_number
-  org-admin/                 subgroup: members get Cost Admin Default in RBAC
+  org-admin/                 subgroup (logged for observability only)
 ```
 
-Enable `spec.rbac.keycloakSync` on the CR. The CronJob copies group members
-into insights-rbac Principals and groups.
+Enable `spec.rbac.keycloakSync` on the CR. The CronJob copies **top-level**
+`org-{orgId}` group members into insights-rbac Principals and runs
+`bootstrap_tenants` for each org. Admin access is **not** granted via the
+subgroup — it remains JWT-based (`is_org_admin` + public "Default admin
+access").
 
 **Secondary path:** First org-admin uses the **User Access UI** in Cost
 Management to assign custom RBAC groups (Payment Viewer, etc.) after login.
@@ -103,7 +111,8 @@ This works because admin_default grants `rbac:*:*`.
 - Run `scripts/deploy-rhbk.sh` realmUsers provisioning in production.
 - Expect the operator to create Keycloak users or passwords.
 - Rely on RBAC migration alone to make someone an admin.
-- Use `bootstrapAdmin` or `keycloakSync` instead of creating the Keycloak user.
+- Use `keycloakSync` instead of creating the Keycloak user and assigning the
+  `org-admin` realm role.
 
 ---
 
@@ -114,7 +123,7 @@ Identity (Keycloak/IdP)  →  Cost auth (JWT + RBAC)  →  Delegation
 ──────────────────────     ─────────────────────     ────────────
 Create users               org-admin realm role       Keycloak groups + keycloakSync
 Assign org-admin           is_org_admin in JWT        OR User Access UI (org-admin)
-Set org_id attributes      admin_default roles        bootstrapAdmin (RBAC DB only)
+Set org_id attributes      admin_default roles        (Principals + bootstrap_tenants)
 ```
 
 ### Two different "org-admin" concepts
@@ -122,10 +131,10 @@ Set org_id attributes      admin_default roles        bootstrapAdmin (RBAC DB on
 | Mechanism | Layer | Purpose |
 |-----------|-------|---------|
 | **`org-admin` realm role** | JWT / Envoy | Sets `is_org_admin=true`; triggers admin_default at runtime |
-| **`org-admin` Keycloak subgroup** | keycloakSync | Group membership synced into RBAC `Cost Admin Default` group |
+| **`org-admin` Keycloak subgroup** | keycloakSync | Logged for observability only; does **not** assign RBAC groups |
 
-Labs set both (e.g. `deploy-rhbk.sh`). Production docs must explain when each
-is needed. For JWT gateway auth, the **realm role** is required.
+Labs may set both (e.g. `deploy-rhbk.sh`). Production docs must explain when
+each is needed. For JWT gateway auth, the **realm role** is required.
 
 ---
 
@@ -164,7 +173,7 @@ reconcile still ran against the cluster API)
 
 - Cost Administrator (`cost-management:*:*`)
 - User Access administrator (`rbac:*:*`)
-- Sources administrator
+- Sources administrator (`sources:*:*`)
 - Notifications administrator
 - Inventory Groups Administrator
 - Inventory Hosts Administrator Local Test
@@ -176,9 +185,12 @@ reconcile still ran against the cluster API)
 | Envoy + RBAC `/access/` via gateway | **Not run** | Application images `ImagePullBackOff` on cluster; validation probes from laptop cannot resolve in-cluster DNS (expected `make run` limitation) |
 | pytest `test_org_admin_identity.py` | **Not run** | Blocked on gateway readiness |
 
-**Conclusion:** Identity and RBAC migration behavior are verified. Full JWT →
-Envoy → RBAC chain remains covered by existing CI pytest on other clusters;
-re-run when operator image is pushed and stack reaches `Available=True`.
+**Conclusion:** Identity and RBAC migration behavior are verified on this
+cluster. Full JWT → Envoy → RBAC chain was **not** re-verified here; that path
+is covered by the auth pytest suite (`test/pytest/suites/auth/`, run via
+`./scripts/run-pytest.sh --auth` on lab clusters — not part of operator-repo
+`make test` / `.github/workflows/ci.yml`). Re-run on Cluster Bot when the
+operator image is available and the stack reaches `Available=True`.
 
 ---
 
@@ -187,22 +199,19 @@ re-run when operator image is pushed and stack reaches `Available=True`.
 ### RBAC migration (`{cr}-rbac-migrate`)
 
 - **Code:** `internal/resources/migration.go` → `RBACMigrationJob`
-- **Runs:** Django migrate, built-in seeds, cost-management/sources seed,
-  admin_default group template, `bootstrap_tenants`, platform_default cleanup
-- **Does not:** Bind roles to usernames
-
-### bootstrapAdmin (`{cr}-rbac-admin-bootstrap`)
-
-- **CR:** `spec.rbac.bootstrapAdmin.enabled` + Secret (`org-id`,
-  `account-number`, `username`)
-- **Does:** Creates Tenant + Principal; adds user to `Cost Admin Default` group
-- **Does not:** Create Keycloak user or assign `org-admin` realm role
+- **Runs:** `python manage.py migrate --noinput`, then
+  `python manage.py seeds --skip-notifications` (permissions, roles, groups
+  including admin_default cost-management/sources roles)
+- **Does not:** Bind roles to usernames or run `bootstrap_tenants`
 
 ### keycloakSync (CronJob)
 
 - **CR:** `spec.rbac.keycloakSync.enabled` + client Secret
 - **Code:** `internal/resources/scripts/sync_keycloak_principals.py`
-- **Does:** Sync Keycloak `org-{orgId}` / `org-admin` subgroup → RBAC Principals
+- **Does:** For each top-level `org-{orgId}` group, sync members into RBAC
+  Principals and run `bootstrap_tenants`
+- **Does not:** Create Keycloak users or grant admin access via the
+  `org-admin` subgroup (admin remains JWT-based)
 
 ---
 
@@ -218,3 +227,7 @@ re-run when operator image is pushed and stack reaches `Available=True`.
 | Cluster verification | Partial (identity + migration); gateway deferred |
 
 **Deliverable:** This document.
+
+**Follow-up (out of scope for this PR):** Customer-facing install docs
+(`docs/install/user-access.md` or extension of `keycloak.md`) should explain
+the `org-admin` realm role requirement explicitly.

--- a/docs/install/keycloak.md
+++ b/docs/install/keycloak.md
@@ -180,26 +180,88 @@ For each claim:
 Do **not** map `organization_id`, `tenant_id`, `account_id`, or `account`.
 Lua does not read those names.
 
-### Optional claims and roles
+### Optional claims
 
-| Claim / role | If missing |
-|--------------|------------|
+| Claim | If missing |
+|-------|------------|
 | `preferred_username` | Lua uses `sub`, then `"user"` |
 | `email` | Lua synthesizes `{username}@example.com` |
-| Realm role `org-admin` | `is_org_admin` in `X-Rh-Identity` is `false` |
 
-To grant org-admin: **Realm roles** → create `org-admin` if needed → assign
-it to the user (UI) or the service-account user (CMMO) under **Role
-mapping**.
+## Org-admin realm role (first administrator)
+
+The operator **does not create human users**. A Keycloak (or IdP) admin
+provisions users, sets `org_id` and `account_number` attributes (above), and
+assigns the **`org-admin` realm role** to anyone who should administer Cost
+Management or delegate access to others.
+
+### What it does
+
+On each request, Envoy Lua reads the access token. If the token includes the
+**realm role** `org-admin`, Envoy sets `is_org_admin: true` in the
+`X-Rh-Identity` header it forwards to koku and insights-rbac. Without that
+role, `is_org_admin` is `false`.
+
+insights-rbac uses `is_org_admin` to apply the **admin_default** role bundle
+at runtime. That bundle includes permissions such as:
+
+| Role | Permission |
+|------|------------|
+| Cost Administrator | `cost-management:*:*` |
+| User Access administrator | `rbac:*:*` |
+| Sources administrator | `sources:*:*` |
+
+Plus other platform admin roles seeded by the operator's RBAC migration Job.
+The migrate Job seeds roles into the database; it does **not** assign them
+to a named user. The realm role is what grants them on login.
+
+### Why it is required
+
+Without `org-admin`, a user can authenticate (valid JWT with `org_id` and
+`account_number`) but receives **no** admin_default permissions — they cannot
+manage Cost data or use the User Access UI to delegate roles. There is no
+chicken-and-egg for the **first** administrator: assigning the realm role is
+enough; the user does not need a pre-existing RBAC group membership.
+
+RBAC migration alone does not make anyone an admin. Keycloak user creation
+plus the `org-admin` realm role is the supported first-admin path.
+
+### How to assign it
+
+1. **Realm roles** → create realm role `org-admin` if it does not exist.
+2. **Users** → select the user → **Role mapping** → **Assign role** →
+   `org-admin`.
+3. Confirm the user has `org_id` and `account_number` attributes (protocol
+   mappers above).
+4. User logs in through the UI (oauth2-proxy → Keycloak).
+
+Service-account users (CMMO) follow the same steps if they need org-admin
+claims; most reporting clusters only need the attribute mappers, not
+`org-admin`.
+
+### Not the same as the `org-admin` Keycloak subgroup
+
+If you enable `spec.rbac.keycloakSync`, labs often create a group layout such
+as `org-{orgId}/org-admin/`. That **subgroup name is for observability only**
+in the sync CronJob — it does **not** grant admin access and is not a
+substitute for the realm role.
+
+| Mechanism | Grants admin access? |
+|-----------|----------------------|
+| **`org-admin` realm role** | **Yes** — JWT → `is_org_admin=true` → admin_default |
+| **`org-admin` Keycloak subgroup** | **No** — sync logs membership; admin stays JWT-based |
+
+For gateway authentication, assign the **realm role**.
 
 ## Authorization
 
 Koku runs with `ENHANCED_ORG_ADMIN=False`. Authorization goes through
-insights-rbac. Do not disable that path or treat `org-admin` as a bypass for
-RBAC.
+insights-rbac. The `org-admin` realm role is the supported way to receive
+admin_default permissions at login; it is not a bypass of RBAC.
 
 Keycloak-to-RBAC principal sync (`spec.rbac.keycloakSync`) is a separate
-CronJob. It is not required for the JWT gateway.
+CronJob. It copies top-level `org-{orgId}` group members into RBAC
+Principals. It is not required for JWT gateway auth and does not replace
+assigning the `org-admin` realm role to administrators.
 
 ## Upgrade note
 


### PR DESCRIPTION
## Summary

Spike findings for [COST-7866](https://redhat.atlassian.net/browse/COST-7866) on how on-prem Cost Management handles user management, `org-admin`, and initial admin seeding.

- User management is owned by Keycloak/IdP — the operator never creates human users.
- The RBAC migration Job seeds roles/permissions into insights-rbac but assigns **0 principals** until first login or sync.
- First administrator path: Keycloak admin creates user → sets `org_id` / `account_number` attributes → assigns **`org-admin` realm role** → JWT → Envoy `is_org_admin=true` → insights-rbac **admin_default** bundle (includes `cost-management:*:*` and `rbac:*:*`).
- No chicken-and-egg for the first admin when using the `org-admin` realm role path.
- `bootstrapAdmin` and `keycloakSync` complement Keycloak but are **not** alternatives for creating the first admin there.
- Cluster Bot verification (2026-09-08): identity + RBAC migration confirmed; full gateway E2E deferred (app image pull / in-cluster DNS from laptop).

**Deliverable:** `.cursor/tasks/COST-7866/COST-7866.md`

## Test plan

- [ ] Review spike document for accuracy against `docs/install/keycloak.md` and operator RBAC code paths
- [ ] Confirm no customer-facing doc changes are intended in this PR (follow-up docs deferred)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

- Documents COST-7866 findings for on-prem Cost Management user management and initial administrator setup.
- Confirms that Keycloak or the configured IdP owns human user management. The operator does not create users.
- Documents that the RBAC migration Job runs migrations and seeds roles and permissions without assigning users.
- Describes first-administrator setup through Keycloak, including `org_id`, `account_number`, the `org-admin` realm role, and the `admin_default` RBAC bundle.
- Describes `keycloakSync` processing of top-level `org-{orgId}` group members and running `bootstrap_tenants`.
- Identifies `bootstrapAdmin` and `{cr}-rbac-admin-bootstrap` as historical mechanisms removed in COST-8088.
- Records partial cluster verification. Identity and RBAC migration succeeded. Gateway end-to-end testing was deferred.
- No CRD API, reconcile-phase, RBAC implementation, or user-visible status-condition changes.
- Customer-facing installation documentation remains deferred.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->