### PR TITLE
Replace the deprecated semver index mode with FBC

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -297,7 +297,7 @@ jobs:
           SHORT_SHA="${GITHUB_SHA::7}"
           CATALOG_IMG="quay.io/project-koku/koku-service-operator-catalog:${SHORT_SHA}"
           make catalog-build \
-            BUNDLE_IMGS=quay.io/project-koku/koku-service-operator-bundle@${{ steps.bundle-push.outputs.digest }} \
+            BUNDLE_IMG=quay.io/project-koku/koku-service-operator-bundle@${{ steps.bundle-push.outputs.digest }} \
             CATALOG_IMG="${CATALOG_IMG}"
           docker tag "${CATALOG_IMG}" \
             quay.io/project-koku/koku-service-operator-catalog:latest

--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,8 @@
 Dockerfile.cross
 index.Dockerfile
 database/
+catalog.Dockerfile
+catalog/
 
 # Test binary, built with `go test -c`
 *.test

--- a/Makefile
+++ b/Makefile
@@ -405,19 +405,10 @@ OPM = $(shell which opm)
 endif
 endif
 
-# A comma-separated list of bundle images (e.g. make catalog-build BUNDLE_IMGS=example.com/operator-bundle:v0.1.0,example.com/operator-bundle:v0.2.0).
-# These images MUST exist in a registry and be pull-able.
-BUNDLE_IMGS ?= $(BUNDLE_IMG)
-
 # The image tag given to the resulting catalog image (e.g. make catalog-build CATALOG_IMG=example.com/operator-catalog:v0.2.0).
 CATALOG_IMG ?= $(IMAGE_TAG_BASE)-catalog:v$(VERSION)
 
-# Set CATALOG_BASE_IMG to an existing catalog image tag to add $BUNDLE_IMGS to that image.
-ifneq ($(origin CATALOG_BASE_IMG), undefined)
-FROM_INDEX_OPT := --from-index $(CATALOG_BASE_IMG)
-endif
-
-# Build a File-Based Catalog (FBC) image from the bundle images listed in BUNDLE_IMGS.
+# Build a File-Based Catalog (FBC) image from the bundle image, BUNDLE_IMG.
 CATALOG_DIR ?= catalog
 
 .PHONY: catalog-render
@@ -425,7 +416,7 @@ catalog-render: opm ## Render bundle images into an FBC catalog directory.
 	rm -rf $(CATALOG_DIR) $(CATALOG_DIR).Dockerfile
 	mkdir -p $(CATALOG_DIR)
 	$(OPM) init koku-service-operator --default-channel=$(DEFAULT_CHANNEL) -o yaml > $(CATALOG_DIR)/index.yaml
-	$(OPM) render $(BUNDLE_IMGS) -o yaml >> $(CATALOG_DIR)/index.yaml
+	$(OPM) render $(BUNDLE_IMG) -o yaml >> $(CATALOG_DIR)/index.yaml
 	@BUNDLE_NAME=$$(grep -B 1 "^package:" $(CATALOG_DIR)/index.yaml | grep "^name:" | head -n 1 | awk '{print $$2}') ; \
 	echo "Detected Bundle Entry: $$BUNDLE_NAME" ; \
 	echo "---"                                                        >> $(CATALOG_DIR)/index.yaml ; \
@@ -439,11 +430,11 @@ catalog-render: opm ## Render bundle images into an FBC catalog directory.
 
 .PHONY: catalog-build
 catalog-build: catalog-render ## Build an FBC catalog image.
-	$(CONTAINER_TOOL) build -f $(CATALOG_DIR)/Dockerfile -t $(CATALOG_IMG) $(CATALOG_DIR)
+	$(CONTAINER_TOOL) build -f $(CATALOG_DIR).Dockerfile -t $(CATALOG_IMG) .
 
 .PHONY: catalog-build-amd64
 catalog-build-amd64: catalog-render ## Build a linux/amd64 FBC catalog image (Mac ARM → remote amd64 cluster).
-	$(CONTAINER_TOOL) build --platform linux/amd64 -f $(CATALOG_DIR)/Dockerfile -t $(CATALOG_IMG) $(CATALOG_DIR)
+	$(CONTAINER_TOOL) build --platform linux/amd64 -f $(CATALOG_DIR).Dockerfile -t $(CATALOG_IMG) .
 
 # Push the catalog image.
 .PHONY: catalog-push

--- a/Makefile
+++ b/Makefile
@@ -417,25 +417,40 @@ ifneq ($(origin CATALOG_BASE_IMG), undefined)
 FROM_INDEX_OPT := --from-index $(CATALOG_BASE_IMG)
 endif
 
