### PR TITLE
No longer require ros/kruize secret when ros disabled

### DIFF
--- a/api/v1alpha1/costmanagementserviceconfig_types.go
+++ b/api/v1alpha1/costmanagementserviceconfig_types.go
@@ -138,8 +138,12 @@ type DatabaseConfig struct {
 	SSLMode string `json:"sslMode,omitempty"`
 
 	// Name of an existing Secret containing DB credentials.
-	// Keys: postgres-user, postgres-password, koku-user, koku-password,
-	// ros-user, ros-password, kruize-user, kruize-password, rbac-user, rbac-password.
+	// Always required: koku-user, koku-password, rbac-user, rbac-password.
+	// When spec.ros.enabled is true, also require ros-user, ros-password,
+	// kruize-user, and kruize-password.
+	// postgres-user and postgres-password are used only by bundled Postgres
+	// init and Kruize partition init; they are not required on this Secret
+	// for BYOI.
 	// When empty the operator generates credentials into <cr-name>-db-credentials.
 	SecretName string `json:"secretName,omitempty"`
 

--- a/bundle/manifests/service.costmanagement.openshift.io_costmanagementserviceconfigs.yaml
+++ b/bundle/manifests/service.costmanagement.openshift.io_costmanagementserviceconfigs.yaml
@@ -1445,8 +1445,12 @@ spec:
                   secretName:
                     description: |-
                       Name of an existing Secret containing DB credentials.
-                      Keys: postgres-user, postgres-password, koku-user, koku-password,
-                      ros-user, ros-password, kruize-user, kruize-password, rbac-user, rbac-password.
+                      Always required: koku-user, koku-password, rbac-user, rbac-password.
+                      When spec.ros.enabled is true, also require ros-user, ros-password,
+                      kruize-user, and kruize-password.
+                      postgres-user and postgres-password are used only by bundled Postgres
+                      init and Kruize partition init; they are not required on this Secret
+                      for BYOI.
                       When empty the operator generates credentials into <cr-name>-db-credentials.
                     type: string
                   sslMode:

--- a/config/crd/bases/service.costmanagement.openshift.io_costmanagementserviceconfigs.yaml
+++ b/config/crd/bases/service.costmanagement.openshift.io_costmanagementserviceconfigs.yaml
@@ -1445,8 +1445,12 @@ spec:
                   secretName:
                     description: |-
                       Name of an existing Secret containing DB credentials.
-                      Keys: postgres-user, postgres-password, koku-user, koku-password,
-                      ros-user, ros-password, kruize-user, kruize-password, rbac-user, rbac-password.
+                      Always required: koku-user, koku-password, rbac-user, rbac-password.
+                      When spec.ros.enabled is true, also require ros-user, ros-password,
+                      kruize-user, and kruize-password.
+                      postgres-user and postgres-password are used only by bundled Postgres
+                      init and Kruize partition init; they are not required on this Secret
+                      for BYOI.
                       When empty the operator generates credentials into <cr-name>-db-credentials.
                     type: string
                   sslMode:

--- a/config/samples/service.costmanagement_v1alpha1_costmanagementserviceconfig_byoi.yaml
+++ b/config/samples/service.costmanagement_v1alpha1_costmanagementserviceconfig_byoi.yaml
@@ -8,16 +8,11 @@
 # Pre-create these Secrets before applying this CR:
 #
 #   kubectl create secret generic my-db-credentials \
-#     --from-literal=postgres-user=postgres \
-#     --from-literal=postgres-password=<password> \
 #     --from-literal=koku-user=koku \
 #     --from-literal=koku-password=<password> \
-#     --from-literal=ros-user=ros_user \
-#     --from-literal=ros-password=<password> \
-#     --from-literal=kruize-user=kruize_user \
-#     --from-literal=kruize-password=<password> \
 #     --from-literal=rbac-user=rbac_user \
 #     --from-literal=rbac-password=<password>
+#   Add ros-* and kruize-* keys only when ros.enabled is true.
 #
 #   kubectl create secret generic my-s3-credentials \
 #     --from-literal=access-key=<key> \

--- a/config/samples/service.costmanagement_v1alpha1_costmanagementserviceconfig_minimal.yaml
+++ b/config/samples/service.costmanagement_v1alpha1_costmanagementserviceconfig_minimal.yaml
@@ -12,17 +12,11 @@
 # Pre-create Secrets in the CR namespace before applying:
 #
 #   kubectl create secret generic my-db-credentials \
-#     --from-literal=postgres-user=postgres \
-#     --from-literal=postgres-password=<password> \
 #     --from-literal=koku-user=koku \
 #     --from-literal=koku-password=<password> \
-#     --from-literal=ros-user=ros_user \
-#     --from-literal=ros-password=<password> \
 #     --from-literal=rbac-user=rbac_user \
-#     --from-literal=rbac-password=<password> \
-#     --from-literal=kruize-user=kruize_user \
-#     --from-literal=kruize-password=<password>
-#   (ros-* and kruize-* keys match the CRD credential list; unused while ros.enabled is false.)
+#     --from-literal=rbac-password=<password>
+#   Add ros-* and kruize-* keys only when ros.enabled is true.
 #
 #   kubectl create secret generic my-cache-credentials \
 #     --from-literal=redis-password=<password>

--- a/docs/gap_analysis/BETA-PRIORITY.md
+++ b/docs/gap_analysis/BETA-PRIORITY.md
@@ -6,7 +6,7 @@
 
 **Scope note (2026-08-10):** ROS and Kruize are **out of beta**. Name them separately in gaps (different secrets, migrate, readiness). Optional install, independent Kruize enablement, and day-2 enablement are owned by **[COST-8054](../jira/COST-8054.md)** — not by COST-7678–7692 closure.
 
-**Code progress since first draft:** `spec.ros.enabled` (`*bool`, **default `false`** for Cost-only beta) + `ROSEnabled()` gate Deployments/CronJobs/migrate/Envoy ROS routes/NPs; `reconcileROSFeature` sets condition `ROSEnabled` and cleans up when flipped off. Samples keep `ros.enabled: false`. **ServiceMonitors are not fully gated:** `reconcileMonitoring` still applies `KruizeServiceMonitor` after cleanup (Cost-only installs get a Kruize SM CR; `ros-api` on the App SM is a dead selector, not a live target) — see [COST-7686](COST-7686.md) G1 leftover / [COST-7692](COST-7692.md). **Still open for Cost-only honesty:** Validation **always** requires `ros-user` / `ros-password` (not conditional; not Kruize keys); Kruize is not independently toggleable (tied to ROS today). Opt in with `ros.enabled: true` + images. “Out of beta scope” means *do not treat ROS or Kruize readiness/hardening as Cost beta blockers*.
+**Code progress since first draft:** `spec.ros.enabled` (`*bool`, **default `false`** for Cost-only beta) + `ROSEnabled()` gate Deployments/CronJobs/migrate/Envoy ROS routes/NPs; `reconcileROSFeature` sets condition `ROSEnabled` and cleans up when flipped off. Samples keep `ros.enabled: false`. **ServiceMonitors are not fully gated:** `reconcileMonitoring` still applies `KruizeServiceMonitor` after cleanup (Cost-only installs get a Kruize SM CR; `ros-api` on the App SM is a dead selector, not a live target) — see [COST-7686](COST-7686.md) G1 leftover / [COST-7692](COST-7692.md). External DB Secret validation requires `ros-*` / `kruize-*` only when `ros.enabled=true`. Kruize is not independently toggleable (tied to ROS today). Opt in with `ros.enabled: true` + images. “Out of beta scope” means *do not treat ROS or Kruize readiness/hardening as Cost beta blockers*.
 
 Per-ticket detail stays in the linked audits. This doc is the cross-cut ranking.
 
@@ -37,8 +37,8 @@ Several paths report success while the underlying dependency is wrong or while a
 | S3 Secret keys never checked; `StorageReady=True` on user path | [7684 G2](COST-7684.md), [7683 R1](COST-7683.md) | Bad/missing credentials still “ready” |
 | No S3 connectivity probe | [7684 G1](COST-7684.md) | Endpoint/TLS/network failures invisible until upload fails |
 | OIDC HTTP probe accepts any status &lt; 500 | [7684 G3](COST-7684.md) | 401/404 still `AuthenticationReady=True` |
-| External DB secret validation omits `kruize-user` / `kruize-password` | [7684 R3](COST-7684.md) | **→ [COST-8054](../jira/COST-8054.md)** (Kruize); not a Cost beta blocker |
-| External DB secret validation always requires `ros-user` / `ros-password` | [7684](COST-7684.md), [8054](../jira/COST-8054.md) | **→ [COST-8054](../jira/COST-8054.md)** — blocks true Cost-only BYOI even when `ros.enabled=false` |
+| External DB secret validation omits `kruize-user` / `kruize-password` | [7684 R3](COST-7684.md) | **Closed** — required when `ros.enabled=true` |
+| External DB secret validation always requires `ros-user` / `ros-password` | [7684](COST-7684.md), [8054](../jira/COST-8054.md) | **Closed** — Cost-only BYOI may omit `ros-*` / `kruize-*` |
 | RBAC Deployments applied but never gated; no `RBACReady` | [7689 G2](COST-7689.md) | **Closed** — `RBACReady` gates on the RBAC API before `Available` |
 | `UIReady` / Celery workers not truly readiness-gated | [7690 R2](COST-7690.md), [7687](COST-7687.md) | Ingress is gated (`IngressReady`, COST-7688 R4 closed); UI/Celery still weaker than RBAC/S3 |
 
@@ -216,7 +216,6 @@ Track separately; do not conflate the two components. **Partial progress already
 
 | Gap | Impact |
 |-----|--------|
-| Validation always requires `ros-user` / `ros-password` | Cost-only BYOI secrets cannot omit ROS keys |
 | No independent Kruize flag (tied to ROS) | Product optionality incomplete |
 | Day-2 enable polish / docs | Full AC of 8054 |
 | Hardening (SA, NP, SM, profile rows, bucket discovery) | Post-beta ROS/Kruize quality |

--- a/docs/gap_analysis/COST-7684.md
+++ b/docs/gap_analysis/COST-7684.md
@@ -4,11 +4,11 @@
 **Audited:** 2026-08-10
 **Updated:** 2026-08-16 — ticket-scoped G1 / G2 / G3 closed in [PR #67](https://github.com/project-koku/koku-service-operator/pull/67)
 **Purpose:** Handoff audit vs ticket acceptance criteria. Does not update `docs/tasks.md` or other trackers.
-**Beta scope:** ROS and Kruize are **out of beta** ([BETA-PRIORITY.md](BETA-PRIORITY.md)). Conditional `ros-*` / Kruize secret keys are owned by [COST-8054](../jira/COST-8054.md). Caveat: Validation still **always** requires `ros-user` / `ros-password` (and `kruize-user` / `kruize-password`) even when `spec.ros.enabled=false` (workloads/migrate already skip).
+**Beta scope:** ROS and Kruize are **out of beta** ([BETA-PRIORITY.md](BETA-PRIORITY.md)). Conditional `ros-*` / Kruize secret keys are owned by [COST-8054](../jira/COST-8054.md). Validation now requires `ros-*` / `kruize-*` Secret keys only when `spec.ros.enabled=true`.
 
 ## Verdict
 
-Ticket-scoped COST-7684 work is **done**. `reconcileValidation` probes DB / Cache / Kafka / S3 / OIDC, validates credential Secret keys, and writes per-dependency conditions. Remaining items are **related** (R1 Edge overwrites `AuthenticationReady`; R2 Kafka host parsing; R3 conditional Kruize/ROS keys → COST-8054), not the Jira AC text.
+Ticket-scoped COST-7684 work is **done**. `reconcileValidation` probes DB / Cache / Kafka / S3 / OIDC, validates credential Secret keys, and writes per-dependency conditions. Remaining related item: R2 Kafka host parsing. R1 (`AuthenticationReady` overwrite) and R3 (conditional ROS/Kruize Secret keys) are closed.
 
 ## Sources
 
@@ -61,7 +61,7 @@ Implemented primarily in [`internal/controller/validation.go`](../../internal/co
 
 | Ref | Required keys |
 |-----|---------------|
-| `database.secretName` | `postgres-user`, `postgres-password`, `koku-user`, `koku-password`, `ros-user`, `ros-password`, `rbac-user`, `rbac-password`, `kruize-user`, `kruize-password` |
+| `database.secretName` | Always: `koku-user`, `koku-password`, `rbac-user`, `rbac-password`. When `ros.enabled`: also `ros-user`, `ros-password`, `kruize-user`, `kruize-password`. `postgres-*` is not required on BYOI Secrets. |
 | `cache.auth.secretName` | `redis-password` |
 | `kafka.sasl.existingSecret` | `username`, `password` |
 | `objectStorage.secretName` (or discovered S3 secret) | `access-key`, `secret-key` — fail `StorageSecretInvalid` before `ListBuckets` |
@@ -125,6 +125,6 @@ Edge now writes `GatewayReady`. Validation keeps `AuthenticationReady` for the O
 
 `kafkaTCPProbe` correctly splits brokers; `KafkaHost` / `KafkaPort` in [`internal/resources/names.go`](../../internal/resources/names.go) still treat the whole comma-separated string as one host (deep-code-review D5). Validation can report `KafkaReady` while apps get a malformed host — outside Validation, but masks the bug.
 
-### R3. Conditional Kruize / ROS DB keys (**→ [COST-8054](../jira/COST-8054.md)**)
+### R3. Conditional Kruize / ROS DB keys (**closed** — Validation; remaining COST-8054 is independent enablement)
 
-The Validation required slice **does** include `kruize-user` / `kruize-password`. Remaining work is *conditional* keys when `ros.enabled=false` / Kruize is off — customers should not have to provision unused ROS/Kruize DB keys. Not required for Cost beta.
+`requiredDBSecretKeys` requires `koku-*` / `rbac-*` always, and `ros-*` / `kruize-*` only when `spec.ros.enabled=true`. `postgres-*` is not required on the BYOI Secret. Remaining COST-8054 work is independent Cost/ROS/Kruize enablement and day-2, not this key list.

--- a/docs/install/prerequisites.md
+++ b/docs/install/prerequisites.md
@@ -7,8 +7,8 @@ OIDC. It connects to services you already run.
 **Beta.** Leave `spec.ros.enabled: false`. ROS and Kruize workloads are not
 supported. Cost-only application databases are `costonprem_koku` and
 `costonprem_rbac`. Do not create a database named `postgres` for Cost
-Management. The operator currently still validates unused Secret keys
-(`postgres-user`, `ros-*`, `kruize-*`) even when ROS is off.
+Management. External DB Secrets need `koku-*` and `rbac-*` keys; `ros-*` and
+`kruize-*` are required only when `ros.enabled` is true.
 
 Companion guides: [quickstart](quickstart.md), [production](production.md),
 [Keycloak](keycloak.md), [CMMO](cmmo.md).
@@ -60,51 +60,42 @@ Beta (`ros.enabled: false`) needs only the koku and rbac databases. Do not
 create `postgres`, `costonprem_ros`, or `costonprem_kruize` as Cost Management
 application databases.
 
-The operator still requires extra Secret keys today (`postgres-user` /
-`postgres-password`, plus `ros-*` and `kruize-*` even when ROS is off).
-`postgres-user` is an admin/bootstrap pair for bundled DB init and Kruize
-partition init — not a fifth database. Schema migration Jobs use the
-application users (`koku-user`, `rbac-user`).
+`postgres-user` / `postgres-password` are an admin/bootstrap pair for bundled
+DB init and Kruize partition init — not a fifth database. They are not
+required on an external `spec.database.secretName` Secret. Schema migration
+Jobs use the application users (`koku-user`, `rbac-user`).
 
 `spec.database.sslMode` is one of `disable`, `require`, `verify-ca`,
 `verify-full` (CRD default `disable`). Use `require` or stricter in production.
 
 ### Secret: `spec.database.secretName`
 
-Create this Secret in the **CR namespace**. All ten keys are required today,
-including unused `postgres-*`, `ros-*`, and `kruize-*` keys. Missing keys set
+Create this Secret in the **CR namespace**. Missing required keys set
 `DatabaseReady=False` with reason `DatabaseSecretInvalid` and block
 migrations.
 
-| Key | Purpose |
-|-----|---------|
-| `koku-user` | Owner of `costonprem_koku` |
-| `koku-password` | |
-| `rbac-user` | Owner of `costonprem_rbac` |
-| `rbac-password` | |
-| `postgres-user` | Admin / bootstrap only (bundled init, Kruize). Unused by Cost-only workloads |
-| `postgres-password` | |
-| `ros-user` | Owner of `costonprem_ros` (validated even when ROS is off) |
-| `ros-password` | |
-| `kruize-user` | Owner of `costonprem_kruize` (validated even when ROS is off) |
-| `kruize-password` | |
+| Key | Purpose | Required |
+|-----|---------|----------|
+| `koku-user` | Owner of `costonprem_koku` | Always |
+| `koku-password` | | Always |
+| `rbac-user` | Owner of `costonprem_rbac` | Always |
+| `rbac-password` | | Always |
+| `ros-user` | Owner of `costonprem_ros` | Only if `ros.enabled: true` |
+| `ros-password` | | Only if `ros.enabled: true` |
+| `kruize-user` | Owner of `costonprem_kruize` | Only if `ros.enabled: true` |
+| `kruize-password` | | Only if `ros.enabled: true` |
 
 ```bash
 kubectl -n "$NAMESPACE" create secret generic my-db-credentials \
-  --from-literal=postgres-user=postgres \
-  --from-literal=postgres-password='<password>' \
   --from-literal=koku-user=koku \
   --from-literal=koku-password='<password>' \
   --from-literal=rbac-user=rbac_user \
-  --from-literal=rbac-password='<password>' \
-  --from-literal=ros-user=ros_user \
-  --from-literal=ros-password='<password>' \
-  --from-literal=kruize-user=kruize_user \
-  --from-literal=kruize-password='<password>'
+  --from-literal=rbac-password='<password>'
 ```
 
-Missing keys set `DatabaseReady=False` with reason `DatabaseSecretInvalid` and
-block migrations.
+When `ros.enabled: true`, also add `ros-user` / `ros-password` and
+`kruize-user` / `kruize-password`. Extra keys (including unused
+`postgres-*`) are ignored.
 
 ## Cache (Valkey / Redis)
 

--- a/docs/install/quickstart.md
+++ b/docs/install/quickstart.md
@@ -188,7 +188,7 @@ ConsoleLink when the UI Route exists.
 
 | Symptom | Typical cause |
 |---------|----------------|
-| `DatabaseSecretInvalid` / `CacheSecretInvalid` | Wrong Secret keys — see [prerequisites](prerequisites.md) (`redis-password`, all ten DB keys) |
+| `DatabaseSecretInvalid` / `CacheSecretInvalid` | Wrong Secret keys — see [prerequisites](prerequisites.md) (`redis-password`; `koku-*` and `rbac-*`, plus `ros-*` / `kruize-*` only if ROS is on) |
 | `DatabaseUnreachable` | Host/port not reachable from the operator pod (NetworkPolicy, wrong Service DNS) |
 | `SchemaUpToDate` never True | Migration Job failed. List Jobs, then logs for the failed one: `oc -n "$NAMESPACE" get jobs` then `oc -n "$NAMESPACE" logs job/<cr>-koku-migrate` (beta Cost-only; RBAC is `{cr}-rbac-migrate`) |
 | `Available` True but `UIReady` False | Missing `{cr}-ui-oauth-client` with `client-id` / `client-secret` |

--- a/internal/controller/validation.go
+++ b/internal/controller/validation.go
@@ -33,17 +33,28 @@ const (
 var (
 	// s3SecretKeys are the required keys in an objectStorage Secret.
 	s3SecretKeys = []string{"access-key", "secret-key"}
-
-	// dbSecretKeys lists the credential keys the operator expects in an
-	// externally-provided database Secret (spec.database.secretName).
-	dbSecretKeys = []string{
-		"postgres-user", "postgres-password",
-		"koku-user", "koku-password",
-		"ros-user", "ros-password",
-		"rbac-user", "rbac-password",
-		"kruize-user", "kruize-password",
-	}
 )
+
+// requiredDBSecretKeys returns the credential keys an externally-provided
+// database Secret (spec.database.secretName) must contain. Cost-only installs
+// need koku and rbac. ROS/Kruize keys are required only when ros.enabled is
+// true. postgres-user/password are omitted: they exist for bundled Postgres
+// init and Kruize partition init, not the BYOI Secret contract.
+//
+//nolint:goconst // Secret key names are intentionally literal.
+func requiredDBSecretKeys(cfg *costv1alpha1.CostManagementServiceConfig) []string {
+	keys := []string{
+		"koku-user", "koku-password",
+		"rbac-user", "rbac-password",
+	}
+	if costv1alpha1.ROSEnabled(cfg) {
+		keys = append(keys,
+			"ros-user", "ros-password",
+			"kruize-user", "kruize-password",
+		)
+	}
+	return keys
+}
 
 // reconcileValidation probes all external dependencies and validates referenced
 // Secrets before the migration gate. DB and Cache failures block the pipeline;
@@ -70,8 +81,7 @@ func (r *CostManagementServiceConfigReconciler) reconcileValidation(ctx context.
 		} else {
 			// Validate secret keys when the user provided their own secret.
 			if cfg.Spec.Database.SecretName != "" {
-				required := dbSecretKeys
-				if _, err := r.getSecret(ctx, cfg.Namespace, cfg.Spec.Database.SecretName, required); err != nil {
+				if _, err := r.getSecret(ctx, cfg.Namespace, cfg.Spec.Database.SecretName, requiredDBSecretKeys(cfg)); err != nil {
 					r.setCondition(cfg, costv1alpha1.ConditionDatabaseReady, metav1.ConditionFalse,
 						"DatabaseSecretInvalid", err.Error())
 					allReady = false

--- a/internal/controller/validation_test.go
+++ b/internal/controller/validation_test.go
@@ -97,6 +97,43 @@ func TestRequiredKafkaTopics(t *testing.T) {
 	})
 }
 
+func TestRequiredDBSecretKeys(t *testing.T) {
+	costOnly := []string{
+		"koku-user", "koku-password",
+		"rbac-user", "rbac-password",
+	}
+	rosOn := []string{
+		"koku-user", "koku-password",
+		"rbac-user", "rbac-password",
+		"ros-user", "ros-password",
+		"kruize-user", "kruize-password",
+	}
+
+	t.Run("cost only", func(t *testing.T) {
+		cfg := &costv1alpha1.CostManagementServiceConfig{}
+		if got := requiredDBSecretKeys(cfg); !slices.Equal(got, costOnly) {
+			t.Fatalf("requiredDBSecretKeys() = %v, want %v", got, costOnly)
+		}
+	})
+
+	t.Run("ros enabled false", func(t *testing.T) {
+		cfg := &costv1alpha1.CostManagementServiceConfig{}
+		cfg.Spec.ROS.Enabled = falsePtr()
+		if got := requiredDBSecretKeys(cfg); !slices.Equal(got, costOnly) {
+			t.Fatalf("requiredDBSecretKeys() = %v, want %v", got, costOnly)
+		}
+	})
+
+	t.Run("ros enabled", func(t *testing.T) {
+		cfg := &costv1alpha1.CostManagementServiceConfig{}
+		cfg.Spec.ROS.Enabled = truePtr()
+		got := requiredDBSecretKeys(cfg)
+		if !slices.Equal(got, rosOn) {
+			t.Fatalf("requiredDBSecretKeys() = %v, want %v", got, rosOn)
+		}
+	})
+}
+
 func TestTopicMissingFromPartitions(t *testing.T) {
 	partitions := []kafka.Partition{
 		{Topic: "platform.upload.announce"},
@@ -922,7 +959,7 @@ func TestReconcileValidation_DBSecretMissingKeys(t *testing.T) {
 	secret := &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{Name: testDBSecret, Namespace: testNamespace},
 		Data: map[string][]byte{
-			// Only one key present; koku-user, koku-password, etc. are missing.
+			// postgres-user is not a Cost-only required key; koku/rbac are missing.
 			"postgres-user": []byte("admin"),
 		},
 	}
@@ -967,40 +1004,177 @@ func findCondition(conditions []metav1.Condition, condType string) *metav1.Condi
 	return nil
 }
 
-// TestDBSecretValidationRequiresKruizeCredentials verifies that the database
-// Secret validation (getSecret) includes kruize-user and kruize-password.
-// Kruize connects to the same PostgreSQL instance; missing its credentials
-// causes Kruize pods to fail silently after migrations complete.
-func TestDBSecretValidationRequiresKruizeCredentials(t *testing.T) {
-	scheme := runtime.NewScheme()
-	_ = corev1.AddToScheme(scheme)
+func costOnlyDBSecretData() map[string][]byte {
+	return map[string][]byte{
+		"koku-user":     []byte("koku"),
+		"koku-password": []byte("kokupass"),
+		"rbac-user":     []byte("rbac"),
+		"rbac-password": []byte("rbacpass"),
+	}
+}
 
-	// Secret with all required keys EXCEPT kruize credentials.
-	secretMissingKruize := &corev1.Secret{
+func TestReconcileValidation_CostOnlyDBSecretOmitsROSKeys(t *testing.T) {
+	ln := listenLocalTCP(t)
+	addr := ln.Addr().(*net.TCPAddr)
+
+	secret := &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{Name: testDBSecret, Namespace: testNamespace},
-		Data: map[string][]byte{ //nolint:goconst // test data — key names must match real values
-			"postgres-user": []byte("postgres"), "postgres-password": []byte("pgpass"),
-			"koku-user": []byte("koku"), "koku-password": []byte("kokupass"),
-			"ros-user": []byte("ros"), "ros-password": []byte("rospass"),
-			"rbac-user": []byte("rbac"), "rbac-password": []byte("rbacpass"),
-			// kruize-user and kruize-password intentionally absent
+		Data:       costOnlyDBSecretData(),
+	}
+	cfg := &costv1alpha1.CostManagementServiceConfig{
+		ObjectMeta: metav1.ObjectMeta{Name: testCRName, Namespace: testNamespace},
+		Spec: costv1alpha1.CostManagementServiceConfigSpec{
+			Database: costv1alpha1.DatabaseConfig{
+				Deploy:     falsePtr(),
+				Host:       localHost,
+				Port:       int32(addr.Port),
+				SecretName: testDBSecret,
+			},
+			Cache: costv1alpha1.CacheConfig{Deploy: truePtr()},
+			Kafka: costv1alpha1.KafkaConfig{BootstrapServers: ""},
 		},
 	}
-	r := &CostManagementServiceConfigReconciler{
-		Client: fake.NewClientBuilder().WithScheme(scheme).WithObjects(secretMissingKruize).Build(),
+
+	r := newValidationReconciler(t, secret)
+	result, err := r.reconcileValidation(context.Background(), cfg)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !result.IsZero() {
+		t.Errorf("expected zero result (cost-only secret valid), got %+v", result)
+	}
+	dbCond := findCondition(cfg.Status.Conditions, costv1alpha1.ConditionDatabaseReady)
+	if dbCond == nil || dbCond.Status != metav1.ConditionTrue {
+		t.Errorf("expected DatabaseReady=True, got %+v", dbCond)
+	}
+}
+
+func TestReconcileValidation_ROSEnabledDBSecretRequiresROSKeys(t *testing.T) {
+	ln := listenLocalTCP(t)
+	addr := ln.Addr().(*net.TCPAddr)
+
+	secret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{Name: testDBSecret, Namespace: testNamespace},
+		Data:       costOnlyDBSecretData(),
+	}
+	cfg := &costv1alpha1.CostManagementServiceConfig{
+		ObjectMeta: metav1.ObjectMeta{Name: testCRName, Namespace: testNamespace},
+		Spec: costv1alpha1.CostManagementServiceConfigSpec{
+			Database: costv1alpha1.DatabaseConfig{
+				Deploy:     falsePtr(),
+				Host:       localHost,
+				Port:       int32(addr.Port),
+				SecretName: testDBSecret,
+			},
+			Cache: costv1alpha1.CacheConfig{Deploy: truePtr()},
+			Kafka: costv1alpha1.KafkaConfig{BootstrapServers: ""},
+			ROS:   costv1alpha1.ROSConfig{Enabled: truePtr()},
+		},
 	}
 
-	// The required list in validation.go must include kruize credentials.
-	requiredKeys := []string{
-		"postgres-user", "postgres-password",
-		"koku-user", "koku-password",
-		"ros-user", "ros-password",
-		"rbac-user", "rbac-password",
-		"kruize-user", "kruize-password",
+	r := newValidationReconciler(t, secret)
+	result, err := r.reconcileValidation(context.Background(), cfg)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
 	}
-	_, err := r.getSecret(context.Background(), testNamespace, testDBSecret, requiredKeys)
-	if err == nil {
-		t.Error("getSecret should fail when kruize-user/kruize-password are absent, got nil")
+	if result.RequeueAfter == 0 {
+		t.Error("expected requeue (ROS keys missing from secret)")
+	}
+	dbCond := findCondition(cfg.Status.Conditions, costv1alpha1.ConditionDatabaseReady)
+	if dbCond == nil || dbCond.Status != metav1.ConditionFalse || dbCond.Reason != "DatabaseSecretInvalid" {
+		t.Errorf("expected DatabaseReady=False DatabaseSecretInvalid, got %+v", dbCond)
+	}
+	if dbCond != nil && (!strings.Contains(dbCond.Message, "ros-user") || !strings.Contains(dbCond.Message, "kruize-user")) {
+		t.Errorf("expected missing ros/kruize keys in message, got %q", dbCond.Message)
+	}
+}
+
+func rosDBSecretData() map[string][]byte {
+	data := costOnlyDBSecretData()
+	data["ros-user"] = []byte("ros")
+	data["ros-password"] = []byte("rospass")
+	data["kruize-user"] = []byte("kruize")
+	data["kruize-password"] = []byte("kruizepass")
+	return data
+}
+
+func TestReconcileValidation_ROSEnabledDBSecretAcceptsROSKeys(t *testing.T) {
+	ln := listenLocalTCP(t)
+	addr := ln.Addr().(*net.TCPAddr)
+
+	secret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{Name: testDBSecret, Namespace: testNamespace},
+		Data:       rosDBSecretData(),
+	}
+	cfg := &costv1alpha1.CostManagementServiceConfig{
+		ObjectMeta: metav1.ObjectMeta{Name: testCRName, Namespace: testNamespace},
+		Spec: costv1alpha1.CostManagementServiceConfigSpec{
+			Database: costv1alpha1.DatabaseConfig{
+				Deploy:     falsePtr(),
+				Host:       localHost,
+				Port:       int32(addr.Port),
+				SecretName: testDBSecret,
+			},
+			Cache: costv1alpha1.CacheConfig{Deploy: truePtr()},
+			Kafka: costv1alpha1.KafkaConfig{BootstrapServers: ""},
+			ROS:   costv1alpha1.ROSConfig{Enabled: truePtr()},
+		},
+	}
+
+	r := newValidationReconciler(t, secret)
+	result, err := r.reconcileValidation(context.Background(), cfg)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !result.IsZero() {
+		t.Errorf("expected zero result (ROS secret valid), got %+v", result)
+	}
+	dbCond := findCondition(cfg.Status.Conditions, costv1alpha1.ConditionDatabaseReady)
+	if dbCond == nil || dbCond.Status != metav1.ConditionTrue {
+		t.Errorf("expected DatabaseReady=True, got %+v", dbCond)
+	}
+}
+
+func TestReconcileValidation_ROSEnabledDBSecretMissingKruize(t *testing.T) {
+	ln := listenLocalTCP(t)
+	addr := ln.Addr().(*net.TCPAddr)
+
+	data := costOnlyDBSecretData()
+	data["ros-user"] = []byte("ros")
+	data["ros-password"] = []byte("rospass")
+	secret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{Name: testDBSecret, Namespace: testNamespace},
+		Data:       data,
+	}
+	cfg := &costv1alpha1.CostManagementServiceConfig{
+		ObjectMeta: metav1.ObjectMeta{Name: testCRName, Namespace: testNamespace},
+		Spec: costv1alpha1.CostManagementServiceConfigSpec{
+			Database: costv1alpha1.DatabaseConfig{
+				Deploy:     falsePtr(),
+				Host:       localHost,
+				Port:       int32(addr.Port),
+				SecretName: testDBSecret,
+			},
+			Cache: costv1alpha1.CacheConfig{Deploy: truePtr()},
+			Kafka: costv1alpha1.KafkaConfig{BootstrapServers: ""},
+			ROS:   costv1alpha1.ROSConfig{Enabled: truePtr()},
+		},
+	}
+
+	r := newValidationReconciler(t, secret)
+	result, err := r.reconcileValidation(context.Background(), cfg)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.RequeueAfter == 0 {
+		t.Error("expected requeue (kruize keys missing from secret)")
+	}
+	dbCond := findCondition(cfg.Status.Conditions, costv1alpha1.ConditionDatabaseReady)
+	if dbCond == nil || dbCond.Status != metav1.ConditionFalse || dbCond.Reason != "DatabaseSecretInvalid" {
+		t.Errorf("expected DatabaseReady=False DatabaseSecretInvalid, got %+v", dbCond)
+	}
+	if dbCond != nil && !strings.Contains(dbCond.Message, "kruize-user") {
+		t.Errorf("expected missing kruize-user in message, got %q", dbCond.Message)
 	}
 }
 


### PR DESCRIPTION
## Summary

Makes it to where ROS & Kruize secrets are only needed when ROS is enabled. 



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Operator impact

- **CRD compatibility:** No CRD schema or API compatibility changes.
- **Reconcile behavior:** External database Secret validation always requires `koku-*` and `rbac-*` keys. It requires `ros-*` and `kruize-*` keys only when `spec.ros.enabled` is `true`. `postgres-*` keys are not required.
- **RBAC:** No RBAC changes.
- **Status conditions:** Reconciliation continues to report invalid database credentials through the existing validation status condition when required keys are missing.
- **Documentation:** Updated samples and installation guides to match the conditional Secret requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->