### PR TITLE
Fix stale Deployment readiness during rollouts

### DIFF
--- a/docs/review-follow-ups.md
+++ b/docs/review-follow-ups.md
@@ -144,29 +144,6 @@ is COST-7687; Envoy/UI are COST-7688.
 
 ---
 
-## 13. `isDeploymentReady` accepts stale replicas during a rollout
-
-**Source:** [PR #105 CodeRabbit](https://github.com/project-koku/koku-service-operator/pull/105); already tracked as [D14](code-review-fixmes.md) in `docs/code-review-fixmes.md`.
-
-**Problem:** `isDeploymentReady` is `AvailableReplicas >= spec.replicas`
-(or 0 replicas). It does not require `status.observedGeneration >=
-metadata.generation` or `status.updatedReplicas >= spec.replicas`. After
-an image/spec change, old ready pods still satisfy the gate.
-
-**Impact:** The CR can go `Available=True` / `AllComponentsReady` while
-the current ReplicaSet has zero available pods. Pre-existing; this PR
-only added more callers (Masu, Listener, Kruize, ROS API/Processor).
-
-**Suggested fix:** Require observed generation + updated + available
-replicas (same contract as `isStatefulSetReady`). Update
-`TestIsDeploymentReady` and `markDeploymentReady`; add a stale-replica
-case.
-
-**Out of scope for PR #105** — changes every existing gate (RBAC, Koku
-API, Ingress, Envoy, Valkey), not just COST-7686.
-
----
-
 ## 15. RBAC API wait has no 5-minute `DeploymentNotReady` timeout
 
 **Source:** João's [PR #105 review](https://github.com/project-koku/koku-service-operator/pull/105#issuecomment-5354975468).

--- a/internal/controller/costmanagementserviceconfig_controller.go
+++ b/internal/controller/costmanagementserviceconfig_controller.go
@@ -1438,7 +1438,18 @@ func (r *CostManagementServiceConfigReconciler) isDeploymentReady(ctx context.Co
 	if d.Spec.Replicas == nil || *d.Spec.Replicas == 0 {
 		return true, nil // 0 replicas = intentionally off
 	}
-	return d.Status.AvailableReplicas >= *d.Spec.Replicas, nil
+	want := *d.Spec.Replicas
+	// AvailableReplicas can still describe the old ReplicaSet while a new
+	// generation is rolling out. Require the Deployment controller to have
+	// observed the current spec and all desired replicas to be updated before
+	// treating the Deployment as ready.
+	if d.Status.ObservedGeneration < d.Generation {
+		return false, nil
+	}
+	if d.Status.UpdatedReplicas < want {
+		return false, nil
+	}
+	return d.Status.AvailableReplicas >= want, nil
 }
 
 type deploymentWait struct {

--- a/internal/controller/readiness_test.go
+++ b/internal/controller/readiness_test.go
@@ -22,9 +22,13 @@ func TestIsDeploymentReady(t *testing.T) {
 		{
 			name: "ready",
 			deploy: &appsv1.Deployment{
-				ObjectMeta: metav1.ObjectMeta{Name: "api", Namespace: "ns"},
+				ObjectMeta: metav1.ObjectMeta{Name: "api", Namespace: "ns", Generation: 1},
 				Spec:       appsv1.DeploymentSpec{Replicas: new(int32(2))},
-				Status:     appsv1.DeploymentStatus{AvailableReplicas: 2},
+				Status: appsv1.DeploymentStatus{
+					ObservedGeneration: 1,
+					UpdatedReplicas:    2,
+					AvailableReplicas:  2,
+				},
 			},
 			want: true,
 		},
@@ -34,6 +38,32 @@ func TestIsDeploymentReady(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{Name: "api", Namespace: "ns"},
 				Spec:       appsv1.DeploymentSpec{Replicas: new(int32(2))},
 				Status:     appsv1.DeploymentStatus{AvailableReplicas: 1},
+			},
+			want: false,
+		},
+		{
+			name: "stale observed generation",
+			deploy: &appsv1.Deployment{
+				ObjectMeta: metav1.ObjectMeta{Name: "api", Namespace: "ns", Generation: 2},
+				Spec:       appsv1.DeploymentSpec{Replicas: new(int32(2))},
+				Status: appsv1.DeploymentStatus{
+					ObservedGeneration: 1,
+					UpdatedReplicas:    2,
+					AvailableReplicas:  2,
+				},
+			},
+			want: false,
+		},
+		{
+			name: "old replicas available during rollout",
+			deploy: &appsv1.Deployment{
+				ObjectMeta: metav1.ObjectMeta{Name: "api", Namespace: "ns", Generation: 2},
+				Spec:       appsv1.DeploymentSpec{Replicas: new(int32(2))},
+				Status: appsv1.DeploymentStatus{
+					ObservedGeneration: 2,
+					UpdatedReplicas:    1,
+					AvailableReplicas:  2,
+				},
 			},
 			want: false,
 		},

--- a/internal/controller/shared_config_test.go
+++ b/internal/controller/shared_config_test.go
@@ -214,8 +214,9 @@ func markRouteAdmitted(t *testing.T, c client.Client, ns, name string) {
 	}
 }
 