-# Build a catalog image by adding bundle images to an empty catalog using the operator package manager tool, 'opm'.
-# This recipe invokes 'opm' in 'semver' bundle add mode. For more information on add modes, see:
-# https://github.com/operator-framework/community-operators/blob/7f1438c/docs/packaging-operator.md#updating-your-existing-operator
-#
-# On Mac ARM building for an amd64 OpenShift lab/cluster-bot node, use catalog-build-amd64 instead —
-# opm's internal container build does not pass --platform and produces an arm64 catalog (Exec format error on amd64).
-CATALOG_INDEX_DOCKERFILE ?= index.Dockerfile
-OPM_BINARY_IMAGE ?= quay.io/operator-framework/opm:v1.55.0
+# Build a File-Based Catalog (FBC) image from the bundle images listed in BUNDLE_IMGS.
+CATALOG_DIR ?= catalog
+
+.PHONY: catalog-render
+catalog-render: opm ## Render bundle images into an FBC catalog directory.
+	rm -rf $(CATALOG_DIR) $(CATALOG_DIR).Dockerfile
+	mkdir -p $(CATALOG_DIR)
+	$(OPM) init koku-service-operator --default-channel=$(DEFAULT_CHANNEL) -o yaml > $(CATALOG_DIR)/index.yaml
+	$(OPM) render $(BUNDLE_IMGS) -o yaml >> $(CATALOG_DIR)/index.yaml
+	@BUNDLE_NAME=$$(grep -B 1 "^package:" $(CATALOG_DIR)/index.yaml | grep "^name:" | head -n 1 | awk '{print $$2}') ; \
+	echo "Detected Bundle Entry: $$BUNDLE_NAME" ; \
+	echo "---"                                                        >> $(CATALOG_DIR)/index.yaml ; \
+	echo "schema: olm.channel"                                        >> $(CATALOG_DIR)/index.yaml ; \
+	echo "package: koku-service-operator"                            >> $(CATALOG_DIR)/index.yaml ; \
+	echo "name: $(DEFAULT_CHANNEL)"                                   >> $(CATALOG_DIR)/index.yaml ; \
+	echo "entries:"                                                   >> $(CATALOG_DIR)/index.yaml ; \
+	echo "  - name: $$BUNDLE_NAME"                                     >> $(CATALOG_DIR)/index.yaml
+	$(OPM) validate $(CATALOG_DIR)
+	$(OPM) generate dockerfile $(CATALOG_DIR)
 
 .PHONY: catalog-build
-catalog-build: opm ## Build a catalog image.
-	$(OPM) index add --container-tool $(CONTAINER_TOOL) --mode semver --tag $(CATALOG_IMG) --bundles $(BUNDLE_IMGS) $(FROM_INDEX_OPT)
+catalog-build: catalog-render ## Build an FBC catalog image.
+	$(CONTAINER_TOOL) build -f $(CATALOG_DIR)/Dockerfile -t $(CATALOG_IMG) $(CATALOG_DIR)
 
 .PHONY: catalog-build-amd64
-catalog-build-amd64: opm ## Build a linux/amd64 catalog image (Mac ARM → remote amd64 cluster).
-	$(OPM) index add --pull-tool $(CONTAINER_TOOL) --mode semver --tag $(CATALOG_IMG) --bundles $(BUNDLE_IMGS) $(FROM_INDEX_OPT) --generate --out-dockerfile $(CATALOG_INDEX_DOCKERFILE) --binary-image $(OPM_BINARY_IMAGE)
-	$(CONTAINER_TOOL) build --platform linux/amd64 -f $(CATALOG_INDEX_DOCKERFILE) -t $(CATALOG_IMG) .
+catalog-build-amd64: catalog-render ## Build a linux/amd64 FBC catalog image (Mac ARM → remote amd64 cluster).
+	$(CONTAINER_TOOL) build --platform linux/amd64 -f $(CATALOG_DIR)/Dockerfile -t $(CATALOG_IMG) $(CATALOG_DIR)
 
 # Push the catalog image.
 .PHONY: catalog-push
 catalog-push: ## Push a catalog image.
 	$(MAKE) docker-push IMG=$(CATALOG_IMG)
+
+.PHONY: catalog-build-multiplatform
+catalog-build-multiplatform: catalog-render ## Build and push a multiplatform FBC catalog image.
+	$(CONTAINER_TOOL) buildx build --platform linux/amd64,linux/arm64 --push -f $(CATALOG_DIR).Dockerfile -t $(CATALOG_IMG) .
+

