### PR TITLE
docs: OLM catalog amd64 build guide, IQE smoke runbook, catalog-build-amd64

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@
 *.dylib
 /bin
 Dockerfile.cross
+index.Dockerfile
 
 # Test binary, built with `go test -c`
 *.test

--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@
 /bin
 Dockerfile.cross
 index.Dockerfile
+database/
 
 # Test binary, built with `go test -c`
 *.test

--- a/Makefile
+++ b/Makefile
@@ -420,9 +420,20 @@ endif
 # Build a catalog image by adding bundle images to an empty catalog using the operator package manager tool, 'opm'.
 # This recipe invokes 'opm' in 'semver' bundle add mode. For more information on add modes, see:
 # https://github.com/operator-framework/community-operators/blob/7f1438c/docs/packaging-operator.md#updating-your-existing-operator
+#
+# On Mac ARM building for an amd64 OpenShift lab/cluster-bot node, use catalog-build-amd64 instead —
+# opm's internal container build does not pass --platform and produces an arm64 catalog (Exec format error on amd64).
+CATALOG_INDEX_DOCKERFILE ?= index.Dockerfile
+OPM_BINARY_IMAGE ?= quay.io/operator-framework/opm:v1.55.0
+
 .PHONY: catalog-build
 catalog-build: opm ## Build a catalog image.
 	$(OPM) index add --container-tool $(CONTAINER_TOOL) --mode semver --tag $(CATALOG_IMG) --bundles $(BUNDLE_IMGS) $(FROM_INDEX_OPT)
+
+.PHONY: catalog-build-amd64
+catalog-build-amd64: opm ## Build a linux/amd64 catalog image (Mac ARM → remote amd64 cluster).
+	$(OPM) index add --pull-tool $(CONTAINER_TOOL) --mode semver --tag $(CATALOG_IMG) --bundles $(BUNDLE_IMGS) $(FROM_INDEX_OPT) --generate --out-dockerfile $(CATALOG_INDEX_DOCKERFILE) --binary-image $(OPM_BINARY_IMAGE)
+	$(CONTAINER_TOOL) build --platform linux/amd64 -f $(CATALOG_INDEX_DOCKERFILE) -t $(CATALOG_IMG) .
 
 # Push the catalog image.
 .PHONY: catalog-push