-// markDeploymentReady sets AvailableReplicas to Spec.Replicas so isDeploymentReady
-// returns true. Requires a client built with WithStatusSubresource(&appsv1.Deployment{}).
+// markDeploymentReady sets Deployment status so isDeploymentReady returns true:
+// the observed generation and updated/available replicas match the spec.
+// Requires a client built with WithStatusSubresource(&appsv1.Deployment{}).
 func markDeploymentReady(t *testing.T, c client.Client, ns, name string) {
 	t.Helper()
 	d := &appsv1.Deployment{}
@@ -226,6 +227,8 @@ func markDeploymentReady(t *testing.T, c client.Client, ns, name string) {
 	if d.Spec.Replicas != nil {
 		replicas = *d.Spec.Replicas
 	}
+	d.Status.ObservedGeneration = d.Generation
+	d.Status.UpdatedReplicas = replicas
 	d.Status.AvailableReplicas = replicas
 	d.Status.ReadyReplicas = replicas
 	d.Status.Replicas = replicas


### PR DESCRIPTION
## Summary

- Require Deployments to have observed the current generation and have all desired replicas updated and available before reporting readiness.
- Add regression coverage for stale generations and old replicas remaining available during a rollout.
- Remove completed follow-up item #13 from the review follow-ups document.

## Validation

- Focused controller readiness and reconciliation tests passed.
- `go vet ./internal/controller ./internal/resources` passed.
- Full `internal/controller` and `internal/resources` package tests passed with the repository Kubernetes 1.33 envtest assets.
- Live CRC test passed: the updated arm64 operator ran in-cluster, and during a controlled three-replica rollout the Deployment reported `desired=3, updated=1, available=3, ready=3` while the CR correctly reported `Available=False/WaitingForAPI`. This is the stale-replica state that the old logic accepted.
- The CRC operator, CR, API replica count, image, and temporary test resources were restored afterward.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Tightens Deployment readiness reporting.
- Requires `observedGeneration` to match the current generation.
- Requires all desired replicas to be updated and available.
- Prevents old replicas from satisfying readiness during rollouts.
- Adds regression coverage for stale generations and old available replicas.
- Removes completed review follow-up `#13`.

## Operator impact

- No CRD API changes.
- Reconciliation now waits for the Deployment controller to observe the current generation and update all desired replicas before reporting readiness.
- RBAC requirements are unchanged.
- Deployment readiness status is more accurate during rollouts.

## Validation

- Focused readiness and reconciliation tests passed.
- Full controller and resource package tests passed.
- `go vet` checks passed.
- Live CRC rollout test passed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->