### PR TITLE
[COST-8124] Document E2E install gaps in customer guides

### DIFF
--- a/config/samples/byoi/app/costmanagementserviceconfig.yaml
+++ b/config/samples/byoi/app/costmanagementserviceconfig.yaml
@@ -107,7 +107,9 @@ spec:
       url: "http://keycloak-service.keycloak.svc.cluster.local:8080"
       # issuerURL: "https://keycloak-keycloak.apps.example.com"
       # tls:
-      #   insecureSkipVerify: true   # dev only when issuer uses a private CA
+      #   # Required for UI oauth2-proxy when issuerURL is a public Route (ingress CA).
+      #   caCertSecretName: "keycloak-ingress-ca"
+      #   insecureSkipVerify: true   # lab only — see docs/install/keycloak.md#ui-login-troubleshooting
       realm: "kubernetes"
       audiences:
         - "cost-management-operator"

--- a/config/samples/byoi/app/costmanagementserviceconfig.yaml
+++ b/config/samples/byoi/app/costmanagementserviceconfig.yaml
@@ -106,10 +106,10 @@ spec:
       # hostname, tokens use that URL as iss — set issuerURL to match.
       url: "http://keycloak-service.keycloak.svc.cluster.local:8080"
       # issuerURL: "https://keycloak-keycloak.apps.example.com"
+      # For production with a public Route issuer, prefer tls.caCertSecretName
+      # (ingress CA) over insecureSkipVerify — see docs/install/keycloak.md.
       # tls:
-      #   # Required for UI oauth2-proxy when issuerURL is a public Route (ingress CA).
-      #   caCertSecretName: "keycloak-ingress-ca"
-      #   insecureSkipVerify: true   # lab only — see docs/install/keycloak.md#ui-login-troubleshooting
+      #   insecureSkipVerify: true   # dev only when issuer uses a private CA
       realm: "kubernetes"
       audiences:
         - "cost-management-operator"