--- a/docs/development/clusterbot-operator-pytest.md
+++ b/docs/development/clusterbot-operator-pytest.md
@@ -68,7 +68,7 @@ follows [Critical rules](#critical-rules-read-first) below.
 
 ```bash
 oc delete subscription koku-service-operator -n openshift-operators --ignore-not-found
-oc delete csv -n openshift-operators -l operators.coreos.com/koku-service-operator.koku-service-operator --ignore-not-found
+oc delete csv -n openshift-operators -l operators.coreos.com/koku-service-operator.openshift-operators --ignore-not-found
 oc delete catalogsource koku-service-operator-catalog -n openshift-marketplace --ignore-not-found
 oc delete namespace cost-byoi --ignore-not-found
 ```

--- a/docs/development/clusterbot-operator-pytest.md
+++ b/docs/development/clusterbot-operator-pytest.md
@@ -16,6 +16,62 @@ cluster-bot reproduction are tracked in
 | [pre-prod-install.md](pre-prod-install.md) | Full BYOI + UI OAuth mirror |
 | [crc-testing.md](crc-testing.md) | Laptop `make run` against CRC |
 | [cmsc-e2e.md](cmsc-e2e.md) | Operator lifecycle Go e2e after stack is Ready (COST-7698; not pytest) |
+| [olm-bundle-testing.md](olm-bundle-testing.md) | Personal Quay bundle/catalog build (`catalog-build-amd64` on Mac ARM) |
+
+## IQE OLM smoke only (no full stack)
+
+Use this path to validate **OLM catalog install** (CatalogSource → Subscription
+→ CSV → controller Deployment → CRD) **without** RHBK, Kafka, S3, or CMSC
+reconcile. Tracked in [COST-8166](https://redhat.atlassian.net/browse/COST-8166)
+(iqe-cost-management-plugin).
+
+| Path | Infra needed | Validates |
+|------|----------------|-----------|
+| **IQE OLM smoke** (this section) | cluster-bot + `oc login` only | OLM wiring, operator pod, CRD, RBAC |
+| **Full pytest** (below) | RHBK + Kafka + S4 + CMSC Ready | Application/day-one stack |
+
+### Prerequisites
+
+- MCE / cluster-bot cluster (OCP **4.18+**, **amd64** workers)
+- IQE venv with `iqe-cost-management-plugin` checked out
+- Pullable catalog image (see [catalog image](#catalog-image))
+
+### Catalog image
+
+| Source | When |
+|--------|------|
+| `quay.io/project-koku/koku-service-operator-catalog:latest` | After [operator CI](https://github.com/project-koku/koku-service-operator) publishes a bundle whose CSV references a pullable operator tag (see project PRs fixing `bundle-publish`) |
+| Personal Quay (`quay.io/<user>/koku-service-operator-catalog:<tag>`) | PR branches, Mac-built catalogs — must be **public** (or cluster pull secret) and **linux/amd64** on cluster-bot |
+
+Build personal catalog on Mac ARM: [olm-bundle-testing.md](olm-bundle-testing.md#build-and-push-catalog-personal-quay).
+
+### Run IQE smoke
+
+From `iqe-cost-management-plugin` (does not need local koku API or full `iqe tests plugin`):
+
+```bash
+export SERVICE_OPERATOR_CATALOG_IMAGE=quay.io/project-koku/koku-service-operator-catalog:latest
+
+pytest --noconftest -p iqe_cost_management.fixtures.operator_fixtures \
+  iqe_cost_management/tests/operator/test_service_operator.py::test_service_operator_clean_olm_catalog_installation \
+  -vv -s --log-cli-level=INFO
+```
+
+Expect ~1–3 min after catalog is READY: CSV `Succeeded`, controller pod in
+`openshift-operators`, operand namespace `cost-byoi` (default).
+
+**Note:** The published CSV uses **AllNamespaces** install mode — controller in
+`openshift-operators`, not OwnNamespace `cost-onprem`. Full CMSC pytest still
+follows [Critical rules](#critical-rules-read-first) below.
+
+### OLM cleanup between runs
+
+```bash
+oc delete subscription koku-service-operator -n openshift-operators --ignore-not-found
+oc delete csv -n openshift-operators -l operators.coreos.com/koku-service-operator.koku-service-operator --ignore-not-found
+oc delete catalogsource koku-service-operator-catalog -n openshift-marketplace --ignore-not-found
+oc delete namespace cost-byoi --ignore-not-found
+```
 
 ## Goal
 

--- a/docs/development/olm-bundle-testing.md
+++ b/docs/development/olm-bundle-testing.md
@@ -81,20 +81,26 @@ export CATALOG_IMG="${IMAGE_TAG_BASE}-catalog:v${VERSION}"
 
 # Bundle must already be pushed and listable (steps above).
 make catalog-build-amd64 BUNDLE_IMGS="$BUNDLE_IMG" CATALOG_IMG="$CATALOG_IMG"
-docker push "$CATALOG_IMG"
 
 # Sanity check before pushing to a remote cluster:
 docker inspect "$CATALOG_IMG" --format '{{.Architecture}}'   # expect: amd64
+
+make catalog-push CATALOG_IMG="$CATALOG_IMG"
 ```
 
 `DOCKER_DEFAULT_PLATFORM=linux/amd64` does **not** fix `make catalog-build` —
 opm does not forward that to its internal build.
 
+If your container engine adds attestation tags that break registry or cluster
+pulls, rebuild the catalog image manually with `--provenance=false --sbom=false`
+(same flags as the bundle steps above) instead of relying on `catalog-build-amd64`'s
+internal `docker build`.
+
 ### Same architecture (CRC on Apple Silicon, local arm64)
 
 ```bash
 make catalog-build BUNDLE_IMGS="$BUNDLE_IMG" CATALOG_IMG="$CATALOG_IMG"
-docker push "$CATALOG_IMG"
+make catalog-push CATALOG_IMG="$CATALOG_IMG"
 ```
 
 Wire the cluster:

--- a/docs/development/olm-bundle-testing.md
+++ b/docs/development/olm-bundle-testing.md
@@ -59,6 +59,54 @@ docker build --platform "$PLATFORM" --provenance=false --sbom=false \
 docker push "${IMAGE_TAG_BASE}-bundle:v${VERSION}"
 ```
 
+## Build and push catalog (personal Quay)
+
+Use this when the cluster installs via **CatalogSource** + **Subscription** (IQE
+OLM fixtures, cluster-bot) instead of `make bundle-run`.
+
+### Mac ARM → amd64 cluster (cluster-bot, MCE, most cloud OpenShift)
+
+`make catalog-build` runs `opm index add`, which calls your container engine
+**without** `--platform`. On Apple Silicon the catalog image is **arm64** and
+fails on amd64 workers with `exec /bin/opm: Exec format error`.
+
+Use `make catalog-build-amd64` (generates `index.Dockerfile`, then builds with
+`--platform linux/amd64`):
+
+```bash
+export IMAGE_TAG_BASE=quay.io/<user>/koku-service-operator
+export VERSION=0.0.1-test
+export BUNDLE_IMG="${IMAGE_TAG_BASE}-bundle:v${VERSION}"
+export CATALOG_IMG="${IMAGE_TAG_BASE}-catalog:v${VERSION}"
+
+# Bundle must already be pushed and listable (steps above).
+make catalog-build-amd64 BUNDLE_IMGS="$BUNDLE_IMG" CATALOG_IMG="$CATALOG_IMG"
+docker push "$CATALOG_IMG"
+
+# Sanity check before pushing to a remote cluster:
+docker inspect "$CATALOG_IMG" --format '{{.Architecture}}'   # expect: amd64
+```
+
+`DOCKER_DEFAULT_PLATFORM=linux/amd64` does **not** fix `make catalog-build` —
+opm does not forward that to its internal build.
+
+### Same architecture (CRC on Apple Silicon, local arm64)
+
+```bash
+make catalog-build BUNDLE_IMGS="$BUNDLE_IMG" CATALOG_IMG="$CATALOG_IMG"
+docker push "$CATALOG_IMG"
+```
+
+Wire the cluster:
+
+```bash
+# CatalogSource spec.image = $CATALOG_IMG
+# Subscription: package koku-service-operator, channel beta,
+# source <your-catalog-name>, sourceNamespace openshift-marketplace
+```
+
+See also [clusterbot-operator-pytest.md](clusterbot-operator-pytest.md#iqe-olm-smoke-only-no-full-stack).
+
 Optional check (single Docker v2 manifest, not an OCI index):
 
 ```bash


### PR DESCRIPTION
## Summary

- **B3** — [olm-bundle-testing.md](docs/development/olm-bundle-testing.md): catalog build section for Mac ARM → amd64 clusters (`make catalog-build-amd64`, why `DOCKER_DEFAULT_PLATFORM` fails)
- **B4** — [clusterbot-operator-pytest.md](docs/development/clusterbot-operator-pytest.md): IQE OLM smoke-only path (no RHBK/Kafka/S3), catalog sources, cleanup commands
- **B5** — `Makefile`: new `catalog-build-amd64` target (`opm index add --generate` + `podman/docker build --platform linux/amd64`)

## Related

- Discovered during COST-8166 IQE OLM validation
- Complements https://github.com/project-koku/koku-service-operator/pull/166 (upstream catalog operator image tag)

## Test plan

- [ ] `make catalog-build-amd64` with a pushed `BUNDLE_IMG` on Mac ARM produces `docker inspect … Architecture=amd64`
- [ ] Docs links render in GitHub preview


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Adds `make catalog-build-amd64` for Mac ARM to amd64 catalog builds.
- Documents catalog push, provenance flags, architecture checks, and OLM cleanup.
- Adds an IQE OLM smoke-only runbook without RHBK, Kafka, S3, or CMSC dependencies.
- Tracks the smoke-test workflow under COST-8166.
- Ignores generated `index.Dockerfile` and `database/` artifacts.

## Operator impact

- No CRD API changes.
- No reconcile-phase behavior changes.
- No RBAC changes.
- No user-visible status condition changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->