--- a/bundle/manifests/koku-service-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/koku-service-operator.clusterserviceversion.yaml
@@ -301,9 +301,158 @@ metadata:
         }
       ]
     capabilities: Basic Install
-    createdAt: "2026-09-08T16:36:08Z"
+    createdAt: "2026-09-10T02:58:04Z"
+    operatorframework.io/initialization-resource: |-
+      {
+        "apiVersion": "service.costmanagement.openshift.io/v1alpha1",
+        "kind": "CostManagementServiceConfig",
+        "metadata": {
+          "name": "cost-onprem",
+          "namespace": "cost-onprem"
+        },
+        "spec": {
+          "auth": {
+            "envoy": {
+              "image": {
+                "repository": "registry.redhat.io/openshift-service-mesh/proxyv2-rhel9",
+                "tag": "2.6"
+              },
+              "replicas": 2
+            },
+            "keycloak": {
+              "url": ""
+            }
+          },
+          "cache": {
+            "auth": {
+              "enabled": true,
+              "secretName": ""
+            },
+            "deploy": false,
+            "host": "",
+            "port": 6379
+          },
+          "costManagement": {
+            "api": {
+              "image": {
+                "repository": "quay.io/redhat-services-prod/cost-mgmt-dev-tenant/koku",
+                "tag": "768be82"
+              },
+              "replicas": 1
+            },
+            "celery": {
+              "workers": {
+                "costModel": {
+                  "replicas": 1
+                },
+                "default": {
+                  "replicas": 1
+                },
+                "ocp": {
+                  "replicas": 2
+                },
+                "priority": {
+                  "replicas": 1
+                },
+                "summary": {
+                  "replicas": 2
+                }
+              }
+            },
+            "listener": {
+              "replicas": 2
+            },
+            "masu": {
+              "image": {
+                "repository": "quay.io/redhat-services-prod/cost-mgmt-dev-tenant/koku",
+                "tag": "768be82"
+              },
+              "replicas": 1
+            }
+          },
+          "database": {
+            "deploy": false,
+            "host": "",
+            "port": 5432,
+            "secretName": "",
+            "sslMode": "require"
+          },
+          "global": {
+            "clusterDomain": "apps.cluster.local",
+            "storageClass": ""
+          },
+          "ingress": {
+            "image": {
+              "repository": "quay.io/iop/ingress",
+              "tag": "master"
+            }
+          },
+          "kafka": {
+            "bootstrapServers": ""
+          },
+          "kruize": {
+            "image": {
+              "repository": "quay.io/redhat-services-prod/kruize-autotune-tenant/autotune",
+              "tag": "d1f0140"
+            },
+            "replicas": 1
+          },
+          "monitoring": {
+            "enabled": true
+          },
+          "objectStorage": {
+            "buckets": {
+              "koku": ""
+            },
+            "endpoint": "",
+            "port": 443,
+            "secretName": "",
+            "useSSL": true
+          },
+          "rbac": {
+            "api": {
+              "replicas": 1
+            },
+            "image": {
+              "repository": "quay.io/redhat-services-prod/hcc-accessmanagement-tenant/insights-rbac",
+              "tag": "73870d8"
+            },
+            "worker": {
+              "replicas": 1
+            }
+          },
+          "ros": {
+            "enabled": false,
+            "image": {
+              "repository": "quay.io/redhat-services-prod/insights-management-tenant/insights-ocp-resource-optimization/ros-ocp-backend",
+              "tag": "ae8c990"
+            },
+            "processor": {
+              "replicas": 1
+            }
+          },
+          "ui": {
+            "app": {
+              "image": {
+                "repository": "quay.io/insights-onprem/koku-ui-onprem",
+                "tag": "2f23c646581028bd385856b6713e6bf367baf953"
+              }
+            },
+            "oauthProxy": {
+              "image": {
+                "repository": "registry.redhat.io/rhceph/oauth2-proxy-rhel9",
+                "tag": "v7.6.0"
+              }
+            },
+            "replicaCount": 1
+          }
+        }
+      }
+    operatorframework.io/suggested-namespace: cost-onprem
     operators.operatorframework.io/builder: operator-sdk-v1.42.3
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v4
+  labels:
+    operatorframework.io/arch.amd64: supported
   name: koku-service-operator.v0.0.1
   namespace: placeholder
 spec:

--- a/config/manifests/bases/koku-service-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/koku-service-operator.clusterserviceversion.yaml
@@ -4,6 +4,155 @@ metadata:
   annotations:
     alm-examples: '[]'
     capabilities: Basic Install
