### PR TITLE
fix(ci): embed published operator image in bundle before catalog push

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -254,6 +254,20 @@ jobs:
           username: ${{ secrets.QUAY_USER }}
           password: ${{ secrets.QUAY_TOKEN }}
 
+      - name: Cache bundle build tools
+        uses: actions/cache@v5
+        with:
+          path: bin
+          key: bundle-tools-${{ runner.os }}-${{ hashFiles('Makefile') }}
+
+      - name: Regenerate bundle with published operator image
+        # Committed bundle/ embeds IMG=v0.0.1 (Makefile default). container-build
+        # publishes latest/main/<sha> only — regenerate here so catalog installs pull
+        # an image that exists on Quay.
+        run: |
+          SHORT_SHA="${GITHUB_SHA::7}"
+          make bundle IMG="quay.io/project-koku/koku-service-operator:${SHORT_SHA}"
+
       - name: Bundle image metadata
         id: bundle-meta
         uses: docker/metadata-action@v5


### PR DESCRIPTION
## Summary

- Regenerate the OLM bundle in the `bundle-publish` job with `IMG=quay.io/project-koku/koku-service-operator:<short-sha>` before building the bundle image
- The committed `bundle/` CSV still references `v0.0.1` (Makefile default), but `container-build` only publishes `latest`, `main`, and `<sha>` — so `catalog:latest` installed a CSV that pointed at a non-existent operator tag

## Context

Discovered while validating [COST-8166](https://redhat.atlassian.net/browse/COST-8166) — IQE fixtures that install `koku-service-operator` via upstream `catalog:latest` on cluster-bot (OLM CatalogSource + Subscription), without a manual `IMG=` override or personal Quay catalog.

## Problem

OLM install from `quay.io/project-koku/koku-service-operator-catalog:latest` could create a CSV successfully, then fail on the controller Deployment with `ImagePullBackOff` for `quay.io/project-koku/koku-service-operator:v0.0.1`.

## Fix

Align the published bundle with the operator image pushed in the same CI run (`GITHUB_SHA` short tag, matching `container-build` metadata).

## Test plan

- [ ] Merge and wait for `bundle-publish` on `main`
- [ ] On a lab cluster: `CatalogSource` → `quay.io/project-koku/koku-service-operator-catalog:latest` → Subscription `koku-service-operator` / `beta`
- [ ] Confirm CSV `Succeeded` and controller pod pulls `quay.io/project-koku/koku-service-operator:<sha>`
- [ ] Re-run IQE smoke: `test_service_operator_clean_olm_catalog_installation` with `SERVICE_OPERATOR_CATALOG_IMAGE=quay.io/project-koku/koku-service-operator-catalog:latest` (iqe-cost-management-plugin MR !2820)

## Related

- Follow-up to COST-7696 (catalog publish without matching operator tag)
- Unblocks IQE OLM smoke using upstream catalog ([COST-8166](https://redhat.atlassian.net/browse/COST-8166), [iqe-cost-management-plugin !2820](https://gitlab.cee.redhat.com/insights-qe/iqe-cost-management-plugin/-/merge_requests/2820))