--- a/docs/install/README.md
+++ b/docs/install/README.md
@@ -17,6 +17,7 @@ namespace** as the CR (OwnNamespace). See [quickstart.md](quickstart.md#install-
 | [Prerequisites](prerequisites.md) | You need the external services, buckets, Kafka topic, and Secret key names |
 | [Keycloak](keycloak.md) | You need realm, clients, audience mappers, and JWT claims for Envoy |
 | [Quickstart](quickstart.md) | Prerequisites and the operator are ready; you want a working CR in under 30 minutes |
+| [First use](first-use.md) | The stack is `Available` and you need data, cost models, and beta UI expectations |
 | [Production](production.md) | You are sizing, hardening TLS, and planning backup for a lasting deploy |
 | [Uninstall](uninstall.md) | You need to remove a CR, the operator, or the namespace without getting stuck in `Terminating` |
 | [CMMO](cmmo.md) | You need reporting clusters to upload metrics into this instance |

--- a/docs/install/cmmo.md
+++ b/docs/install/cmmo.md
@@ -121,15 +121,34 @@ certificates instead.
 - Do not enable ROS collection against a Cost-only (`ros.enabled: false`)
   instance.
 
+## Upload timing
+
+`spec.upload.upload_cycle` is in **minutes**. The example above uses `360`
+(six hours) between upload attempts. After a fresh CMMO install, the first
+successful upload may not happen until the next cycle. For lab testing only,
+you may lower `upload_cycle` (for example `15`) — do not use aggressive
+values in production.
+
 ## Check
 
-On the reporting cluster:
+On the **reporting** cluster:
 
 ```bash
-oc -n costmanagement-metrics-operator get costmanagementmetricsconfig
-oc -n costmanagement-metrics-operator logs deploy/costmanagement-metrics-operator
+oc -n costmanagement-metrics-operator get costmanagementmetricsconfig -o yaml
+oc -n costmanagement-metrics-operator logs deploy/costmanagement-metrics-operator --tail=100
 ```
 
-On the Cost Management cluster, Listener and Ingress should see uploads on
-topic `platform.upload.announce` after a successful CMMO cycle. The UI Sources
-page lists the cluster when `source.create_source` is true.
+Look at `status` on `CostManagementMetricsConfig`. A successful cycle often
+shows `last_upload_status` such as `202 Accepted` and a recent
+`last_successful_upload_time`.
+
+On the **Cost Management** cluster:
+
+1. **UI** → **Integrations** (or **Sources**) — a new OpenShift source when
+   `spec.source.create_source` is true.
+2. Listener / Ingress activity on topic `platform.upload.announce` after a
+   successful cycle (operator logs or your Kafka tooling).
+
+Do not rely on a single `grep` in Listener logs before the first CMMO cycle
+completes — other uploads (for example lab seed data) may use different
+cluster IDs or timestamps.

--- a/docs/install/cmmo.md
+++ b/docs/install/cmmo.md
@@ -124,10 +124,12 @@ certificates instead.
 ## Upload timing
 
 `spec.upload.upload_cycle` is in **minutes**. The example above uses `360`
-(six hours) between upload attempts. After a fresh CMMO install, the first
-successful upload may not happen until the next cycle. For lab testing only,
-you may lower `upload_cycle` (for example `15`) — do not use aggressive
-values in production.
+(six hours), the CMMO default. CMMO clamps values below **60** minutes up to
+60. For lab testing only, you may lower `upload_cycle` to `60` — keep
+production values conservative.
+
+How soon the first upload runs depends on CMMO startup and Prometheus
+collection; use `status.upload` (below) instead of assuming an immediate cycle.
 
 ## Check
 
@@ -136,11 +138,12 @@ On the **reporting** cluster:
 ```bash
 oc -n costmanagement-metrics-operator get costmanagementmetricsconfig -o yaml
 oc -n costmanagement-metrics-operator logs deploy/costmanagement-metrics-operator --tail=100
+oc -n costmanagement-metrics-operator get costmanagementmetricsconfig \
+  -o jsonpath='upload={.status.upload.last_upload_status} time={.status.upload.last_successful_upload_time}{"\n"}'
 ```
 
-Look at `status` on `CostManagementMetricsConfig`. A successful cycle often
-shows `last_upload_status` such as `202 Accepted` and a recent
-`last_successful_upload_time`.
+A successful cycle often shows `status.upload.last_upload_status` such as
+`202 Accepted` and a recent `status.upload.last_successful_upload_time`.
 
 On the **Cost Management** cluster:
 

--- a/docs/install/first-use.md
+++ b/docs/install/first-use.md
@@ -1,0 +1,44 @@
+# First use after install
+
+After the `CostManagementServiceConfig` reaches `Available=True` and you can
+log in to the UI, you still need data and a **cost model** before dollar
+amounts appear in Overview and Cost Explorer.
+
+**Beta.** These guides assume `spec.ros.enabled: false` (Cost-only). AWS, GCP,
+and Azure views require cloud integrations that are not part of the on-prem
+beta path.
+
+## Data paths
+
+| Source | How data arrives | What you see first |
+|--------|------------------|-------------------|
+| OpenShift cluster metrics | [CMMO](cmmo.md) upload from a reporting cluster | Usage and inventory after Listener ingest |
+| Lab / test payloads | Your own upload tooling (not covered here) | Depends on payload type |
+
+Ingest alone can show **usage** (CPU, memory, node counts) before any **cost
+in currency**.
+
+## Cost model (required for dollar amounts)
+
+OpenShift costs are calculated from a **cost model** assigned to the OpenShift
+source. Without it, Overview and Cost Explorer may show **$0.00** even when
+usage graphs have data.
+
+1. In the UI, open **Cost management** → **Cost models**.
+2. Create an OpenShift cost model (or use your organization's template).
+3. Open **Integrations** (or **Sources**) and assign that cost model to the
+   OpenShift cluster source.
+
+Red Hat documents cost models in the
+[Cost Management product documentation](https://access.redhat.com/documentation/en-us/red_hat_hybrid_cloud_console/1.0/html-single/cost_management/index).
+
+## Beta UI scope
+
+With ROS disabled on the CR, Resource Optimization pages and some SaaS-only
+navigation entries are not applicable. Errors on cloud provider pages when you
+have no AWS, GCP, or Azure sources are expected for an OpenShift-only deploy.
+
+## Next
+
+- Reporting cluster setup: [cmmo.md](cmmo.md)
+- TLS and sizing: [production.md](production.md)

--- a/docs/install/keycloak.md
+++ b/docs/install/keycloak.md
@@ -252,6 +252,77 @@ substitute for the realm role.
 
 For gateway authentication, assign the **realm role**.
 
+## UI login troubleshooting
+
+The UI Deployment runs **oauth2-proxy** beside the nginx app container.
+oauth2-proxy performs OIDC discovery against `spec.auth.keycloak.issuerURL`
+(or the issuer derived from `url` + realm when `issuerURL` is unset).
+
+That is a **different** URL than the JWKS probe the operator uses for
+`AuthenticationReady`. Envoy fetches JWKS from `spec.auth.keycloak.url`
+(often an in-cluster HTTP Service). The UI talks to the **public issuer**
+(typically an HTTPS OpenShift Route). `AuthenticationReady=True` and
+`UIReady=True` do **not** guarantee the UI Route serves traffic.
+
+### `UIReady` vs a working UI
+
+`UIReady=True` means the UI OAuth client Secret exists (and the UI Route is
+admitted when a cluster domain is known). It does **not** check that UI pods
+are Ready. Always confirm the Deployment after conditions look good:
+
+```bash
+export NAMESPACE=cost-onprem
+export CR_NAME=cost-management-minimal
+
+oc -n "$NAMESPACE" get deploy "${CR_NAME}-ui"
+oc -n "$NAMESPACE" get pods -l app.kubernetes.io/component=ui
+oc -n "$NAMESPACE" logs deploy/"${CR_NAME}"-ui -c oauth-proxy --tail=50
+```
+
+Both containers (`oauth-proxy` and the app) should be `Running` and the
+Deployment should show `READY` matching desired replicas.
+
+### TLS when `issuerURL` is a public Route
+
+When RHBK issues tokens with `iss` on a public HTTPS Route, set
+`spec.auth.keycloak.issuerURL` to that Route host. oauth2-proxy then verifies
+the Route certificate using `spec.auth.keycloak.tls.caCertSecretName` (Secret
+key `ca.crt`).
+
+Without a custom CA Secret, the operator mounts the OpenShift **service-CA**
+for `--provider-ca-file`. Public Routes use the **ingress/router** CA, not
+the service CA. A common symptom is oauth-proxy in CrashLoopBackOff with:
+
+`x509: certificate signed by unknown authority`
+
+**Production fix:** create a Secret with the ingress/router CA (or a bundle
+that includes it) and set `spec.auth.keycloak.tls.caCertSecretName`. See
+[production.md](production.md).
+
+**Lab only:** `spec.auth.keycloak.tls.insecureSkipVerify: true` skips TLS
+verification for oauth2-proxy. Do not use in production.
+
+Example (replace Secret name and issuer host):
+
+```yaml
+spec:
+  auth:
+    keycloak:
+      url: "http://keycloak-service.keycloak.svc.cluster.local:8080"
+      issuerURL: "https://keycloak-keycloak.apps.cluster.example.com"
+      tls:
+        caCertSecretName: "keycloak-ingress-ca"
+```
+
+### Symptom table
+
+| Symptom | Check |
+|---------|-------|
+| `UIReady=False`, reason `OAuthClientSecretMissing` | Create `{cr-name}-ui-oauth-client` with `client-id` / `client-secret` |
+| `UIReady=True`, Route shows "Application is not available" | `oc logs deploy/{cr}-ui -c oauth-proxy` for TLS or OIDC errors |
+| oauth-proxy `x509: unknown authority` on issuer host | Set `tls.caCertSecretName` to ingress CA when `issuerURL` is a Route |
+| Login redirect fails after UI loads | Redirect URI in Keycloak must match `https://{cr}-ui-{ns}.{domain}/oauth2/callback` |
+
 ## Authorization
 
 Koku runs with `ENHANCED_ORG_ADMIN=False`. Authorization goes through

--- a/docs/install/quickstart.md
+++ b/docs/install/quickstart.md
@@ -22,8 +22,20 @@ OperatorHub catalog yet. Two current vehicles:
    `IMG=<your-image> ./hack/deploy-incluster.sh "$NAMESPACE"` after CRDs/RBAC
    (`./hack/deploy-dev.sh "$NAMESPACE"`).
 
-The generated CSV currently advertises AllNamespaces; the **runtime** still
-watches only the install namespace. Put the CR in that namespace.
+The generated CSV currently advertises **AllNamespaces** install mode; the
+**runtime** still watches only the install namespace. Put the CR in that
+namespace.
+
+**Console pitfall:** subscribing through OLM into the application namespace
+with an `OperatorGroup` that sets `targetNamespaces` can fail the CSV with
+`OwnNamespace InstallModeType not supported` when the published catalog only
+supports AllNamespaces. Working paths today:
+
+- **In-cluster** (this repo): `IMG=<image> ./hack/deploy-incluster.sh
+  "$NAMESPACE"` after `./hack/deploy-dev.sh "$NAMESPACE"`.
+- **OLM + lab layout:** install the catalog Subscription in
+  `openshift-operators` (or another namespace OLM accepts), then run
+  `deploy-incluster.sh` so the manager Deployment and CR share `$NAMESPACE`.
 
 Do not run `make run` on a laptop against `*.svc.cluster.local` hosts. Database
 and cache probes will stay False.
@@ -66,6 +78,8 @@ Replace at least:
   bucket — the operator does not create buckets)
 - `spec.auth.keycloak.url` (required; see [keycloak.md](keycloak.md))
 - `spec.auth.keycloak.issuerURL` if token `iss` is the public Route
+- `spec.auth.keycloak.tls.caCertSecretName` when `issuerURL` is HTTPS on a
+  Route (UI oauth2-proxy needs the ingress CA — see [keycloak.md](keycloak.md))
 - Image `repository` / `tag` values for your environment
 
 Leave `spec.database.deploy` and `spec.cache.deploy` **false**. Leave
@@ -141,8 +155,8 @@ oc -n "$NAMESPACE" describe cmsc cost-management-minimal
 | `RBACReady`, `IngressReady`, `GatewayReady` | True |
 | `Available` | True (`KokuAvailable`) — **success for this quickstart** |
 | `ROSEnabled` | False |
-| `AuthenticationReady` | True once JWKS is reachable |
-| `UIReady` | True only after the UI OAuth Secret exists |
+| `AuthenticationReady` | True once JWKS is reachable at `spec.auth.keycloak.url` |
+| `UIReady` | True after the UI OAuth Secret exists — **not** proof UI pods are healthy (see [keycloak.md](keycloak.md#ui-login-troubleshooting)) |
 
 If `DatabaseReady` or `CacheReady` is False, fix the Secret keys or network
 path before waiting on Deployments.
@@ -151,7 +165,12 @@ path before waiting on Deployments.
 
 ```bash
 oc -n "$NAMESPACE" get deploy,job,route
+oc -n "$NAMESPACE" get deploy cost-management-minimal-ui
 ```
+
+Confirm the UI Deployment shows available replicas (`READY` column) before
+opening the UI Route. If `UIReady=True` but the Route fails, check oauth-proxy
+logs — see [keycloak.md](keycloak.md#ui-login-troubleshooting).
 
 With CR name `cost-management-minimal` in namespace `cost-onprem`:
 
@@ -171,11 +190,13 @@ ConsoleLink when the UI Route exists.
 | `DatabaseUnreachable` | Host/port not reachable from the operator pod (NetworkPolicy, wrong Service DNS) |
 | `SchemaUpToDate` never True | Migration Job failed. List Jobs, then logs for the failed one: `oc -n "$NAMESPACE" get jobs` then `oc -n "$NAMESPACE" logs job/<cr>-koku-migrate` (beta Cost-only; RBAC is `{cr}-rbac-migrate`) |
 | `Available` True but `UIReady` False | Missing `{cr}-ui-oauth-client` with `client-id` / `client-secret` |
+| `UIReady` True but UI Route unavailable | oauth-proxy TLS/OIDC failure — often missing `auth.keycloak.tls.caCertSecretName` when `issuerURL` is a public Route ([keycloak.md](keycloak.md#ui-login-troubleshooting)) |
 | `StorageReady` False | Missing `access-key` / `secret-key`, or bucket does not exist |
 | Uploads return 500 | Bucket in `spec.objectStorage.buckets.koku` was never created |
 
 ## Next
 
+- First login, data, and cost models: [first-use.md](first-use.md)
 - Size and TLS: [production.md](production.md)
 - Point Cost Management Metrics Operator at this instance: [cmmo.md](cmmo.md)
 - Tear down: [uninstall.md](uninstall.md) — delete the CR **before** the namespace or the operator

--- a/docs/install/quickstart.md
+++ b/docs/install/quickstart.md
@@ -33,9 +33,11 @@ supports AllNamespaces. Working paths today:
 
 - **In-cluster** (this repo): `IMG=<image> ./hack/deploy-incluster.sh
   "$NAMESPACE"` after `./hack/deploy-dev.sh "$NAMESPACE"`.
-- **OLM + lab layout:** install the catalog Subscription in
-  `openshift-operators` (or another namespace OLM accepts), then run
-  `deploy-incluster.sh` so the manager Deployment and CR share `$NAMESPACE`.
+- **OLM + lab layout:** the catalog Subscription installs the **OLM package**
+  only; it does not place the manager Deployment in your app namespace. Install
+  the catalog Subscription in `openshift-operators` (or another namespace OLM
+  accepts), then run `deploy-incluster.sh` so the **runtime** manager
+  Deployment and CR share `$NAMESPACE`.
 
 Do not run `make run` on a laptop against `*.svc.cluster.local` hosts. Database
 and cache probes will stay False.


### PR DESCRIPTION
## Summary

Customer install guides updated from the on-prem E2E doc walkthrough (ROSA lab, 2026-09-10):

- **UI / Keycloak TLS:** document oauth2-proxy discovery on `issuerURL`, ingress CA via `caCertSecretName`, and that `AuthenticationReady` / `UIReady` do not prove the UI Route is serving (`docs/install/keycloak.md`).
- **Quickstart:** OLM AllNamespaces vs in-cluster install pitfalls, catalog vs runtime Deployment, `UIReady` semantics, UI Deployment check, troubleshooting row for oauth-proxy TLS.
- **First use:** new guide for cost models (dollar amounts after ingest) and beta OCP-only UI scope (`docs/install/first-use.md`).
- **CMMO:** `upload_cycle` timing (60-minute floor), verify via `status.upload` fields, UI Integrations check.
- **BYOI sample:** comment `caCertSecretName` when `issuerURL` is a public Route.

Related E2E review also informed comments on the COST-8163 customer doc draft.

## Test plan

- [x] `make test-hack`
- [ ] Markdown links between install guides resolve

https://redhat.atlassian.net/browse/COST-8124