### PR TITLE
[COST-7849] Configure dependency-aware ingress probes

### DIFF
--- a/internal/resources/ingress.go
+++ b/internal/resources/ingress.go
@@ -117,15 +117,8 @@ func IngressDeployment(cfg *costv1alpha1.CostManagementServiceConfig) *appsv1.De
 
 	vols, mounts := ingressVolumes(cfg)
 
-	probe := &corev1.Probe{
-		ProbeHandler: corev1.ProbeHandler{
-			HTTPGet: &corev1.HTTPGetAction{
-				Path: "/",
-				Port: intstr.FromInt32(ingressHTTPPort),
-			},
-		},
-		InitialDelaySeconds: 15, PeriodSeconds: 10, TimeoutSeconds: 5, FailureThreshold: 3,
-	}
+	livenessProbe := ingressProbe("/healthz")
+	readinessProbe := ingressProbe("/status/")
 
 	return &appsv1.Deployment{
 		TypeMeta:   metav1.TypeMeta{APIVersion: "apps/v1", Kind: "Deployment"},
@@ -150,8 +143,8 @@ func IngressDeployment(cfg *costv1alpha1.CostManagementServiceConfig) *appsv1.De
 							{Name: "metrics", ContainerPort: ingressMetricsPort, Protocol: corev1.ProtocolTCP},
 						},
 						Env:             env,
-						LivenessProbe:   probe,
-						ReadinessProbe:  probe,
+						LivenessProbe:   livenessProbe,
+						ReadinessProbe:  readinessProbe,
 						Resources:       spec.Resources,
 						VolumeMounts:    mounts,
 						SecurityContext: restrictedContainerSC(),
@@ -160,6 +153,26 @@ func IngressDeployment(cfg *costv1alpha1.CostManagementServiceConfig) *appsv1.De
 				},
 			},
 		},
+	}
+}
+
+// ingressProbe configures the timings used by the upstream ingress deployment.
+// Readiness has its own bounded dependency checks, while liveness only verifies
+// that the HTTP process is serving requests.
+func ingressProbe(path string) *corev1.Probe {
+	return &corev1.Probe{
+		ProbeHandler: corev1.ProbeHandler{
+			HTTPGet: &corev1.HTTPGetAction{
+				Path:   path,
+				Port:   intstr.FromInt32(ingressHTTPPort),
+				Scheme: corev1.URISchemeHTTP,
+			},
+		},
+		InitialDelaySeconds: 35,
+		PeriodSeconds:       5,
+		TimeoutSeconds:      120,
+		FailureThreshold:    3,
+		SuccessThreshold:    1,
 	}
 }
 

--- a/internal/resources/ingress_test.go
+++ b/internal/resources/ingress_test.go
@@ -3,6 +3,7 @@ package resources
 import (
 	"testing"
 
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	costv1alpha1 "github.com/project-koku/koku-service-operator/api/v1alpha1"
@@ -80,6 +81,24 @@ func TestIngressDeployment(t *testing.T) {
 	}
 	if len(c.Ports) != 2 {
 		t.Fatalf("ports = %+v", c.Ports)
+	}
+	for name, probe := range map[string]*corev1.Probe{
+		"liveness":  c.LivenessProbe,
+		"readiness": c.ReadinessProbe,
+	} {
+		if probe == nil || probe.HTTPGet == nil {
+			t.Fatalf("%s probe = %+v, want HTTP probe", name, probe)
+		}
+		wantPath := "/healthz"
+		if name == "readiness" {
+			wantPath = "/status/"
+		}
+		if probe.HTTPGet.Path != wantPath || probe.HTTPGet.Port.IntVal != ingressHTTPPort || probe.HTTPGet.Scheme != corev1.URISchemeHTTP {
+			t.Errorf("%s probe HTTPGet = %+v, want path %q on HTTP port %d", name, probe.HTTPGet, wantPath, ingressHTTPPort)
+		}
+		if probe.InitialDelaySeconds != 35 || probe.PeriodSeconds != 5 || probe.TimeoutSeconds != 120 || probe.FailureThreshold != 3 || probe.SuccessThreshold != 1 {
+			t.Errorf("%s probe timings = %+v", name, probe)
+		}
 	}
 	env := envValues(c)
 	checks := map[string]string{


### PR DESCRIPTION
Configures /healthz liveness and /status/ dependency-aware readiness probes for the operator-managed ingress Deployment, matching the upstream ingress service contract.\n\nVerified with go test ./internal/resources and make test.

depends on https://github.com/RedHatInsights/insights-ingress-go/pull/789

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Adds separate ingress liveness and readiness probes.
- Uses `/healthz` for liveness and `/status/` for dependency-aware readiness on port 8080.
- Adds tests for probe paths and timing values.
- No changes to CRD APIs, reconcile behavior, RBAC, or user-visible status conditions.
- Verification completed with `go test ./internal/resources` and `make test`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->