+    operatorframework.io/initialization-resource: |-
+      {
+        "apiVersion": "service.costmanagement.openshift.io/v1alpha1",
+        "kind": "CostManagementServiceConfig",
+        "metadata": {
+          "name": "cost-onprem",
+          "namespace": "cost-onprem"
+        },
+        "spec": {
+          "auth": {
+            "envoy": {
+              "image": {
+                "repository": "registry.redhat.io/openshift-service-mesh/proxyv2-rhel9",
+                "tag": "2.6"
+              },
+              "replicas": 2
+            },
+            "keycloak": {
+              "url": ""
+            }
+          },
+          "cache": {
+            "auth": {
+              "enabled": true,
+              "secretName": ""
+            },
+            "deploy": false,
+            "host": "",
+            "port": 6379
+          },
+          "costManagement": {
+            "api": {
+              "image": {
+                "repository": "quay.io/redhat-services-prod/cost-mgmt-dev-tenant/koku",
+                "tag": "768be82"
+              },
+              "replicas": 1
+            },
+            "celery": {
+              "workers": {
+                "costModel": {
+                  "replicas": 1
+                },
+                "default": {
+                  "replicas": 1
+                },
+                "ocp": {
+                  "replicas": 2
+                },
+                "priority": {
+                  "replicas": 1
+                },
+                "summary": {
+                  "replicas": 2
+                }
+              }
+            },
+            "listener": {
+              "replicas": 2
+            },
+            "masu": {
+              "image": {
+                "repository": "quay.io/redhat-services-prod/cost-mgmt-dev-tenant/koku",
+                "tag": "768be82"
+              },
+              "replicas": 1
+            }
+          },
+          "database": {
+            "deploy": false,
+            "host": "",
+            "port": 5432,
+            "secretName": "",
+            "sslMode": "require"
+          },
+          "global": {
+            "clusterDomain": "apps.cluster.local",
+            "storageClass": ""
+          },
+          "ingress": {
+            "image": {
+              "repository": "quay.io/iop/ingress",
+              "tag": "master"
+            }
+          },
+          "kafka": {
+            "bootstrapServers": ""
+          },
+          "kruize": {
+            "image": {
+              "repository": "quay.io/redhat-services-prod/kruize-autotune-tenant/autotune",
+              "tag": "d1f0140"
+            },
+            "replicas": 1
+          },
+          "monitoring": {
+            "enabled": true
+          },
+          "objectStorage": {
+            "buckets": {
+              "koku": ""
+            },
+            "endpoint": "",
+            "port": 443,
+            "secretName": "",
+            "useSSL": true
+          },
+          "rbac": {
+            "api": {
+              "replicas": 1
+            },
+            "image": {
+              "repository": "quay.io/redhat-services-prod/hcc-accessmanagement-tenant/insights-rbac",
+              "tag": "73870d8"
+            },
+            "worker": {
+              "replicas": 1
+            }
+          },
+          "ros": {
+            "enabled": false,
+            "image": {
+              "repository": "quay.io/redhat-services-prod/insights-management-tenant/insights-ocp-resource-optimization/ros-ocp-backend",
+              "tag": "ae8c990"
+            },
+            "processor": {
+              "replicas": 1
+            }
+          },
+          "ui": {
+            "app": {
+              "image": {
+                "repository": "quay.io/insights-onprem/koku-ui-onprem",
+                "tag": "2f23c646581028bd385856b6713e6bf367baf953"
+              }
+            },
+            "oauthProxy": {
+              "image": {
+                "repository": "registry.redhat.io/rhceph/oauth2-proxy-rhel9",
+                "tag": "v7.6.0"
+              }
+            },
+            "replicaCount": 1
+          }
+        }
+      }
+    operatorframework.io/suggested-namespace: cost-onprem
+  labels:
+    operatorframework.io/arch.amd64: supported
   name: koku-service-operator.v0.0.0
   namespace: placeholder
 spec:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

- Replaced deprecated semver catalog builds with File-Based Catalog (FBC) workflows.
- Added catalog rendering and multiplatform build targets.
- Added ignore rules for generated catalog files.
- Updated the bundle publish workflow to use `BUNDLE_IMG`.

## Operator impact

- No CRD API changes.
- No reconcile-phase behavior changes.
- No RBAC changes.
- No user-visible status condition changes.
- Added an OLM initialization resource for `CostManagementServiceConfig` in the `cost-onprem` namespace.
- Added the `cost-onprem` suggested namespace.
- Declared amd64 support.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->